### PR TITLE
docs(s2): update plan_02 §10 PDF fetch cascade

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,0 +1,18 @@
+# Changelog
+
+All notable changes to this project are documented here.
+
+The format is based on [Keep a Changelog](https://keepachangelog.com/en/1.1.0/),
+and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
+
+## [Unreleased]
+
+### Changed
+
+- **Spec**: `docs/plan_02_subsystem2.md` §10 — replaced the single-line PDF
+  fetch priority (which excluded Sci-Hub as "illegal") with an explicit
+  six-source cascade: OpenAlex OA URL → DOI resolver → Anna's Archive →
+  Library Genesis → Sci-Hub → RSS URL. Each source is toggleable via
+  `S2_PDF_SOURCES`. Rationale: the tool is local and personal, and the
+  target audience relies on these services as standard fallbacks when
+  institutional access falls short. Issue #16.

--- a/docs/plan_02_subsystem2.md
+++ b/docs/plan_02_subsystem2.md
@@ -353,10 +353,18 @@ Se dispara cuando un candidate se marca `accepted`.
 
 **Lógica**:
 1. Crear item en Zotero via API con metadata del candidate.
-2. Si el candidate tiene DOI o URL con PDF descargable, intentar fetch del PDF:
-   - Priorizar: OpenAccess URL de OpenAlex → DOI resolver → Sci-Hub (NO, illegal) → URL del RSS.
-   - Si conseguimos PDF, adjuntar al item Zotero.
-   - Si no, item queda sin PDF, tag `needs-pdf`.
+2. Si el candidate tiene DOI o URL con PDF descargable, intentar fetch del PDF.
+   Priorizar en orden (detener en primer éxito):
+   1. OpenAccess URL de OpenAlex (`best_oa_location.pdf_url`)
+   2. DOI resolver (seguir redirect, verificar content-type PDF)
+   3. Anna's Archive (búsqueda por DOI/ISBN)
+   4. Library Genesis (búsqueda por DOI/título)
+   5. Sci-Hub (búsqueda por DOI)
+   6. URL del RSS (si sirve PDF directo)
+
+   Cada fuente es configurable via `.env` (`S2_PDF_SOURCES`). Un fetch por
+   candidato aceptado, rate-limited por servicio. Si ninguna fuente entrega
+   PDF, el item mantiene el tag `needs-pdf`.
 3. Aplicar tags derivados del scoring (los que mejor matchearon).
 4. Mover a colección "Inbox S2" en Zotero (configurable).
 5. Update del candidate: `zotero_item_key`, `pushed_at`.


### PR DESCRIPTION
## Summary

- Replaces the single-line "OpenAlex → DOI → Sci-Hub (NO, illegal) → RSS" priority in `docs/plan_02_subsystem2.md` §10 with an explicit six-source cascade (OpenAlex OA → DOI resolver → Anna's Archive → LibGen → Sci-Hub → RSS URL), each toggleable via `S2_PDF_SOURCES`.
- Adds `CHANGELOG.md` (first entry) documenting the spec change and rationale.

## Why separate from implementation

Per `CLAUDE.md` → "Reglas sobre los documentos plan_*.md": spec changes land in their own PR, ahead of the implementation PR (#14).

Closes #16.

## Test plan

- [x] `docs/plan_02_subsystem2.md` §10.2 reads the new six-step cascade.
- [x] `CHANGELOG.md` notes the spec change under `[Unreleased]`.
- [ ] Issue #14 implementation (future PR) aligns with this cascade.