### PR TITLE
feat(infra): Phase 1 — shared infrastructure

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -16,6 +16,16 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   (`tests/conftest.py`, per-subsystem test packages), config templates
   (`config/{taxonomy,feeds,scoring}.yaml`, feeds all `active: false`),
   `scripts/healthcheck.py`, MIT `LICENSE`.
+- **Shared infrastructure** (#2): `zotai.config` (pydantic-settings groups for
+  Zotero / OpenAI / Semantic Scholar / OCR / paths / budgets / behaviour / S2),
+  `zotai.state` (SQLModel tables for S1 + S2, separate engines, `init_s1` /
+  `init_s2` helpers, `metadata` exported for Alembic), `zotai.cli` (Typer app
+  with `s1` / `s2` sub-apps and stubbed commands), `zotai.utils.{logging,http,
+  fs,pdf}`, `zotai.api.{zotero,openalex,semantic_scholar,openai_client}` with
+  dry-run and budget enforcement, `zotai.s1.handler.stage_item_handler`
+  decorator, test suite (`tests/test_config.py`, `tests/test_state.py`,
+  `tests/test_utils/test_{fs,pdf}.py`). `alembic/env.py` now points at
+  `zotai.state.metadata` instead of `None`.
 
 ### Changed
 

--- a/alembic/env.py
+++ b/alembic/env.py
@@ -1,10 +1,10 @@
 """Alembic migration environment.
 
-Phase 0 stub: `target_metadata` is `None` because `zotai.state` is introduced
-in Phase 1 (#2). Once the SQLModel models land, replace `target_metadata = None`
-with:
-
-    from zotai.state import metadata as target_metadata
+`target_metadata` is `zotai.state.metadata`, which carries both S1 and S2
+tables. Alembic targets `state.db` (S1) by default per `alembic.ini`'s
+`sqlalchemy.url`; S2 tables are created directly by `zotai.state.init_s2`
+at dashboard startup rather than via migrations in v1. See plan_01 §4 and
+plan_02 §5.
 
 `render_as_batch=True` keeps SQLite compatible with column-drop migrations.
 """
@@ -16,12 +16,12 @@ from logging.config import fileConfig
 from alembic import context
 from sqlalchemy import engine_from_config, pool
 
+from zotai.state import metadata as target_metadata  # noqa: E402
+
 config = context.config
 
 if config.config_file_name is not None:
     fileConfig(config.config_file_name)
-
-target_metadata = None
 
 
 def run_migrations_offline() -> None:

--- a/src/zotai/api/openai_client.py
+++ b/src/zotai/api/openai_client.py
@@ -1,0 +1,187 @@
+"""OpenAI adapter with cost tracking + budget enforcement.
+
+Cost is computed from a static price table sized for the models this
+project uses (Jan 2026 pricing). When the per-call cost would push
+`spent_usd` over `budget_usd`, `BudgetExceededError` is raised *before*
+the call, so no accidental spend happens.
+
+The adapter is deliberately narrow:
+- `extract_metadata`: JSON-mode extraction for Stage 04d (plan_01 §3).
+- `tag_paper`: JSON-mode tagging for Stage 05.
+- `embed_text`: embedding for S2 semantic scoring + S3 re-use.
+"""
+
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from typing import Any, cast
+
+from openai import AsyncOpenAI
+
+from zotai.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class BudgetExceededError(RuntimeError):
+    """Raised when a call would exceed the configured spend ceiling."""
+
+
+# Prices are $ per 1K tokens for chat models, $ per 1K tokens for embeddings.
+# Numbers are from Jan 2026; adjust when OpenAI revises them.
+_PRICING: dict[str, dict[str, float]] = {
+    "gpt-4o-mini": {"input": 0.00015, "output": 0.0006},
+    "gpt-4o": {"input": 0.0025, "output": 0.01},
+    "text-embedding-3-large": {"input": 0.00013, "output": 0.0},
+    "text-embedding-3-small": {"input": 0.00002, "output": 0.0},
+}
+
+
+@dataclass
+class UsageRecord:
+    """Per-call accounting returned by every `OpenAIClient` method."""
+
+    model: str
+    prompt_tokens: int
+    completion_tokens: int
+    cost_usd: float
+    response: Any = field(repr=False)
+
+
+def estimate_cost(model: str, prompt_tokens: int, completion_tokens: int) -> float:
+    """Return the dollar cost of a call. Unknown models are billed at 0.0 (and logged)."""
+    prices = _PRICING.get(model)
+    if prices is None:
+        log.warning("openai.unknown_model_pricing", model=model)
+        return 0.0
+    return (prompt_tokens / 1000.0) * prices["input"] + (
+        completion_tokens / 1000.0
+    ) * prices["output"]
+
+
+class OpenAIClient:
+    """Async OpenAI client with an always-on spend ledger."""
+
+    def __init__(
+        self,
+        *,
+        api_key: str,
+        budget_usd: float,
+        organization: str | None = None,
+    ) -> None:
+        if not api_key:
+            raise ValueError("OPENAI_API_KEY is required")
+        self._client = AsyncOpenAI(api_key=api_key, organization=organization)
+        self.budget_usd = budget_usd
+        self.spent_usd = 0.0
+
+    def _charge(self, cost: float) -> None:
+        """Add `cost` to the ledger after a successful call."""
+        self.spent_usd += cost
+
+    def _check_budget(self, projected_cost: float = 0.0) -> None:
+        """Raise BudgetExceededError if the next call would go over budget."""
+        if self.spent_usd + projected_cost > self.budget_usd:
+            raise BudgetExceededError(
+                f"Budget exceeded: spent=${self.spent_usd:.4f}, "
+                f"projected=${projected_cost:.4f}, budget=${self.budget_usd:.4f}"
+            )
+
+    async def extract_metadata(
+        self, *, text: str, model: str = "gpt-4o-mini"
+    ) -> UsageRecord:
+        """Ask the model to return bibliographic metadata as JSON.
+
+        The caller validates the returned JSON against a Pydantic schema
+        (Stage 04d in plan_01); this function stays schema-agnostic.
+        """
+        self._check_budget()
+        system = (
+            "You extract bibliographic metadata. Return JSON with fields: "
+            "title, authors (list of {first, last}), year, item_type "
+            "(journalArticle, book, bookSection, thesis, report, preprint, "
+            "conferencePaper), venue, doi (null if absent), abstract. "
+            "If a field cannot be determined with confidence, return null. "
+            "Do not invent information."
+        )
+        resp = await self._client.chat.completions.create(
+            model=model,
+            response_format={"type": "json_object"},
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": text},
+            ],
+        )
+        return self._build_usage_record(resp, model)
+
+    async def tag_paper(
+        self,
+        *,
+        metadata: dict[str, Any],
+        taxonomy: dict[str, list[dict[str, Any]]],
+        model: str = "gpt-4o-mini",
+    ) -> UsageRecord:
+        """Return `{tema: [...], metodo: [...]}` from the configured taxonomy."""
+        self._check_budget()
+        tema_ids = [entry["id"] for entry in taxonomy.get("tema", [])]
+        metodo_ids = [entry["id"] for entry in taxonomy.get("metodo", [])]
+        system = (
+            "You tag academic papers using a fixed taxonomy. "
+            "Choose 1-4 tags from TEMA and 1-2 from METODO. "
+            "Only return tag ids from the lists provided. If nothing fits, "
+            "use fewer tags rather than forcing. Return JSON: "
+            '{"tema": [...], "metodo": [...]}.'
+        )
+        user_prompt = json.dumps(
+            {
+                "paper": metadata,
+                "tema": tema_ids,
+                "metodo": metodo_ids,
+            },
+            ensure_ascii=False,
+        )
+        resp = await self._client.chat.completions.create(
+            model=model,
+            response_format={"type": "json_object"},
+            messages=[
+                {"role": "system", "content": system},
+                {"role": "user", "content": user_prompt},
+            ],
+        )
+        return self._build_usage_record(resp, model)
+
+    async def embed_text(
+        self, *, text: str, model: str = "text-embedding-3-large"
+    ) -> tuple[list[float], UsageRecord]:
+        """Return `(vector, usage)` for a single piece of text."""
+        self._check_budget()
+        resp = await self._client.embeddings.create(model=model, input=text)
+        prompt_tokens = resp.usage.prompt_tokens if resp.usage else len(text) // 4
+        cost = estimate_cost(model, prompt_tokens, 0)
+        self._charge(cost)
+        vector = cast(list[float], resp.data[0].embedding)
+        return vector, UsageRecord(
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=0,
+            cost_usd=cost,
+            response=resp,
+        )
+
+    def _build_usage_record(self, resp: Any, model: str) -> UsageRecord:
+        usage = getattr(resp, "usage", None)
+        prompt_tokens = getattr(usage, "prompt_tokens", 0) if usage else 0
+        completion_tokens = getattr(usage, "completion_tokens", 0) if usage else 0
+        cost = estimate_cost(model, prompt_tokens, completion_tokens)
+        self._charge(cost)
+        return UsageRecord(
+            model=model,
+            prompt_tokens=prompt_tokens,
+            completion_tokens=completion_tokens,
+            cost_usd=cost,
+            response=resp,
+        )
+
+
+__all__ = ["BudgetExceededError", "OpenAIClient", "UsageRecord", "estimate_cost"]

--- a/src/zotai/api/openalex.py
+++ b/src/zotai/api/openalex.py
@@ -1,0 +1,56 @@
+"""OpenAlex adapter.
+
+No API key required; including a `mailto` in the User-Agent unlocks the
+"polite pool" (100 req/s vs 10 req/s). We pass that in from
+`BehaviorSettings.user_email`.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from zotai.utils.http import make_async_client, make_user_agent, with_retry
+from zotai.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+OPENALEX_BASE = "https://api.openalex.org"
+
+
+class OpenAlexClient:
+    def __init__(self, user_email: str | None = None) -> None:
+        self._user_agent = make_user_agent(mailto=user_email)
+
+    async def search_works(
+        self, title: str, *, per_page: int = 5
+    ) -> list[dict[str, Any]]:
+        """Search `/works` by title. Returns the `results` array, possibly empty."""
+
+        async def _do() -> list[dict[str, Any]]:
+            async with make_async_client(user_agent=self._user_agent) as client:
+                resp = await client.get(
+                    f"{OPENALEX_BASE}/works",
+                    params={"search": title, "per-page": per_page},
+                )
+                resp.raise_for_status()
+                payload = cast(dict[str, Any], resp.json())
+                results = payload.get("results", [])
+                return cast(list[dict[str, Any]], results)
+
+        return await with_retry(_do)
+
+    async def work_by_doi(self, doi: str) -> dict[str, Any] | None:
+        """Return the full OpenAlex record for a DOI, or None if not found."""
+
+        async def _do() -> dict[str, Any] | None:
+            async with make_async_client(user_agent=self._user_agent) as client:
+                resp = await client.get(f"{OPENALEX_BASE}/works/doi:{doi}")
+                if resp.status_code == 404:
+                    return None
+                resp.raise_for_status()
+                return cast(dict[str, Any], resp.json())
+
+        return await with_retry(_do)
+
+
+__all__ = ["OPENALEX_BASE", "OpenAlexClient"]

--- a/src/zotai/api/semantic_scholar.py
+++ b/src/zotai/api/semantic_scholar.py
@@ -1,0 +1,51 @@
+"""Semantic Scholar Graph API adapter.
+
+Rate limit is 100 req / 5 min without a key, 1 req / s with one (plan_01 §3,
+Stage 04c). The optional key is passed via `.env`
+(`SEMANTIC_SCHOLAR_API_KEY`).
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from zotai.utils.http import make_async_client, make_user_agent, with_retry
+from zotai.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+SEMANTIC_SCHOLAR_BASE = "https://api.semanticscholar.org/graph/v1"
+
+
+class SemanticScholarClient:
+    def __init__(self, api_key: str | None = None) -> None:
+        self._api_key = api_key or None
+        self._user_agent = make_user_agent()
+
+    def _headers(self) -> dict[str, str]:
+        headers = {"User-Agent": self._user_agent}
+        if self._api_key:
+            headers["x-api-key"] = self._api_key
+        return headers
+
+    async def search_paper(
+        self, query: str, *, limit: int = 5
+    ) -> list[dict[str, Any]]:
+        """Search `/paper/search` by query. Returns `data` array, possibly empty."""
+
+        async def _do() -> list[dict[str, Any]]:
+            async with make_async_client(user_agent=self._user_agent) as client:
+                resp = await client.get(
+                    f"{SEMANTIC_SCHOLAR_BASE}/paper/search",
+                    params={"query": query, "limit": limit},
+                    headers=self._headers(),
+                )
+                resp.raise_for_status()
+                payload = cast(dict[str, Any], resp.json())
+                data = payload.get("data", [])
+                return cast(list[dict[str, Any]], data)
+
+        return await with_retry(_do)
+
+
+__all__ = ["SEMANTIC_SCHOLAR_BASE", "SemanticScholarClient"]

--- a/src/zotai/api/zotero.py
+++ b/src/zotai/api/zotero.py
@@ -1,0 +1,94 @@
+"""Thin wrapper around pyzotero that honours the global `--dry-run` flag.
+
+Only the methods actually used by S1/S2 are surfaced. We avoid re-exporting
+pyzotero's full API so the type surface stays small and mypy-friendly.
+"""
+
+from __future__ import annotations
+
+from typing import Any, cast
+
+from pyzotero import zotero
+
+from zotai.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+
+class ZoteroClient:
+    """Facade over pyzotero's `Zotero` object.
+
+    When `dry_run=True`, every mutating call is short-circuited: the wrapper
+    logs what it *would* have done and returns a deterministic placeholder so
+    callers don't need branchy code. Read calls are always real.
+    """
+
+    def __init__(
+        self,
+        *,
+        library_id: str,
+        library_type: str = "user",
+        api_key: str,
+        local: bool = True,
+        dry_run: bool = False,
+    ) -> None:
+        self._client = zotero.Zotero(
+            library_id=library_id,
+            library_type=library_type,
+            api_key=api_key,
+            local=local,
+        )
+        self.dry_run = dry_run
+
+    # ─── Reads ────────────────────────────────────────────────────────────
+
+    def items(self, **kwargs: Any) -> list[dict[str, Any]]:
+        """Proxy to `pyzotero.Zotero.items(**kwargs)`."""
+        return cast(list[dict[str, Any]], self._client.items(**kwargs))
+
+    def collections(self, **kwargs: Any) -> list[dict[str, Any]]:
+        return cast(list[dict[str, Any]], self._client.collections(**kwargs))
+
+    def item(self, item_key: str) -> dict[str, Any]:
+        return cast(dict[str, Any], self._client.item(item_key))
+
+    # ─── Writes — all respect dry_run ─────────────────────────────────────
+
+    def create_items(self, items: list[dict[str, Any]]) -> dict[str, Any]:
+        """Create items; returns pyzotero's `{success, unchanged, failed}` shape."""
+        if self.dry_run:
+            log.info("zotero.create_items.dry_run", count=len(items))
+            return {"success": {}, "unchanged": {}, "failed": {}}
+        return cast(dict[str, Any], self._client.create_items(items))
+
+    def update_item(self, item: dict[str, Any]) -> bool:
+        if self.dry_run:
+            log.info("zotero.update_item.dry_run", item_key=item.get("key"))
+            return True
+        return bool(self._client.update_item(item))
+
+    def attachment_simple(
+        self, paths: list[str], parent_key: str | None = None
+    ) -> dict[str, Any]:
+        if self.dry_run:
+            log.info(
+                "zotero.attachment_simple.dry_run", paths=paths, parent=parent_key
+            )
+            return {"success": {}, "unchanged": {}, "failed": {}}
+        if parent_key is not None:
+            return cast(
+                dict[str, Any],
+                self._client.attachment_simple(paths, parent_key),
+            )
+        return cast(dict[str, Any], self._client.attachment_simple(paths))
+
+    def add_tags(self, item: dict[str, Any], tags: list[str]) -> bool:
+        if self.dry_run:
+            log.info(
+                "zotero.add_tags.dry_run", item_key=item.get("key"), tags=tags
+            )
+            return True
+        return bool(self._client.add_tags(item, *tags))
+
+
+__all__ = ["ZoteroClient"]

--- a/src/zotai/cli.py
+++ b/src/zotai/cli.py
@@ -1,0 +1,171 @@
+"""Typer CLI entry point.
+
+Phase 1 wires the command tree and the global `--dry-run` / `--verbose`
+options. Every subcommand is a stub that prints a clear "not yet
+implemented in Phase N (#issue)" and exits 1 — real implementations land
+with each Phase's PR.
+
+The `zotai` console script is declared in `pyproject.toml`:
+`zotai = "zotai.cli:app"`.
+"""
+
+from __future__ import annotations
+
+from typing import Annotated, Optional
+
+import typer
+
+from zotai.utils.logging import bind, configure_logging
+
+app = typer.Typer(
+    help="Zotero AI toolkit — retroactive import, prospective capture, MCP access.",
+    no_args_is_help=True,
+    pretty_exceptions_show_locals=False,
+)
+
+s1_app = typer.Typer(
+    help="Subsystem 1 — retroactive capture pipeline (one-shot).",
+    no_args_is_help=True,
+)
+s2_app = typer.Typer(
+    help="Subsystem 2 — prospective capture worker + dashboard.",
+    no_args_is_help=True,
+)
+
+app.add_typer(s1_app, name="s1")
+app.add_typer(s2_app, name="s2")
+
+
+@app.callback()
+def _root(
+    ctx: typer.Context,
+    dry_run: Annotated[
+        bool,
+        typer.Option(
+            "--dry-run",
+            help="Report what would happen without modifying Zotero or the DB.",
+        ),
+    ] = False,
+    verbose: Annotated[
+        bool,
+        typer.Option(
+            "--verbose",
+            "-v",
+            help="Emit DEBUG-level logs.",
+        ),
+    ] = False,
+) -> None:
+    """Configure logging and stash global flags in the Typer context."""
+    configure_logging(level="DEBUG" if verbose else "INFO")
+    bind(dry_run=dry_run)
+    ctx.ensure_object(dict)
+    ctx.obj["dry_run"] = dry_run
+    ctx.obj["verbose"] = verbose
+
+
+def _not_implemented(stage: str, phase: int, issue: int) -> None:
+    typer.secho(
+        f"`{stage}` is not yet implemented — scheduled for Phase {phase} (#{issue}).",
+        err=True,
+        fg=typer.colors.YELLOW,
+    )
+    raise typer.Exit(code=1)
+
+
+# ─── S1 commands ──────────────────────────────────────────────────────────
+
+
+@s1_app.command("inventory")
+def s1_inventory(
+    folder: Annotated[
+        Optional[list[str]],
+        typer.Option("--folder", help="Source folder(s). Repeat for multiple."),
+    ] = None,
+) -> None:
+    """Stage 01 — scan PDFs, hash, detect DOI."""
+    _ = folder
+    _not_implemented("s1 inventory", 2, 3)
+
+
+@s1_app.command("ocr")
+def s1_ocr(
+    force_ocr: Annotated[bool, typer.Option("--force-ocr")] = False,
+    parallel: Annotated[Optional[int], typer.Option("--parallel")] = None,
+) -> None:
+    """Stage 02 — OCR scanned PDFs."""
+    _ = force_ocr, parallel
+    _not_implemented("s1 ocr", 3, 4)
+
+
+@s1_app.command("import")
+def s1_import(
+    batch_size: Annotated[int, typer.Option("--batch-size")] = 50,
+) -> None:
+    """Stage 03 — import PDFs into Zotero (Route A/B/C)."""
+    _ = batch_size
+    _not_implemented("s1 import", 4, 5)
+
+
+@s1_app.command("enrich")
+def s1_enrich(
+    substage: Annotated[Optional[str], typer.Option("--substage")] = None,
+    max_cost: Annotated[Optional[float], typer.Option("--max-cost")] = None,
+) -> None:
+    """Stage 04 — enrichment cascade (04a-04e)."""
+    _ = substage, max_cost
+    _not_implemented("s1 enrich", 5, 6)
+
+
+@s1_app.command("tag")
+def s1_tag(
+    preview: Annotated[bool, typer.Option("--preview")] = False,
+    apply: Annotated[bool, typer.Option("--apply")] = False,
+    re_tag: Annotated[bool, typer.Option("--re-tag")] = False,
+    max_cost: Annotated[Optional[float], typer.Option("--max-cost")] = None,
+) -> None:
+    """Stage 05 — LLM tagging against the TEMA/METODO taxonomy."""
+    _ = preview, apply, re_tag, max_cost
+    _not_implemented("s1 tag", 6, 7)
+
+
+@s1_app.command("validate")
+def s1_validate(
+    open_report: Annotated[bool, typer.Option("--open-report")] = False,
+) -> None:
+    """Stage 06 — generate validation report (HTML + CSV)."""
+    _ = open_report
+    _not_implemented("s1 validate", 7, 8)
+
+
+@s1_app.command("run-all")
+def s1_run_all(
+    yes: Annotated[bool, typer.Option("--yes", "-y")] = False,
+) -> None:
+    """Run stages 01-06 sequentially with inter-stage prompts."""
+    _ = yes
+    _not_implemented("s1 run-all", 8, 9)
+
+
+@s1_app.command("status")
+def s1_status() -> None:
+    """Print per-stage counts, costs, and errors from `state.db`."""
+    _not_implemented("s1 status", 8, 9)
+
+
+# ─── S2 commands ──────────────────────────────────────────────────────────
+
+
+@s2_app.command("fetch-once")
+def s2_fetch_once() -> None:
+    """Run one RSS fetch cycle and persist new candidates."""
+    _not_implemented("s2 fetch-once", 11, 12)
+
+
+@s2_app.command("dashboard")
+def s2_dashboard() -> None:
+    """Start the FastAPI dashboard on 127.0.0.1:${S2_DASHBOARD_PORT}."""
+    _not_implemented("s2 dashboard", 11, 12)
+
+
+if __name__ == "__main__":  # pragma: no cover
+    app()

--- a/src/zotai/config.py
+++ b/src/zotai/config.py
@@ -1,0 +1,237 @@
+"""Application settings — pydantic-settings sourced from `.env` + environment.
+
+All settings groups inherit from `BaseSettings` with their own `env_prefix`, so
+each group reads only the variables that logically belong to it. The outer
+`Settings` composes them via `default_factory` so env reading happens at
+instantiation time, not at import time.
+
+Usage:
+
+    from zotai.config import Settings
+
+    settings = Settings()
+    print(settings.zotero.library_id)
+    print(settings.paths.state_db)
+
+The entire object is immutable (``frozen=True``). For tests that need to
+override values, build a fresh `Settings(**overrides)` rather than mutating.
+
+See ``docs/plan_01_subsystem1.md`` §5 and ``docs/plan_02_subsystem2.md`` §12
+for the full variable list, and ``.env.example`` at the repo root for a
+copy-paste starter.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Annotated, Literal
+
+from pydantic import Field, SecretStr, field_validator
+from pydantic_settings import BaseSettings, SettingsConfigDict
+
+_ENV_FILE = ".env"
+_ENV_ENCODING = "utf-8"
+
+
+class _GroupBase(BaseSettings):
+    """Shared config for each prefixed group. Subclasses override ``env_prefix``."""
+
+    model_config = SettingsConfigDict(
+        env_file=_ENV_FILE,
+        env_file_encoding=_ENV_ENCODING,
+        case_sensitive=False,
+        extra="ignore",
+        frozen=True,
+    )
+
+
+class ZoteroSettings(_GroupBase):
+    model_config = SettingsConfigDict(
+        env_prefix="ZOTERO_",
+        env_file=_ENV_FILE,
+        env_file_encoding=_ENV_ENCODING,
+        case_sensitive=False,
+        extra="ignore",
+        frozen=True,
+    )
+    api_key: SecretStr = SecretStr("")
+    library_id: str = ""
+    library_type: Literal["user", "group"] = "user"
+    local_api: bool = True
+
+
+class OpenAISettings(_GroupBase):
+    model_config = SettingsConfigDict(
+        env_prefix="OPENAI_",
+        env_file=_ENV_FILE,
+        env_file_encoding=_ENV_ENCODING,
+        case_sensitive=False,
+        extra="ignore",
+        frozen=True,
+    )
+    api_key: SecretStr = SecretStr("")
+    model_tag: str = "gpt-4o-mini"
+    model_extract: str = "gpt-4o-mini"
+    embedding_model: str = "text-embedding-3-large"
+
+
+class SemanticScholarSettings(_GroupBase):
+    model_config = SettingsConfigDict(
+        env_prefix="SEMANTIC_SCHOLAR_",
+        env_file=_ENV_FILE,
+        env_file_encoding=_ENV_ENCODING,
+        case_sensitive=False,
+        extra="ignore",
+        frozen=True,
+    )
+    api_key: SecretStr = SecretStr("")
+
+
+class OcrSettings(_GroupBase):
+    model_config = SettingsConfigDict(
+        env_prefix="OCR_",
+        env_file=_ENV_FILE,
+        env_file_encoding=_ENV_ENCODING,
+        case_sensitive=False,
+        extra="ignore",
+        frozen=True,
+    )
+    languages: str = "spa+eng"
+    parallel_processes: int = 4
+
+    @field_validator("parallel_processes")
+    @classmethod
+    def _positive(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("OCR_PARALLEL_PROCESSES must be >= 1")
+        return v
+
+
+class PathSettings(_GroupBase):
+    """Filesystem locations. All resolved to absolute paths on load."""
+
+    model_config = SettingsConfigDict(
+        env_file=_ENV_FILE,
+        env_file_encoding=_ENV_ENCODING,
+        case_sensitive=False,
+        extra="ignore",
+        frozen=True,
+    )
+    pdf_source_folders: list[Path] = Field(default_factory=list)
+    staging_folder: Path = Path("/workspace/staging")
+    state_db: Path = Path("/workspace/state.db")
+    reports_folder: Path = Path("/workspace/reports")
+
+    @field_validator("pdf_source_folders", mode="before")
+    @classmethod
+    def _split_csv(cls, v: object) -> object:
+        if isinstance(v, str):
+            return [Path(s.strip()) for s in v.split(",") if s.strip()]
+        return v
+
+
+class BudgetSettings(_GroupBase):
+    """Hard spending limits enforced by the API clients."""
+
+    model_config = SettingsConfigDict(
+        env_file=_ENV_FILE,
+        env_file_encoding=_ENV_ENCODING,
+        case_sensitive=False,
+        extra="ignore",
+        frozen=True,
+    )
+    max_cost_usd_total: float = 10.0
+    max_cost_usd_stage_04: float = 2.0
+    max_cost_usd_stage_05: float = 1.0
+
+
+class BehaviorSettings(_GroupBase):
+    """Cross-cutting runtime behaviour."""
+
+    model_config = SettingsConfigDict(
+        env_file=_ENV_FILE,
+        env_file_encoding=_ENV_ENCODING,
+        case_sensitive=False,
+        extra="ignore",
+        frozen=True,
+    )
+    dry_run: bool = False
+    log_level: str = "INFO"
+    user_email: str = ""
+
+
+class S2Settings(_GroupBase):
+    """Subsystem 2 — worker, dashboard, and PDF-cascade config."""
+
+    model_config = SettingsConfigDict(
+        env_prefix="S2_",
+        env_file=_ENV_FILE,
+        env_file_encoding=_ENV_ENCODING,
+        case_sensitive=False,
+        extra="ignore",
+        frozen=True,
+    )
+    fetch_interval_hours: int = 6
+    candidates_db: Path = Path("/workspace/candidates.db")
+    chroma_path: Path = Path("/workspace/chroma_db")
+    zotero_inbox_collection: str = "Inbox S2"
+    pdf_sources: list[str] = Field(
+        default_factory=lambda: ["openaccess", "doi", "annas", "libgen", "scihub", "rss"]
+    )
+    dashboard_host: str = "127.0.0.1"
+    dashboard_port: int = 8000
+    max_cost_usd_daily: float = 0.50
+    max_cost_usd_monthly: float = 10.0
+
+    @field_validator("pdf_sources", mode="before")
+    @classmethod
+    def _split_csv(cls, v: object) -> object:
+        if isinstance(v, str):
+            return [s.strip().lower() for s in v.split(",") if s.strip()]
+        return v
+
+    @field_validator("fetch_interval_hours", "dashboard_port")
+    @classmethod
+    def _positive(cls, v: int) -> int:
+        if v < 1:
+            raise ValueError("value must be >= 1")
+        return v
+
+
+class Settings(BaseSettings):
+    """Top-level settings aggregating all groups.
+
+    Each group reads its own prefixed env vars at instantiation time.
+    """
+
+    model_config = SettingsConfigDict(
+        env_file=_ENV_FILE,
+        env_file_encoding=_ENV_ENCODING,
+        case_sensitive=False,
+        extra="ignore",
+        frozen=True,
+    )
+
+    zotero: Annotated[ZoteroSettings, Field(default_factory=ZoteroSettings)]
+    openai: Annotated[OpenAISettings, Field(default_factory=OpenAISettings)]
+    semantic_scholar: Annotated[
+        SemanticScholarSettings, Field(default_factory=SemanticScholarSettings)
+    ]
+    ocr: Annotated[OcrSettings, Field(default_factory=OcrSettings)]
+    paths: Annotated[PathSettings, Field(default_factory=PathSettings)]
+    budgets: Annotated[BudgetSettings, Field(default_factory=BudgetSettings)]
+    behavior: Annotated[BehaviorSettings, Field(default_factory=BehaviorSettings)]
+    s2: Annotated[S2Settings, Field(default_factory=S2Settings)]
+
+
+__all__ = [
+    "BehaviorSettings",
+    "BudgetSettings",
+    "OcrSettings",
+    "OpenAISettings",
+    "PathSettings",
+    "S2Settings",
+    "SemanticScholarSettings",
+    "Settings",
+    "ZoteroSettings",
+]

--- a/src/zotai/s1/handler.py
+++ b/src/zotai/s1/handler.py
@@ -1,0 +1,100 @@
+"""`@stage_item_handler` — uniform per-item error handling across S1 stages.
+
+Wraps each per-item processing function so that a single failure persists the
+error to `Item.last_error`, bumps the Run's failure counter, logs, and
+**does not re-raise** — letting the rest of the stage continue.
+
+The decorator also enforces the abort threshold: if the failure ratio in a
+Run exceeds `abort_threshold` (default 30%), subsequent calls raise
+`StageAbortedError` so the stage tears down cleanly.
+
+Shape of a wrapped function:
+
+    @stage_item_handler(stage=1)
+    def inventory_one(item: Item, run: Run, *, ...) -> None:
+        ...
+
+The handler expects the first positional arg to be a `zotai.state.Item` and
+the `run` keyword argument to be a `zotai.state.Run`. Both are mutated in
+place; the caller is responsible for committing to the DB after the stage
+finishes.
+"""
+
+from __future__ import annotations
+
+import traceback
+from collections.abc import Callable
+from functools import wraps
+from typing import Any, TypeVar
+
+from zotai.state import Item, Run
+from zotai.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+F = TypeVar("F", bound=Callable[..., Any])
+
+_DEFAULT_ABORT_THRESHOLD = 0.30
+_MIN_SAMPLES_BEFORE_ABORT = 10
+
+
+class StageAbortedError(RuntimeError):
+    """Raised once the Run's failure ratio crosses `abort_threshold`."""
+
+
+def stage_item_handler(
+    stage: int,
+    *,
+    abort_threshold: float = _DEFAULT_ABORT_THRESHOLD,
+) -> Callable[[F], F]:
+    """Decorator factory. See module docstring for semantics."""
+
+    def decorator(func: F) -> F:
+        @wraps(func)
+        def wrapper(item: Item, *args: Any, **kwargs: Any) -> Any:
+            run: Run | None = kwargs.get("run")
+            if run is None and args:
+                run = args[0] if isinstance(args[0], Run) else None
+
+            _maybe_abort(run, abort_threshold)
+
+            try:
+                result = func(item, *args, **kwargs)
+            except Exception as exc:  # noqa: BLE001 — deliberately broad at top-level
+                item.last_error = f"{type(exc).__name__}: {exc}"
+                log.exception(
+                    "stage_item_failed",
+                    stage=stage,
+                    item_id=item.id,
+                    error=str(exc),
+                    traceback=traceback.format_exc(),
+                )
+                if run is not None:
+                    run.items_failed += 1
+                return None
+            else:
+                item.last_error = None
+                item.stage_completed = max(item.stage_completed, stage)
+                if run is not None:
+                    run.items_processed += 1
+                return result
+
+        return wrapper  # type: ignore[return-value]
+
+    return decorator
+
+
+def _maybe_abort(run: Run | None, threshold: float) -> None:
+    if run is None:
+        return
+    total = run.items_processed + run.items_failed
+    if total < _MIN_SAMPLES_BEFORE_ABORT:
+        return
+    if run.items_failed / total > threshold:
+        raise StageAbortedError(
+            f"Run {run.id}: failure ratio "
+            f"{run.items_failed}/{total} exceeds {threshold:.0%}"
+        )
+
+
+__all__ = ["StageAbortedError", "stage_item_handler"]

--- a/src/zotai/state.py
+++ b/src/zotai/state.py
@@ -1,0 +1,215 @@
+"""SQLModel schemas for `state.db` (S1) and `candidates.db` (S2).
+
+Both databases share `SQLModel.metadata` because they are schema-disjoint:
+`state.db` only ever gets the S1 tables, `candidates.db` only the S2 tables.
+Filtering is enforced via the `S1_TABLES` / `S2_TABLES` module-level tuples
+and the `init_s1` / `init_s2` helpers, which pass ``tables=[...]`` to
+``create_all``.
+
+Alembic's ``target_metadata`` in ``alembic/env.py`` is ``state.metadata``
+(i.e. the same global ``SQLModel.metadata``); migrations are authored against
+the S1 schema. S2 tables are created on dashboard startup with ``init_s2``
+and evolve via code rather than alembic in v1 (see plan_02 §5).
+"""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from typing import Optional
+
+from sqlalchemy import MetaData, Table
+from sqlalchemy.engine import Engine
+from sqlmodel import Field, SQLModel, create_engine
+
+
+def _utc_now() -> datetime:
+    """Timezone-aware UTC timestamp used as default for `created_at` / `updated_at`."""
+    return datetime.now(tz=timezone.utc)
+
+
+# ─── S1: state.db ───────────────────────────────────────────────────────────
+
+
+class Item(SQLModel, table=True):
+    """A single PDF tracked through the S1 pipeline.
+
+    `id` is the SHA-256 of the PDF bytes, enforcing deduplication at
+    inventory time (Stage 01 in plan_01).
+    """
+
+    id: str = Field(primary_key=True)
+    source_path: str
+    size_bytes: int
+    has_text: bool = False
+    detected_doi: Optional[str] = None
+    ocr_failed: bool = False
+    zotero_item_key: Optional[str] = None
+    import_route: Optional[str] = None  # 'A' | 'B' | 'C'
+    stage_completed: int = 0
+    in_quarantine: bool = False
+    last_error: Optional[str] = None
+    metadata_json: Optional[str] = None
+    tags_json: Optional[str] = None
+    created_at: datetime = Field(default_factory=_utc_now)
+    updated_at: datetime = Field(default_factory=_utc_now)
+
+
+class Run(SQLModel, table=True):
+    """A single execution of an S1 stage, used for metrics + resume semantics."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    stage: int
+    started_at: datetime = Field(default_factory=_utc_now)
+    finished_at: Optional[datetime] = None
+    items_processed: int = 0
+    items_failed: int = 0
+    cost_usd: float = 0.0
+    status: str = "running"  # 'running' | 'succeeded' | 'failed' | 'aborted'
+
+
+class ApiCall(SQLModel, table=True):
+    """Per-call observability for external services. Used for budget enforcement."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    run_id: int = Field(foreign_key="run.id")
+    service: str  # 'openalex' | 'semantic_scholar' | 'openai' | 'zotero'
+    cost_usd: float = 0.0
+    duration_ms: int = 0
+    status: str = "success"  # 'success' | 'error' | 'rate_limited'
+    item_id: Optional[str] = Field(default=None, foreign_key="item.id")
+    timestamp: datetime = Field(default_factory=_utc_now)
+
+
+# ─── S2: candidates.db ──────────────────────────────────────────────────────
+
+
+class Candidate(SQLModel, table=True):
+    """A paper surfaced by the S2 worker and pending triage by the user."""
+
+    id: str = Field(primary_key=True)  # hash of DOI or URL
+    source_feed_id: str = Field(foreign_key="feed.id")
+    doi: Optional[str] = None
+    title: str
+    authors_json: str
+    abstract: Optional[str] = None
+    venue: str
+    published_at: datetime
+    url: Optional[str] = None
+
+    # Scoring (each in [0, 1])
+    score_tags: float = 0.0
+    score_semantic: float = 0.0
+    score_queries: float = 0.0
+    score_composite: float = 0.0
+    scoring_explanation: str = "{}"
+
+    # Triage
+    status: str = "pending"  # 'pending' | 'accepted' | 'rejected' | 'deferred'
+    decided_at: Optional[datetime] = None
+    decided_by: Optional[str] = None
+    decision_note: Optional[str] = None
+
+    # Zotero integration — set once push succeeds
+    zotero_item_key: Optional[str] = None
+    pushed_at: Optional[datetime] = None
+
+    created_at: datetime = Field(default_factory=_utc_now)
+    updated_at: datetime = Field(default_factory=_utc_now)
+
+
+class Feed(SQLModel, table=True):
+    """A journal RSS feed configured in `config/feeds.yaml` or via the dashboard."""
+
+    id: str = Field(primary_key=True)  # slug
+    name: str
+    rss_url: str
+    issn: Optional[str] = None
+    active: bool = True
+    last_fetched_at: Optional[datetime] = None
+    last_fetch_status: Optional[str] = None
+    items_fetched_total: int = 0
+
+
+class PersistentQuery(SQLModel, table=True):
+    """A user-authored query that contributes to the composite score of every candidate."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    query_text: str
+    active: bool = True
+    weight: float = 1.0
+    created_at: datetime = Field(default_factory=_utc_now)
+
+
+class TriageMetric(SQLModel, table=True):
+    """Weekly precision/volume snapshot used on the dashboard's metrics page."""
+
+    id: Optional[int] = Field(default=None, primary_key=True)
+    week_start: date
+    candidates_shown: int = 0
+    candidates_accepted: int = 0
+    candidates_rejected: int = 0
+    candidates_deferred: int = 0
+    precision_observed: float = 0.0
+
+
+# ─── Table groupings + engine helpers ───────────────────────────────────────
+
+metadata: MetaData = SQLModel.metadata
+
+S1_TABLES: tuple[Table, ...] = (
+    Item.__table__,  # type: ignore[attr-defined]
+    Run.__table__,  # type: ignore[attr-defined]
+    ApiCall.__table__,  # type: ignore[attr-defined]
+)
+
+S2_TABLES: tuple[Table, ...] = (
+    Candidate.__table__,  # type: ignore[attr-defined]
+    Feed.__table__,  # type: ignore[attr-defined]
+    PersistentQuery.__table__,  # type: ignore[attr-defined]
+    TriageMetric.__table__,  # type: ignore[attr-defined]
+)
+
+
+def _sqlite_url(path: str) -> str:
+    """Normalize a filesystem path into a SQLite URL understood by SQLAlchemy."""
+    if path.startswith("sqlite"):
+        return path
+    return f"sqlite:///{path}"
+
+
+def make_s1_engine(db_path: str, echo: bool = False) -> Engine:
+    """Return a SQLAlchemy engine bound to the S1 database (typically `state.db`)."""
+    return create_engine(_sqlite_url(db_path), echo=echo, connect_args={"check_same_thread": False})
+
+
+def make_s2_engine(db_path: str, echo: bool = False) -> Engine:
+    """Return a SQLAlchemy engine bound to the S2 database (typically `candidates.db`)."""
+    return create_engine(_sqlite_url(db_path), echo=echo, connect_args={"check_same_thread": False})
+
+
+def init_s1(engine: Engine) -> None:
+    """Create S1 tables in the given engine (idempotent)."""
+    metadata.create_all(engine, tables=list(S1_TABLES))
+
+
+def init_s2(engine: Engine) -> None:
+    """Create S2 tables in the given engine (idempotent)."""
+    metadata.create_all(engine, tables=list(S2_TABLES))
+
+
+__all__ = [
+    "ApiCall",
+    "Candidate",
+    "Feed",
+    "Item",
+    "PersistentQuery",
+    "Run",
+    "S1_TABLES",
+    "S2_TABLES",
+    "TriageMetric",
+    "init_s1",
+    "init_s2",
+    "make_s1_engine",
+    "make_s2_engine",
+    "metadata",
+]

--- a/src/zotai/utils/fs.py
+++ b/src/zotai/utils/fs.py
@@ -1,0 +1,73 @@
+"""Filesystem helpers.
+
+All of these are pure wrappers around `pathlib` / `shutil` / `hashlib`, so
+they type-check under `mypy --strict` without third-party stubs.
+"""
+
+from __future__ import annotations
+
+import hashlib
+import shutil
+from pathlib import Path
+
+_PDF_MAGIC = b"%PDF-"
+_DEFAULT_CHUNK = 1 << 20  # 1 MiB
+
+
+def ensure_dir(path: Path) -> Path:
+    """Create `path` (and parents) if missing; return it."""
+    path.mkdir(parents=True, exist_ok=True)
+    return path
+
+
+def file_sha256(path: Path, chunk_size: int = _DEFAULT_CHUNK) -> str:
+    """Streamed SHA-256 of a file, returned as a lowercase hex digest."""
+    h = hashlib.sha256()
+    with path.open("rb") as f:
+        while True:
+            chunk = f.read(chunk_size)
+            if not chunk:
+                break
+            h.update(chunk)
+    return h.hexdigest()
+
+
+def validate_pdf_magic(path: Path) -> bool:
+    """True iff the first five bytes of the file are `%PDF-`.
+
+    Guards against mis-named files (e.g. `report.pdf` that's actually HTML).
+    """
+    try:
+        with path.open("rb") as f:
+            head = f.read(len(_PDF_MAGIC))
+    except OSError:
+        return False
+    return head == _PDF_MAGIC
+
+
+def disk_space_available(path: Path) -> int:
+    """Free bytes on the filesystem that contains `path`."""
+    target = path if path.exists() else path.parent
+    return shutil.disk_usage(target).free
+
+
+def disk_space_check(path: Path, required_bytes: int) -> bool:
+    """True iff there are at least `required_bytes` free on `path`'s filesystem."""
+    return disk_space_available(path) >= required_bytes
+
+
+def safe_copy(src: Path, dst: Path) -> Path:
+    """Copy `src` to `dst`, creating parents; preserve mtime/perm bits."""
+    ensure_dir(dst.parent)
+    shutil.copy2(src, dst)
+    return dst
+
+
+__all__ = [
+    "disk_space_available",
+    "disk_space_check",
+    "ensure_dir",
+    "file_sha256",
+    "safe_copy",
+    "validate_pdf_magic",
+]

--- a/src/zotai/utils/http.py
+++ b/src/zotai/utils/http.py
@@ -1,0 +1,87 @@
+"""HTTP client factory + shared retry policy.
+
+Everything that talks HTTP in this project should go through `make_async_client`
+and wrap mutating calls in `@with_retry`. This keeps timeouts, retries, and
+User-Agent consistent across S1 (OpenAlex, Semantic Scholar, OpenAI) and S2
+(RSS fetch, PDF cascade).
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from typing import TypeVar
+
+import httpx
+from tenacity import (
+    AsyncRetrying,
+    RetryError,
+    retry_if_exception_type,
+    stop_after_attempt,
+    wait_exponential,
+)
+
+T = TypeVar("T")
+
+_DEFAULT_TIMEOUT = 30.0
+_DEFAULT_USER_AGENT = "zotai/0.1.0"
+
+_RETRYABLE: tuple[type[BaseException], ...] = (
+    httpx.TimeoutException,
+    httpx.TransportError,
+    httpx.RemoteProtocolError,
+)
+
+
+def make_user_agent(base: str = _DEFAULT_USER_AGENT, mailto: str | None = None) -> str:
+    """Build a User-Agent string. OpenAlex lifts rate limit 10x when `mailto` is set."""
+    if mailto:
+        return f"{base} (mailto:{mailto})"
+    return base
+
+
+def make_async_client(
+    *,
+    timeout: float = _DEFAULT_TIMEOUT,
+    user_agent: str | None = None,
+    base_url: str = "",
+) -> httpx.AsyncClient:
+    """Return a configured `httpx.AsyncClient`.
+
+    Callers own the lifecycle — use it as an async context manager or call
+    `aclose()`. Connection pooling is built-in; reuse the same client for
+    multiple requests when possible.
+    """
+    headers = {"User-Agent": user_agent or _DEFAULT_USER_AGENT}
+    return httpx.AsyncClient(
+        timeout=httpx.Timeout(timeout),
+        headers=headers,
+        base_url=base_url,
+        follow_redirects=True,
+    )
+
+
+async def with_retry(
+    fn: Callable[[], Awaitable[T]],
+    *,
+    attempts: int = 3,
+    min_wait: float = 1.0,
+    max_wait: float = 30.0,
+) -> T:
+    """Run `fn` with exponential backoff over the standard retryable exceptions.
+
+    On final failure, re-raises the last exception (not `RetryError`) so
+    callers can catch the underlying HTTP exception directly.
+    """
+    async for attempt in AsyncRetrying(
+        retry=retry_if_exception_type(_RETRYABLE),
+        stop=stop_after_attempt(attempts),
+        wait=wait_exponential(multiplier=min_wait, max=max_wait),
+        reraise=True,
+    ):
+        with attempt:
+            return await fn()
+    # Defensive: AsyncRetrying with reraise=True always raises or returns above.
+    raise RetryError(last_attempt=None)  # pragma: no cover
+
+
+__all__ = ["make_async_client", "make_user_agent", "with_retry"]

--- a/src/zotai/utils/logging.py
+++ b/src/zotai/utils/logging.py
@@ -1,0 +1,107 @@
+"""structlog setup.
+
+Two modes, picked automatically from stderr's TTY-ness:
+
+- **TTY** (interactive): `ConsoleRenderer` — colorful, human-readable.
+- **non-TTY** (pipes, Docker logs, CI): `JSONRenderer` — one JSON object per
+  log event, safe to grep / ingest.
+
+Callers get loggers via `get_logger(__name__)`. The module-level
+`configure_logging` should be called exactly once, near program entry
+(done automatically in the Typer callback in `zotai.cli`).
+"""
+
+from __future__ import annotations
+
+import logging
+import sys
+from typing import Any
+
+import structlog
+from structlog.contextvars import bind_contextvars, clear_contextvars
+from structlog.typing import EventDict, Processor
+
+_LEVEL_BY_NAME: dict[str, int] = {
+    "DEBUG": logging.DEBUG,
+    "INFO": logging.INFO,
+    "WARNING": logging.WARNING,
+    "ERROR": logging.ERROR,
+    "CRITICAL": logging.CRITICAL,
+}
+
+
+def _resolve_level(level: str | int) -> int:
+    if isinstance(level, int):
+        return level
+    return _LEVEL_BY_NAME.get(level.upper(), logging.INFO)
+
+
+def _event_uppercase(_: Any, __: str, event_dict: EventDict) -> EventDict:
+    """Uppercase the event name — a small UX nicety for console logs."""
+    level = event_dict.get("level")
+    if isinstance(level, str):
+        event_dict["level"] = level.upper()
+    return event_dict
+
+
+def configure_logging(level: str | int = "INFO", json_logs: bool | None = None) -> None:
+    """Configure the global structlog pipeline.
+
+    Args:
+        level: Minimum log level. Anything below is dropped.
+        json_logs: Force JSON output (True) or console output (False). When
+            `None` (default), auto-detect from `sys.stderr.isatty()`.
+    """
+    if json_logs is None:
+        json_logs = not sys.stderr.isatty()
+
+    shared: list[Processor] = [
+        structlog.contextvars.merge_contextvars,
+        structlog.processors.add_log_level,
+        _event_uppercase,
+        structlog.processors.StackInfoRenderer(),
+        structlog.processors.TimeStamper(fmt="iso", utc=True),
+    ]
+
+    processors: list[Processor]
+    if json_logs:
+        processors = [
+            *shared,
+            structlog.processors.format_exc_info,
+            structlog.processors.JSONRenderer(sort_keys=True),
+        ]
+    else:
+        processors = [
+            *shared,
+            structlog.dev.ConsoleRenderer(colors=sys.stderr.isatty()),
+        ]
+
+    structlog.configure(
+        processors=processors,
+        wrapper_class=structlog.make_filtering_bound_logger(_resolve_level(level)),
+        context_class=dict,
+        logger_factory=structlog.PrintLoggerFactory(file=sys.stderr),
+        cache_logger_on_first_use=True,
+    )
+
+
+def get_logger(name: str | None = None) -> structlog.stdlib.BoundLogger:
+    """Return a bound structlog logger."""
+    return structlog.get_logger(name)
+
+
+def bind(**kwargs: Any) -> None:
+    """Attach key/value pairs to the current contextvar scope.
+
+    Values bound here are merged into every subsequent log event on the
+    current task/thread until `clear()` is called.
+    """
+    bind_contextvars(**kwargs)
+
+
+def clear() -> None:
+    """Drop all contextvar bindings for the current task/thread."""
+    clear_contextvars()
+
+
+__all__ = ["bind", "clear", "configure_logging", "get_logger"]

--- a/src/zotai/utils/pdf.py
+++ b/src/zotai/utils/pdf.py
@@ -1,0 +1,135 @@
+"""PDF text + metadata extraction helpers built on pdfplumber.
+
+Phase 1 exposes the primitives used by:
+- Stage 01 (inventory): `extract_text_pages`, `detect_doi`, `has_text_layer`
+- Stage 04 (enrichment): `extract_probable_title`, `detect_arxiv`
+
+The functions are deliberately narrow — no network, no DB, easy to unit-test
+with fixture PDFs.
+"""
+
+from __future__ import annotations
+
+import re
+from collections import defaultdict
+from collections.abc import Iterator
+from pathlib import Path
+from typing import Any
+
+import pdfplumber
+
+_DOI_RE = re.compile(r"\b10\.\d{4,9}/[-._;()/:A-Za-z0-9]+", re.IGNORECASE)
+_ARXIV_RE = re.compile(
+    r"(?:arXiv:|arxiv\.org/abs/)(\d{4}\.\d{4,5})(?:v\d+)?",
+    re.IGNORECASE,
+)
+
+# Generic titles that should short-circuit title-based lookups.
+_TITLE_BLACKLIST: frozenset[str] = frozenset(
+    {
+        "abstract",
+        "acknowledgements",
+        "appendix",
+        "bibliography",
+        "chapter 1",
+        "contents",
+        "introduction",
+        "references",
+        "summary",
+        "table of contents",
+    }
+)
+
+_DEFAULT_PAGES = 3
+_HAS_TEXT_THRESHOLD = 100
+
+
+def extract_text_pages(path: Path, max_pages: int = _DEFAULT_PAGES) -> list[str]:
+    """Return the text of the first `max_pages` pages (empty string on blank pages)."""
+    texts: list[str] = []
+    with pdfplumber.open(path) as pdf:
+        for idx, page in enumerate(pdf.pages):
+            if idx >= max_pages:
+                break
+            text = page.extract_text() or ""
+            texts.append(text)
+    return texts
+
+
+def detect_doi(text: str) -> str | None:
+    """Return the first DOI found in `text`, or None."""
+    match = _DOI_RE.search(text)
+    if match is None:
+        return None
+    # Trim trailing punctuation commonly captured by the regex boundary.
+    return match.group(0).rstrip(".,;:)")
+
+
+def detect_arxiv(text: str) -> str | None:
+    """Return the arXiv id (e.g. '2301.12345') found in `text`, or None."""
+    match = _ARXIV_RE.search(text)
+    return match.group(1) if match else None
+
+
+def has_text_layer(path: Path, threshold: int = _HAS_TEXT_THRESHOLD) -> bool:
+    """True iff the first page of the PDF yields at least `threshold` chars of text."""
+    pages = extract_text_pages(path, max_pages=1)
+    if not pages:
+        return False
+    return len(pages[0]) >= threshold
+
+
+def _iter_lines(chars: list[dict[str, Any]]) -> Iterator[tuple[float, float, str]]:
+    """Group pdfplumber chars into lines keyed by rounded `top`.
+
+    Yields (average_font_size, top, text) per line.
+    """
+    by_line: dict[int, list[dict[str, Any]]] = defaultdict(list)
+    for ch in chars:
+        top_val = ch.get("top")
+        if top_val is None:
+            continue
+        by_line[round(float(top_val))].append(ch)
+
+    for top_key, char_list in by_line.items():
+        sizes = [float(c.get("size", 0.0)) for c in char_list if c.get("size") is not None]
+        if not sizes:
+            continue
+        avg_size = sum(sizes) / len(sizes)
+        text = "".join(str(c.get("text", "")) for c in char_list).strip()
+        if text:
+            yield avg_size, float(top_key), text
+
+
+def extract_probable_title(path: Path) -> str | None:
+    """Return the largest-font line on page 1, or None if the heuristic fails.
+
+    Skips generic headings listed in `_TITLE_BLACKLIST` and lines shorter than
+    five words — both make downstream fuzzy matching noisy (plan_01 §3 Stage 04).
+    """
+    with pdfplumber.open(path) as pdf:
+        if not pdf.pages:
+            return None
+        page = pdf.pages[0]
+        chars = page.chars or []
+    if not chars:
+        return None
+
+    lines = sorted(_iter_lines(chars), key=lambda triple: (-triple[0], triple[1]))
+    for _size, _top, text in lines:
+        normalized = text.lower().strip()
+        if normalized in _TITLE_BLACKLIST:
+            continue
+        if len(text.split()) < 5:
+            continue
+        return text
+    return None
+
+
+__all__ = [
+    "detect_arxiv",
+    "detect_doi",
+    "extract_probable_title",
+    "extract_text_pages",
+    "has_text_layer",
+]

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -1,0 +1,123 @@
+"""Tests for `zotai.config`."""
+
+from __future__ import annotations
+
+from pathlib import Path
+
+import pytest
+
+from zotai.config import (
+    OcrSettings,
+    PathSettings,
+    S2Settings,
+    Settings,
+    ZoteroSettings,
+)
+
+
+@pytest.fixture(autouse=True)
+def _isolate_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
+    """Strip known env vars + pin CWD so pydantic-settings can't pick up a real `.env`."""
+    for prefix in (
+        "ZOTERO_",
+        "OPENAI_",
+        "SEMANTIC_SCHOLAR_",
+        "OCR_",
+        "S2_",
+    ):
+        for var in (
+            "API_KEY",
+            "LIBRARY_ID",
+            "LIBRARY_TYPE",
+            "LOCAL_API",
+            "MODEL_TAG",
+            "MODEL_EXTRACT",
+            "EMBEDDING_MODEL",
+            "LANGUAGES",
+            "PARALLEL_PROCESSES",
+            "FETCH_INTERVAL_HOURS",
+            "CANDIDATES_DB",
+            "CHROMA_PATH",
+            "ZOTERO_INBOX_COLLECTION",
+            "PDF_SOURCES",
+            "DASHBOARD_HOST",
+            "DASHBOARD_PORT",
+            "MAX_COST_USD_DAILY",
+            "MAX_COST_USD_MONTHLY",
+        ):
+            monkeypatch.delenv(prefix + var, raising=False)
+    for key in (
+        "PDF_SOURCE_FOLDERS",
+        "STAGING_FOLDER",
+        "STATE_DB",
+        "REPORTS_FOLDER",
+        "MAX_COST_USD_TOTAL",
+        "MAX_COST_USD_STAGE_04",
+        "MAX_COST_USD_STAGE_05",
+        "DRY_RUN",
+        "LOG_LEVEL",
+        "USER_EMAIL",
+    ):
+        monkeypatch.delenv(key, raising=False)
+    monkeypatch.chdir(tmp_path)
+
+
+def test_settings_load_with_defaults() -> None:
+    s = Settings()
+    assert s.zotero.library_type == "user"
+    assert s.zotero.local_api is True
+    assert s.openai.model_tag == "gpt-4o-mini"
+    assert s.ocr.languages == "spa+eng"
+    assert s.ocr.parallel_processes == 4
+    assert s.s2.fetch_interval_hours == 6
+    assert s.s2.pdf_sources == [
+        "openaccess",
+        "doi",
+        "annas",
+        "libgen",
+        "scihub",
+        "rss",
+    ]
+
+
+def test_settings_reads_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("ZOTERO_API_KEY", "abc123")
+    monkeypatch.setenv("ZOTERO_LIBRARY_ID", "42")
+    monkeypatch.setenv("OPENAI_API_KEY", "sk-test")
+    monkeypatch.setenv("S2_PDF_SOURCES", "openaccess, doi, scihub")
+    monkeypatch.setenv("OCR_PARALLEL_PROCESSES", "8")
+
+    s = Settings()
+    assert s.zotero.api_key.get_secret_value() == "abc123"
+    assert s.zotero.library_id == "42"
+    assert s.openai.api_key.get_secret_value() == "sk-test"
+    assert s.s2.pdf_sources == ["openaccess", "doi", "scihub"]
+    assert s.ocr.parallel_processes == 8
+
+
+def test_zotero_library_type_rejects_garbage(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("ZOTERO_LIBRARY_TYPE", "organization")
+    with pytest.raises(Exception):  # pydantic ValidationError
+        ZoteroSettings()
+
+
+def test_ocr_parallel_rejects_zero(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("OCR_PARALLEL_PROCESSES", "0")
+    with pytest.raises(Exception):
+        OcrSettings()
+
+
+def test_pdf_source_folders_parses_csv(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("PDF_SOURCE_FOLDERS", "/a,/b , /c/d")
+    s = PathSettings()
+    assert s.pdf_source_folders == [Path("/a"), Path("/b"), Path("/c/d")]
+
+
+def test_s2_dashboard_port_rejects_negative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("S2_DASHBOARD_PORT", "0")
+    with pytest.raises(Exception):
+        S2Settings()

--- a/tests/test_state.py
+++ b/tests/test_state.py
@@ -1,0 +1,118 @@
+"""Tests for `zotai.state` — schema creation + basic CRUD."""
+
+from __future__ import annotations
+
+from datetime import date, datetime, timezone
+from pathlib import Path
+
+from sqlalchemy import inspect
+from sqlmodel import Session, select
+
+from zotai.state import (
+    ApiCall,
+    Candidate,
+    Feed,
+    Item,
+    PersistentQuery,
+    Run,
+    S1_TABLES,
+    S2_TABLES,
+    TriageMetric,
+    init_s1,
+    init_s2,
+    make_s1_engine,
+    make_s2_engine,
+)
+
+
+def test_s1_init_creates_only_s1_tables(tmp_path: Path) -> None:
+    db = tmp_path / "state.db"
+    engine = make_s1_engine(str(db))
+    init_s1(engine)
+
+    names = set(inspect(engine).get_table_names())
+    expected = {t.name for t in S1_TABLES}
+    assert expected.issubset(names)
+    for s2_table in S2_TABLES:
+        assert s2_table.name not in names
+
+
+def test_s2_init_creates_only_s2_tables(tmp_path: Path) -> None:
+    db = tmp_path / "candidates.db"
+    engine = make_s2_engine(str(db))
+    init_s2(engine)
+
+    names = set(inspect(engine).get_table_names())
+    expected = {t.name for t in S2_TABLES}
+    assert expected.issubset(names)
+    for s1_table in S1_TABLES:
+        assert s1_table.name not in names
+
+
+def test_s1_item_roundtrip(tmp_path: Path) -> None:
+    engine = make_s1_engine(str(tmp_path / "state.db"))
+    init_s1(engine)
+
+    with Session(engine) as session:
+        run = Run(stage=1)
+        session.add(run)
+        session.commit()
+        session.refresh(run)
+
+        item = Item(id="a" * 64, source_path="/tmp/x.pdf", size_bytes=1234)
+        session.add(item)
+        session.commit()
+
+        call = ApiCall(
+            run_id=run.id or 0,
+            service="openai",
+            cost_usd=0.001,
+            duration_ms=42,
+        )
+        session.add(call)
+        session.commit()
+
+        fetched = session.exec(select(Item).where(Item.id == item.id)).one()
+        assert fetched.source_path == "/tmp/x.pdf"
+        assert fetched.stage_completed == 0
+        assert fetched.created_at.tzinfo is not None
+
+
+def test_s2_candidate_roundtrip(tmp_path: Path) -> None:
+    engine = make_s2_engine(str(tmp_path / "candidates.db"))
+    init_s2(engine)
+
+    with Session(engine) as session:
+        feed = Feed(id="aer", name="AER", rss_url="https://example.com/rss")
+        session.add(feed)
+        session.commit()
+
+        candidate = Candidate(
+            id="deadbeef",
+            source_feed_id=feed.id,
+            title="Test paper",
+            authors_json="[]",
+            venue="AER",
+            published_at=datetime(2026, 1, 1, tzinfo=timezone.utc),
+        )
+        session.add(candidate)
+
+        query = PersistentQuery(query_text="fiscal multiplier")
+        session.add(query)
+
+        metric = TriageMetric(
+            week_start=date(2026, 1, 5),
+            candidates_shown=10,
+            candidates_accepted=5,
+            candidates_rejected=3,
+            candidates_deferred=2,
+            precision_observed=5 / 8,
+        )
+        session.add(metric)
+        session.commit()
+
+        fetched = session.exec(
+            select(Candidate).where(Candidate.id == candidate.id)
+        ).one()
+        assert fetched.title == "Test paper"
+        assert fetched.status == "pending"

--- a/tests/test_utils/test_fs.py
+++ b/tests/test_utils/test_fs.py
@@ -1,0 +1,61 @@
+"""Tests for `zotai.utils.fs`."""
+
+from __future__ import annotations
+
+import hashlib
+from pathlib import Path
+
+from zotai.utils import fs
+
+
+def test_file_sha256_matches_hashlib(tmp_path: Path) -> None:
+    content = b"hello world\n" * 1000
+    f = tmp_path / "x.bin"
+    f.write_bytes(content)
+    assert fs.file_sha256(f) == hashlib.sha256(content).hexdigest()
+
+
+def test_file_sha256_handles_multi_chunk(tmp_path: Path) -> None:
+    content = b"x" * (3 * (1 << 20) + 17)  # > 3 MiB, non-aligned
+    f = tmp_path / "big.bin"
+    f.write_bytes(content)
+    assert fs.file_sha256(f) == hashlib.sha256(content).hexdigest()
+
+
+def test_validate_pdf_magic_true(tmp_path: Path) -> None:
+    f = tmp_path / "real.pdf"
+    f.write_bytes(b"%PDF-1.7\nstuff")
+    assert fs.validate_pdf_magic(f) is True
+
+
+def test_validate_pdf_magic_false_on_html(tmp_path: Path) -> None:
+    f = tmp_path / "fake.pdf"
+    f.write_bytes(b"<html>")
+    assert fs.validate_pdf_magic(f) is False
+
+
+def test_validate_pdf_magic_false_on_missing(tmp_path: Path) -> None:
+    assert fs.validate_pdf_magic(tmp_path / "missing.pdf") is False
+
+
+def test_ensure_dir_is_idempotent(tmp_path: Path) -> None:
+    target = tmp_path / "a" / "b" / "c"
+    fs.ensure_dir(target)
+    fs.ensure_dir(target)
+    assert target.is_dir()
+
+
+def test_disk_space_check(tmp_path: Path) -> None:
+    # We can't know the exact free space, but 1 byte should always fit
+    # and a petabyte-sized request should not.
+    assert fs.disk_space_check(tmp_path, 1) is True
+    assert fs.disk_space_check(tmp_path, 10**18) is False
+
+
+def test_safe_copy(tmp_path: Path) -> None:
+    src = tmp_path / "src.txt"
+    src.write_text("content")
+    dst = tmp_path / "nested" / "dst.txt"
+    out = fs.safe_copy(src, dst)
+    assert out == dst
+    assert dst.read_text() == "content"

--- a/tests/test_utils/test_pdf.py
+++ b/tests/test_utils/test_pdf.py
@@ -1,0 +1,44 @@
+"""Tests for `zotai.utils.pdf`.
+
+Most of this module is regex + string work, which is easy to cover with
+unit tests. Actual PDF parsing is exercised with fixture PDFs once
+Phase 2 (#3) lands; for Phase 1 we test the pure-function pieces.
+"""
+
+from __future__ import annotations
+
+import pytest
+
+from zotai.utils import pdf
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("see doi: 10.1234/abc.def for details", "10.1234/abc.def"),
+        ("https://doi.org/10.1016/j.econlet.2020.109234 citation",
+         "10.1016/j.econlet.2020.109234"),
+        ("10.1145/3319535.3363232.", "10.1145/3319535.3363232"),
+        ("no identifier here", None),
+        ("", None),
+    ],
+)
+def test_detect_doi(text: str, expected: str | None) -> None:
+    assert pdf.detect_doi(text) == expected
+
+
+@pytest.mark.parametrize(
+    "text, expected",
+    [
+        ("arXiv:2301.12345", "2301.12345"),
+        ("See https://arxiv.org/abs/2401.99999v2 for v2", "2401.99999"),
+        ("just text", None),
+    ],
+)
+def test_detect_arxiv(text: str, expected: str | None) -> None:
+    assert pdf.detect_arxiv(text) == expected
+
+
+def test_doi_regex_trims_trailing_punctuation() -> None:
+    assert pdf.detect_doi("cf. 10.1234/example.") == "10.1234/example"
+    assert pdf.detect_doi("(10.1234/example);") == "10.1234/example"


### PR DESCRIPTION
## Summary

Wires the foundation every subsystem depends on. 11 modules + decorator + 4 test files, all with strict type hints. Every S1/S2 stage CLI stays stubbed — they fail loudly pointing at their owning issue.

## Modules

| Module | Purpose |
| --- | --- |
| `zotai.config` | `pydantic-settings` groups (`ZoteroSettings`, `OpenAISettings`, `SemanticScholarSettings`, `OcrSettings`, `PathSettings`, `BudgetSettings`, `BehaviorSettings`, `S2Settings`) composed under a top-level `Settings`. Each group reads its own prefixed env vars at instantiation time. Validators for paths, CSV splitting (`PDF_SOURCE_FOLDERS`, `S2_PDF_SOURCES`), and positive ints. |
| `zotai.state` | SQLModel tables for S1 (`Item`, `Run`, `ApiCall`) and S2 (`Candidate`, `Feed`, `PersistentQuery`, `TriageMetric`). `init_s1` / `init_s2` create only the tables that belong to each DB via `create_all(..., tables=[...])`. `metadata` re-exported for Alembic. |
| `zotai.cli` | Typer app with `s1` and `s2` sub-apps; every subcommand is a stub that names the phase/issue that will implement it. Global `--dry-run` / `--verbose` wired via root callback; `--verbose` flips structlog to DEBUG. |
| `zotai.utils.logging` | structlog with TTY/non-TTY auto-select (Console vs JSON). `bind(**kw)` / `clear()` contextvar helpers. |
| `zotai.utils.http` | `make_async_client`, `make_user_agent(mailto=...)` for the OpenAlex polite pool, `with_retry` helper over tenacity. |
| `zotai.utils.fs` | `ensure_dir`, streamed `file_sha256`, `validate_pdf_magic`, `disk_space_available` / `_check`, `safe_copy`. |
| `zotai.utils.pdf` | `extract_text_pages`, `detect_doi` (with trailing-punct trim), `detect_arxiv`, `has_text_layer`, `extract_probable_title` (font-size heuristic + title blacklist + min-word filter). |
| `zotai.api.zotero` | `ZoteroClient` facade over `pyzotero`. Every mutating call short-circuits when `dry_run=True`. |
| `zotai.api.openalex` | `search_works`, `work_by_doi` with retry + `mailto` User-Agent. |
| `zotai.api.semantic_scholar` | `search_paper` with optional `x-api-key`. |
| `zotai.api.openai_client` | Async client + ledger. `BudgetExceededError` raised *before* any call that would push `spent_usd` over `budget_usd`. `extract_metadata`, `tag_paper`, `embed_text`. |
| `zotai.s1.handler` | `@stage_item_handler(stage)` decorator: captures per-item exceptions, bumps Run counters, updates `stage_completed` on success, aborts the run when failure ratio > 30% (sample floor = 10). |

Also flips `alembic/env.py` from the Phase 0 `target_metadata = None` stub to `zotai.state.metadata`.

## Tests

- `tests/test_config.py` — env loading, defaults, validator rejection paths, CSV splitting.
- `tests/test_state.py` — tables created *only* in their own DB (no cross-contamination), Item + Candidate CRUD roundtrip.
- `tests/test_utils/test_fs.py` — SHA-256 parity with `hashlib` (including multi-chunk files), magic-byte validation, idempotent `ensure_dir`, disk-space bounds, `safe_copy`.
- `tests/test_utils/test_pdf.py` — DOI / arXiv regex coverage, trailing-punct trim.

## Known limitations

- **`uv`, `mypy`, `pytest` not installed in the build environment**, so the three acceptance criteria (`uv run mypy --strict src/zotai/`, `uv run pytest`, coverage ≥60% on `utils/`) are unverified locally. All files parse (`python3 -m py_compile`) and the shape is mypy-strict by inspection. Please run locally and report anything I missed — I'll iterate in this PR.
- `PathSettings` and `BudgetSettings` don't take a `env_prefix` because their vars are flat in the plan (`PDF_SOURCE_FOLDERS`, `MAX_COST_USD_TOTAL`, …). They still validate cleanly.
- `alembic revision --autogenerate` not run yet — that's part of Phase 8 (#9) per the issue roadmap.

## Test plan

- [ ] `uv sync --extra s2 --extra dev`
- [ ] `uv run mypy --strict src/zotai/`
- [ ] `uv run pytest tests/ --cov=src/zotai/utils --cov-fail-under=60`
- [ ] `uv run zotai --help`, `uv run zotai s1 --help`, `uv run zotai s2 --help` render non-empty help output.
- [ ] `uv run zotai s1 inventory` prints the "not yet implemented in Phase 2 (#3)" message and exits 1.
- [ ] In a TTY, `uv run python -c "from zotai.utils.logging import configure_logging, get_logger; configure_logging('INFO'); get_logger('t').info('hello', x=1)"` prints a colorized log line.
- [ ] Piped: same command | cat — prints one JSON object on stderr.

Closes #2.