### PR TITLE
docs(s1): Stage 01 academic classifier + Zotero organization in README

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -43,6 +43,26 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Spec**: `docs/plan_01_subsystem1.md` §3 Etapa 01 — added an
+  **academic / non-academic classifier** upstream of the rest of the S1
+  pipeline (plan §3.1). Hybrid strategy: (1) zero-cost positive
+  heuristic accept on DOI / arXiv / ISBN / academic keywords in pages
+  1-3; (2) zero-cost negative heuristic reject on `pages ≤ 2` combined
+  with absent text or billing keywords (`factura`, `recibo`, `invoice`,
+  `CUIT`, `CUIL`, `DNI`, `ticket`, etc.); (3) LLM gate (`gpt-4o-mini`)
+  for the ambiguous remainder, budgeted via a new
+  `MAX_COST_USD_STAGE_01=1.00` env var (~$0.12 / 1000 PDFs expected).
+  Rejected PDFs land in `reports/excluded_report_<ts>.csv` and never
+  enter `state.db`, so they consume no OCR or downstream API calls.
+  New `Item.classification` and `Item.needs_review` columns documented
+  (implementation lands in a separate PR — Phase 2.5). New CLI flags
+  `--skip-llm-gate` and `--max-cost N` on `zotai s1 inventory`.
+  `plan_glossary.md` gained entries for *Clasificador académico / no-
+  académico*, *Excluded report*, and *Needs review*. `README.md` and
+  `CLAUDE.md` updated accordingly. Rationale: researchers' source
+  folders (`Downloads/`, etc.) are mixed content; running the whole
+  pipeline on a DNI photo or electricity bill wastes OCR + API budget
+  and pollutes Zotero. Option C (híbrido) from the 2026-04-21 review.
 - **Spec**: `docs/plan_01_subsystem1.md` §3 Etapa 03 — removed Ruta B
   (Zotero "Retrieve Metadata for PDFs" recognizer applied to orphan
   attachments). Items without a detected DOI, or where Ruta A's

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -51,6 +51,7 @@ Este archivo es leído automáticamente por Claude Code al iniciar sesión en es
 - **No reemplaza el juicio académico del usuario**: las sugerencias de cita requieren verificación manual obligatoria.
 - **No hay autenticación multiusuario, roles, permisos**: cada investigador es dueño único de su instancia.
 - **No hay nube propia**: todo corre localmente (o Zotero cloud para sync personal).
+- **No procesa PDFs no-académicos**: S1 Etapa 01 filtra explícitamente facturas, DNIs, tickets, manuales, etc. antes de gastar OCR / APIs en ellos. Ver `docs/plan_01_subsystem1.md` §3.1 para el clasificador (híbrido heurística + LLM gate). No remover el filtro sin ADR que lo justifique.
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -33,11 +33,41 @@ Ver `docs/plan_00_overview.md` para el detalle.
 
 ---
 
+## Cómo queda tu biblioteca Zotero
+
+El sistema maneja **3 collections** al nivel de Zotero y **2 dimensiones de tags** planas — nada más. Geografía, tipo de documento y año van en campos nativos de Zotero, no se duplican como tags.
+
+### Collections (manejadas automáticamente)
+- **Biblioteca principal** (root): items con metadata completa, el corazón de tu biblioteca utilizable.
+- **Quarantine**: items que S1 no pudo enriquecer con calidad suficiente. Quedan accesibles pero fuera de las búsquedas por default.
+- **Inbox S2**: donde S2 empuja candidatos aceptados por triage (cuando esté implementado).
+
+Si querés colecciones por proyecto de investigación (p.ej. "Tesis doctoral", "Paper inflación 2026"), las creás a mano en Zotero — el sistema no las gestiona.
+
+### Tags (dos dimensiones, 25-40 total)
+- **TEMA** (2-4 por paper): sustantivo del paper — `macro-fiscal`, `informalidad`, `mercado-laboral`, etc.
+- **METODO** (1-2 por paper): cómo aborda el problema — `empirico-rct`, `empirico-quasi-exp`, `teorico-analitico`, etc.
+
+Definidas en `config/taxonomy.yaml`; taxonomía completa y reglas en `docs/plan_taxonomy.md`. El archivo hoy viene con plantilla de economía / LATAM que el investigador debe customizar antes de correr Etapa 05 (tagging).
+
+### Campos nativos de Zotero (no duplicar como tags)
+- `Place` → país / región del estudio.
+- `Item Type` → `journalArticle`, `book`, `thesis`, `report`, `preprint`, `conferencePaper`, etc.
+- `Date` → año.
+- `Publication` → journal / editorial.
+
+### Filtrado de PDFs no-académicos
+S1 Etapa 01 incluye un **clasificador upstream** que separa papers de material de descarte (facturas, DNIs, tickets, manuales). Estrategia híbrida: heurística positiva (DOI/arXiv/ISBN/keywords académicos) para accept inmediato, heurística negativa (pocas páginas + keywords de facturación) para reject inmediato, LLM gate (gpt-4o-mini, ~$0.12 por 1000 PDFs) solo para los ambiguos. Los rechazados quedan en un CSV separado y **nunca entran al pipeline** — no se les gasta OCR ni llamadas a APIs.
+
+Ver `docs/plan_01_subsystem1.md` §3.1 para el detalle del clasificador.
+
+---
+
 ## Estado del proyecto
 
 | Subsistema | Estado | Plan |
 |---|---|---|
-| S1 – Retroactive | 🟡 Spec, pendiente implementación | `docs/plan_01_subsystem1.md` |
+| S1 – Retroactive | 🟢 En implementación (Phase 2 / Stage 01 mergeado) | `docs/plan_01_subsystem1.md` |
 | S3 – MCP access | 🟡 Spec, pendiente implementación | `docs/plan_03_subsystem3.md` |
 | S2 – Prospective | 🟡 Spec, pendiente implementación | `docs/plan_02_subsystem2.md` |
 

--- a/docs/plan_01_subsystem1.md
+++ b/docs/plan_01_subsystem1.md
@@ -35,30 +35,84 @@ Pipeline CLI one-shot que lleva ~1000 PDFs dispersos en carpetas del usuario a s
 ### Etapa 01 — Inventory
 
 **Input**: rutas de carpetas fuente (desde `.env`: `PDF_SOURCE_FOLDERS`).
-**Output**: filas en tabla `items` del `state.db`.
+**Output**:
+- Filas en tabla `items` del `state.db` (solo para PDFs clasificados como académicos o ambiguos).
+- `reports/inventory_report_<ts>.csv`: todos los PDFs escaneados con su clasificación.
+- `reports/excluded_report_<ts>.csv`: PDFs rechazados por el clasificador — **no tienen fila en `state.db`**.
 
-**Lógica**:
-1. Recorrer recursivamente las carpetas.
-2. Para cada PDF:
-   - Calcular SHA-256 del archivo.
-   - Si el hash ya existe en DB, marcar como duplicado, no crear item nuevo.
-   - Extraer primeras 3 páginas como texto (via `pdfplumber`).
-   - Detectar si el PDF tiene capa de texto (threshold: >100 chars extraíbles de página 1).
-   - Buscar DOI por regex en texto extraíble.
-   - Persistir: `id` (hash), `source_path`, `size_bytes`, `has_text`, `detected_doi`, `stage_completed=01`.
-3. Generar reporte CSV con counts y anomalías.
+**Lógica** (para cada PDF bajo las carpetas fuente, en orden):
+1. Validar magic bytes (`%PDF-`); si falla, saltear con status `invalid_magic`.
+2. Calcular SHA-256 del archivo.
+3. Si el hash ya existe en DB: reportar como duplicado (status `duplicate`), no crear item nuevo.
+4. Extraer primeras 3 páginas como texto via `pdfplumber`.
+5. Detectar `has_text` (threshold: ≥100 chars extraíbles de página 1).
+6. Buscar DOI / arXiv / ISBN por regex en las primeras 3 páginas.
+7. **Clasificación** (nueva lógica — ver §3.1 Clasificador):
+   - Si marcador positivo claro → `classification='academic'`.
+   - Si marcador negativo claro → emitir fila en `excluded_report.csv` y **saltear** (no hay fila en `state.db`).
+   - Ambiguo → llamar LLM gate; según respuesta, `academic` o excluded.
+8. Persistir en `state.db`: `id` (hash), `source_path`, `size_bytes`, `has_text`, `detected_doi`, `classification`, `needs_review` (True iff LLM tuvo que decidir y el item quedó como ambiguo-incluido), `stage_completed=01`.
+
+#### §3.1 Clasificador académico / no-académico (tres ramas)
+
+Opera sobre el texto de las primeras 3 páginas + metadata barata (page count, tamaño).
+
+**Rama 1 — Accept automático** (zero cost). Se aplica al menos uno de:
+- DOI detectado (regex `10\.\d{4,9}/[-._;()/:A-Za-z0-9]+`).
+- arXiv ID detectado (`arXiv:\d{4}\.\d{4,5}` o `arxiv.org/abs/...`).
+- ISBN válido (10 o 13 dígitos con checksum).
+- Keywords académicos en páginas 1-3 (case-insensitive, word-boundary): `abstract`, `references`, `bibliography`, `introduction`, `keywords`, `JEL codes`, `et al\.`, `University of …`, `Universidad de …`, `Instituto de …`.
+
+Resultado: `classification='academic'`. Continúa al resto del pipeline.
+
+**Rama 2 — Reject automático** (zero cost). Se aplica cuando:
+- `page_count ≤ 2` **Y** (`has_text=False` **O** primera página contiene ≥1 keyword de facturación/documento personal del blacklist: `factura`, `recibo`, `invoice`, `receipt`, `CUIT`, `CUIL`, `DNI`, `ticket`, `boleta`, `comprobante`, `nota de débito`, `nota de crédito`, `voucher`, `bill`).
+
+Resultado: fila en `excluded_report.csv` con `reason`; **no entra a `state.db`**.
+
+**Rama 3 — Ambiguo → LLM gate** (costo marginal). Todo el resto. Se llama a `gpt-4o-mini` con un prompt corto:
+```
+You are classifying a PDF document for a researcher's bibliographic library.
+
+Here are the first 500 characters of page 1:
+---
+{first_page_snippet}
+---
+
+Page count: {page_count}
+
+Return JSON: {"is_academic": bool, "confidence": "low"|"medium"|"high", "reason": "<one short sentence>"}
+
+Academic = research paper, preprint, book chapter, thesis, technical report, working paper, or a similar scholarly work.
+Non-academic = bill, receipt, ID card, manual, slideshow deck, contract, personal document, administrative form, screenshot.
+```
+
+Decisión:
+- `is_academic=True` con `confidence∈{medium,high}` → `classification='academic'`, `needs_review=False`.
+- `is_academic=True` con `confidence=low` → `classification='academic'`, `needs_review=True`. Queda en `state.db` pero se surfacea en el reporte de Etapa 06.
+- `is_academic=False` con `confidence∈{medium,high}` → `excluded_report.csv`, no entra a DB.
+- `is_academic=False` con `confidence=low` → `classification='academic'`, `needs_review=True` (sesgo conservador: ante duda, incluir y flaggear).
+
+**Presupuesto**: ~$0.0004 por llamada al LLM gate. En un corpus de 1000 PDFs con mezcla ~30% ambiguos, eso son ~$0.12. Límite configurable `MAX_COST_USD_STAGE_01=1.00`. Al exceder, abortar con mensaje claro.
+
+**Control**: flag `--skip-llm-gate` salta la Rama 3 y trata todos los ambiguos como `academic` + `needs_review=True`. Útil para correr sin OPENAI_API_KEY.
 
 **Edge cases**:
-- PDFs corruptos: logear, marcar `last_error`, no detener pipeline.
-- PDFs protegidos con password: idem.
-- Archivos no-PDF con extensión `.pdf`: validar magic bytes.
-- Duplicados por hash: reportar en CSV, solo uno va al resto del pipeline.
+- PDFs corruptos: logear, marcar `last_error`, `classification='academic'` por default (sesgo conservador — no rechazamos lo que no podemos leer), `needs_review=True`.
+- PDFs protegidos con password: idem corruptos.
+- Archivos no-PDF con extensión `.pdf`: rechazar por magic bytes, van a `inventory_report` como `invalid_magic` (no se evalúan para clasificación).
+- Duplicados por hash: se evalúan contra el item que ya entró a DB; la clasificación no se recalcula.
+- LLM retorna JSON malformado: reintento 1 vez; si vuelve a fallar, default `academic` + `needs_review=True`.
 
-**Criterio de éxito etapa 01**: `stage_completed=01` en el 100% de PDFs válidos. Reporte `inventory_report.csv` generado.
+**Criterio de éxito etapa 01**:
+- `stage_completed=01` en el 100% de items que entraron a `state.db`.
+- Reportes `inventory_report.csv` y `excluded_report.csv` generados.
+- Costo total del LLM gate < presupuesto configurado.
 
 **CLI**:
 ```bash
-zotai s1 inventory [--folder PATH ...] [--dry-run]
+zotai s1 inventory [--folder PATH ...] [--dry-run] [--retry-errors] \
+  [--skip-llm-gate] [--max-cost N]
 ```
 
 ---
@@ -268,8 +322,9 @@ zotai s1 tag [--preview|--apply] [--max-cost N]
 2. **Distribución de tags**: tag counts, tags huérfanos (usados <3 veces), tags dominantes (>30% del corpus).
 3. **Consistencia**: items con `year` fuera de rango razonable [1900, current_year+1], items con 0 autores, items sin título.
 4. **Duplicados potenciales**: pares con `fuzz.ratio(title) > 90 AND same year`.
-5. **Costos**: total gastado, breakdown por etapa y servicio.
-6. **Tiempo**: por etapa, total wall-clock.
+5. **Filtrado Stage 01**: count de items rechazados (del `excluded_report.csv` de la última corrida de Stage 01) con razón desglosada (heurística negativa vs. LLM gate). Count de items con `needs_review=True` listados con link a Zotero para inspección manual.
+6. **Costos**: total gastado, breakdown por etapa y servicio (incluye `stage_01` si se usó LLM gate).
+7. **Tiempo**: por etapa, total wall-clock.
 
 **Output HTML**: navegable, con links a Zotero para cada item flagged.
 
@@ -295,6 +350,8 @@ class Item(SQLModel, table=True):
     size_bytes: int
     has_text: bool = False
     detected_doi: Optional[str] = None
+    classification: str = "academic"  # 'academic' only — rejects live in excluded_report.csv
+    needs_review: bool = False  # True when LLM gate was uncertain; surfaced in Etapa 06 report
     ocr_failed: bool = False
     zotero_item_key: Optional[str] = None
     import_route: Optional[str] = None  # 'A' | 'C' (Ruta B removed — see §3 Etapa 03)
@@ -358,6 +415,7 @@ REPORTS_FOLDER=/workspace/reports
 
 # ──────────── Budgets ────────────
 MAX_COST_USD_TOTAL=10.00
+MAX_COST_USD_STAGE_01=1.00      # LLM gate del clasificador académico (Rama 3)
 MAX_COST_USD_STAGE_04=2.00
 MAX_COST_USD_STAGE_05=1.00
 
@@ -427,6 +485,7 @@ Modo `--yes` skippea confirmaciones (para CI o usuarios experimentados).
 - Pipeline se reanuda desde stage_completed correcta tras interrupción.
 - `--dry-run` no modifica ni Zotero ni `state.db`.
 - Budget enforcement: mockear costos altos, verificar abort.
+- **Clasificador Stage 01**: fixture con (i) paper con DOI → Rama 1; (ii) paper con "Abstract" + "References" sin DOI → Rama 1; (iii) recibo de 1 página con keyword `factura` → Rama 2 (no entra a DB); (iv) PDF genérico de 5 páginas sin markers → Rama 3, mock OpenAI respuesta `{"is_academic": true, "confidence": "high"}` → entra con `needs_review=False`; (v) mismo PDF con LLM respondiendo `{"is_academic": true, "confidence": "low"}` → entra con `needs_review=True`; (vi) `--skip-llm-gate` deja todos los ambiguos como `academic + needs_review=True` sin llamar a OpenAI.
 
 ---
 

--- a/docs/plan_glossary.md
+++ b/docs/plan_glossary.md
@@ -58,6 +58,15 @@ SQLite con candidates, feeds, queries. Separado del `state.db`. Ubicación: `/wo
 **Chroma DB**
 Base vectorial gestionada por `zotero-mcp` para embeddings. Ubicación canónica: `~/.config/zotero-mcp/chroma_db/`. S3 la escribe, S2 la lee.
 
+**Clasificador académico / no-académico** (S1 Etapa 01)
+Filtro upstream del pipeline S1. Decide, para cada PDF encontrado bajo `PDF_SOURCE_FOLDERS`, si es material bibliográfico o material de descarte (facturas, DNIs, tickets, manuales, etc.). Estrategia híbrida en 3 ramas: (1) **accept** automático por heurística positiva — DOI / arXiv / ISBN / keywords académicos en páginas 1-3; (2) **reject** automático por heurística negativa — ≤2 páginas + ausencia de texto o keywords de facturación en primera página; (3) **ambiguos** resueltos por `gpt-4o-mini` con prompt corto. Ver `plan_01_subsystem1.md` §3 Etapa 01 y §3.1.
+
+**Excluded report**
+CSV en `reports/excluded_report_<ts>.csv` que lista los PDFs rechazados por el clasificador con su razón. Estos PDFs **no entran a `state.db`** y no consumen OCR/API de stages posteriores. Archivo paralelo al `inventory_report.csv`.
+
+**Needs review**
+Flag booleano en `Item.needs_review`. True cuando el clasificador Stage 01 tuvo que decidir con incertidumbre (LLM respondió con `confidence=low`, o tras error transitorio). El item sigue al resto del pipeline como académico, pero se lo surfacea explícitamente en el reporte de Etapa 06 para que el usuario lo revise manualmente.
+
 **Ruta A/C** (S1 Etapa 03)
 Las dos estrategias de import:
 - **A**: import por DOI directo — el translator de Zotero resuelve metadata a partir del DOI detectado en Etapa 01.


### PR DESCRIPTION
## Summary
Two atomic commits, both docs-only:

### Commit 1 — Spec: academic/non-academic classifier in Stage 01

Implements **Option C hybrid** from the 2026-04-21 alignment review.

Addresses a gap: Stage 01 today scans every `.pdf` under `PDF_SOURCE_FOLDERS` with no discrimination. In a real researcher's `Downloads/` folder that means bills, DNI scans, receipts, manuals — all of them get hashed, OCR'd, uploaded to Zotero, and run through LLM enrichment. Wasted budget + polluted library.

The new spec adds a three-branch classifier upstream of everything else:

| Branch | Trigger | Action | Cost |
|---|---|---|---|
| **Accept** | DOI / arXiv / ISBN / academic keyword (`abstract`, `references`, `et al.`, `University of …`, etc.) in pages 1-3 | `classification='academic'`, continues to Stage 02 | $0 |
| **Reject** | `pages ≤ 2` AND (no text OR billing keyword: `factura`, `recibo`, `invoice`, `CUIT`, `CUIL`, `DNI`, `ticket`, etc.) | Row in `excluded_report.csv`, **no entry in state.db** | $0 |
| **Ambiguous** | Neither above | `gpt-4o-mini` with short prompt → decides accept/reject + confidence | ~$0.0004/PDF |

Budget gated by new `MAX_COST_USD_STAGE_01=1.00` env var (expected spend ~$0.12 per 1000 PDFs). `--skip-llm-gate` bypass and `--max-cost N` override on the CLI.

Two new `Item` columns documented in §4 schema: `classification` and `needs_review`. Conservative bias — when the LLM says low-confidence, we keep the item with `needs_review=True` and surface it in the Etapa 06 validation report for manual review.

**Implementation (state.py column additions + alembic migration + stage_01 classifier logic + tests) lands in a separate PR — Phase 2.5.** This PR is spec-only per CLAUDE.md's plan-change rule.

### Commit 2 — README: document Zotero organization + filter gate

Surfaces existing plan decisions into the README so a new user reading top-down understands the product shape without having to dig into `docs/`:

- **3 collections** (Biblioteca principal / Quarantine / Inbox S2) managed by the system; other collections are manual.
- **2-dimension tag taxonomy** (TEMA + METODO) pointing at `config/taxonomy.yaml` + `plan_taxonomy.md`.
- **Zotero-native fields** (`Place`, `Item Type`, `Date`, `Publication`) as canonical home for geography / doc type / year — not duplicated as tags.
- Short paragraph on the Stage 01 classifier with pointer to `plan_01` §3.1.
- Bumps S1 project-status row from 🟡 to 🟢 to reflect post-#21 state.

## Test plan
- [ ] `docs/plan_01_subsystem1.md` §3 Etapa 01 ends with the three-branch classifier description and a `CLI` block listing the new flags.
- [ ] §3.1 subsection exists and documents the accept / reject / ambiguous semantics + LLM prompt.
- [ ] §4 schema shows `classification` and `needs_review` columns with doc comments.
- [ ] §5 `.env` template lists `MAX_COST_USD_STAGE_01=1.00`.
- [ ] §6 Etapa 06 chequeos mention `excluded_report.csv` counts and `needs_review` listing.
- [ ] `plan_glossary.md` has three new entries: *Clasificador …*, *Excluded report*, *Needs review*.
- [ ] `README.md` shows the "Cómo queda tu biblioteca Zotero" section between the architecture diagram and project status.
- [ ] `CLAUDE.md` §"Lo que este proyecto NO es" pins "No procesa PDFs no-académicos".
- [ ] `CHANGELOG.md` §Changed has a new entry ahead of the Ruta B removal one.

## Follow-ups (tracked separately, not in this PR)
- New implementation issue: **Phase 2.5 — S1 Stage 01 classification filter**. Touches `state.py`, alembic migration, `stage_01_inventory.py`, tests.
- Update issue #4 (Phase 3 OCR) body: input spec changes slightly — OCR now only processes items with `classification='academic'`.
- Update issue #5 (Phase 4 Import) body for the Ruta A/C change from #22 (still pending from that PR).
- Update issue #8 (Phase 7 Validation) body to include filter stats + `needs_review` listing.

I'll open Phase 2.5 and post the issue body comments once this PR merges, so the issue descriptions reference the merged spec.