### PR TITLE
docs(cli): drop stale Route B reference in s1 import docstring

### DIFF
--- a/src/zotai/cli.py
+++ b/src/zotai/cli.py
@@ -150,7 +150,7 @@ def s1_ocr(
 def s1_import(
     batch_size: Annotated[int, typer.Option("--batch-size")] = 50,
 ) -> None:
-    """Stage 03 — import PDFs into Zotero (Route A/B/C)."""
+    """Stage 03 — import PDFs into Zotero (Route A/C)."""
     _ = batch_size
     _not_implemented("s1 import", 4, 5)
 


### PR DESCRIPTION
## Summary

- `src/zotai/cli.py` — change `s1 import` docstring from "Route A/B/C" to "Route A/C".

Aligns with `docs/plan_01_subsystem1.md` §3 Etapa 03 post-PR #22, where Route B (Zotero recognizer over orphan PDFs) was removed and no-DOI recovery was consolidated into the Etapa 04 cascade.

## Context

This is the first place a new dev reads when exploring the `zotai` CLI; a stale Route B reference would confuse the mental model. Found during the 2026-04-22 alignment review.

## Test plan

- [x] `git diff` scoped to a single line change.
- [x] Command is still a stub (`_not_implemented("s1 import", 4, 5)`), so no behavioural change.