### PR TITLE
docs(adr): 001-003 backfill for already-taken decisions

### DIFF
--- a/docs/decisions/001-use-docker.md
+++ b/docs/decisions/001-use-docker.md
@@ -1,0 +1,109 @@
+# ADR 001 — Docker as the distribution medium
+
+**Status**: Accepted
+**Date**: 2026-04-20
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+The target audience is researchers (α scenario — see ADR 003): each runs the
+toolkit against their own personal Zotero library, on their own machine. The
+primary platform split is **Windows 10/11 + WSL2** and **Linux (Ubuntu
+22.04+)**; macOS is nice-to-have. Python skill levels are mixed; none of them
+want to fight `tesseract`, `ghostscript`, `poppler`, `ocrmypdf`, a specific
+Python minor, and three native compilers before their first run.
+
+Onboarding time is the scarcest resource in this project. If the first
+experience is 90 minutes of `apt install`, `brew` errors, `WSL` path
+confusion, and `pyenv` vs. system Python disputes, the toolkit simply does
+not get adopted.
+
+## Decision
+
+Ship the toolkit as a **Docker image** orchestrated by `docker-compose`.
+
+- Multi-stage `Dockerfile`: builder stage with compilation toolchain,
+  final stage minimal (no dev headers, no uv cache).
+- Non-root user `zotai` (UID 1000) in the final stage.
+- System deps baked in: `tesseract-ocr`, `tesseract-ocr-spa`,
+  `tesseract-ocr-eng`, `ocrmypdf`, `ghostscript`, Poppler libs.
+- Python deps managed by `uv` inside the image.
+- `docker-compose.yml` is the user-facing interface; `onboarding` and
+  `dashboard` are the two services (S1 one-shot vs. S2 long-running).
+- Volumes for the only state that must persist: `state.db`, `candidates.db`,
+  `staging/`, `reports/`, and the ChromaDB shared with `zotero-mcp`.
+
+The `README.md` quickstart assumes Docker Desktop (Windows/macOS) or Docker
+Engine (Linux) is already installed. Installation of Docker itself is out of
+scope for this project's docs.
+
+## Consequences
+
+### Positive
+
+- **Reproducible builds**: `uv.lock` + `Dockerfile` freeze the entire stack,
+  including native OCR tooling. Two users on different OSes get the same
+  binary.
+- **Onboarding time collapses** from hours to one `docker compose run` line.
+- Native build complexity (`ocrmypdf` → `tesseract` → language packs)
+  becomes an image-build concern, not a user concern.
+- Cross-platform path issues (`/` vs. `\`, case sensitivity) are resolved
+  once inside a Linux container — host paths only show up at volume mount
+  boundaries.
+- We can pin a single Python minor (3.11) independently of whatever the
+  user has globally installed.
+
+### Negative
+
+- **Docker Desktop is a hard prerequisite** (free for personal and research
+  use, but users must install it). This is accepted; the target audience
+  has shown willingness.
+- **Volume permission mismatches** on Linux hosts (UID 1000 inside the
+  container vs. the host user's UID) require documentation but are a
+  one-line fix (`--user $(id -u):$(id -g)`).
+- **Image size** (~1.2 GB with Tesseract + language packs) — acceptable for
+  a toolkit a user installs once.
+- `zotero-mcp` (S3) cannot easily run inside the same container because
+  Claude Desktop spawns it as a subprocess on the host. This is not a
+  regression of Docker; it is a property of MCP's stdio transport. S3 is
+  installed on the host via `uv tool install` (see `plan_03`).
+
+### Neutral
+
+- We do not ship a native binary, wheel, or pip package. Users who really
+  want non-Docker local installs can clone the repo and run `uv sync`
+  themselves, but that path is not supported.
+
+## Alternatives considered
+
+**A. `pip install zotero-ai-toolkit` (pypi package)**.
+Rejected. Leaves users to install `tesseract`, `poppler`, `ghostscript`
+themselves; adoption friction defeats the purpose. Pypi would still be
+useful as a secondary distribution once Docker-first is proven.
+
+**B. Native scripts per OS (`.sh`, `.ps1`) installing system deps**.
+Rejected. Multiplies surface area: every package manager (`apt`, `brew`,
+`choco`, `winget`) behaves differently, language packs have different
+names, and the matrix explodes fast. `CLAUDE.md` explicitly bans bash
+scripts as a cross-platform strategy for this reason.
+
+**C. Conda / mamba environment**.
+Rejected. Conda handles some native deps (tesseract is available on
+conda-forge) but adds its own bootstrap step and its own class of
+environment confusion. `uv` is the project's declared dependency manager
+(see `CLAUDE.md` §Stack canónico); mixing uv + conda is worse than either
+alone.
+
+**D. `nix` flakes**.
+Rejected on audience grounds. The target user base is not going to install
+Nix to run a Zotero loader.
+
+## References
+
+- `CLAUDE.md` §Stack canónico, §Reglas sobre Docker
+- `docs/plan_00_overview.md` §5 row 001
+- `Dockerfile`, `docker-compose.yml`, `.dockerignore`

--- a/docs/decisions/002-sqlite-for-state.md
+++ b/docs/decisions/002-sqlite-for-state.md
@@ -1,0 +1,118 @@
+# ADR 002 — SQLite for pipeline state
+
+**Status**: Accepted
+**Date**: 2026-04-20
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+The S1 pipeline tracks ~1000 PDFs across six stages (inventory → OCR →
+import → enrich → tag → validate). Each stage reads where the previous one
+left off and writes its own outputs. The pipeline must be **idempotent**
+(re-runnable without corrupting state) and **resumable** (interruption in
+stage 04 must not repeat stages 01–03). S2 has a parallel but independent
+store for candidates, feeds, triage metrics, and persistent queries.
+
+The process runs inside a Docker container, on a single researcher's
+laptop, with no concurrent writers. Read/write volume is modest:
+low-thousands of rows per table, writes batched at stage boundaries, reads
+dominated by "give me all items at `stage_completed=3`".
+
+## Decision
+
+Use **SQLite** as the persistence layer for both `state.db` (S1) and
+`candidates.db` (S2). Access via `sqlmodel` (= SQLAlchemy + pydantic).
+Schema migrations via `alembic`.
+
+- One file per database (`state.db`, `candidates.db`), mounted as Docker
+  volumes so they survive container rebuilds.
+- The two DBs are disjoint by design: S1 tables are grouped in `S1_TABLES`
+  and S2 tables in `S2_TABLES` in `src/zotai/state.py`; each `init_s1` /
+  `init_s2` helper only creates its own slice. This enforces the
+  "communication between subsystems only via Zotero" contract from
+  `plan_00` §3.
+- Alembic's `target_metadata` is the shared `SQLModel.metadata`; migrations
+  are authored against the S1 schema. S2 tables are created on dashboard
+  startup and evolve in code in v1 (see `plan_02` §5).
+
+## Consequences
+
+### Positive
+
+- **Zero setup.** No server process, no port, no auth, no role management.
+  The "database" is just a file; `docker-compose up` is all that is needed.
+  This matches the α scenario (see ADR 003) where each user owns a
+  single-machine instance.
+- **Inspectable.** The user can open `state.db` in the `sqlite3` CLI,
+  DBeaver, VSCode extensions, or `datasette` to audit state without any
+  project-specific tooling. This is load-bearing for trust: users must be
+  able to see what the pipeline did.
+- **Idempotence is trivial.** PDF identity is `SHA-256(bytes)`, used as
+  `Item.id` (primary key). Re-running stage 01 produces zero inserts,
+  because every PDF already has a row. No "upsert" ceremony required.
+- **Transactions.** SQLite gives us atomic stage transitions for free; a
+  `KeyboardInterrupt` mid-stage leaves the DB in the pre-stage state.
+- **Embedded.** The DB travels with the Docker volume. Backup = copy a
+  file. Restore = move the file back.
+- **SQLModel gives one type per row.** Pydantic validation + typed ORM
+  rows + `mypy --strict` all line up with minimal ceremony.
+
+### Negative
+
+- **Not suitable for multi-writer workloads.** We explicitly do not have
+  those (single-user, single-machine). If scenario β (shared library) is
+  ever adopted, this ADR must be revisited.
+- **Schema changes require alembic discipline.** Adding a column post-v1
+  needs a migration, not just an `ALTER TABLE` in code. See issue #24
+  (classifier columns) for the first real exercise.
+- **Concurrent access from the FastAPI dashboard + the APScheduler worker
+  (both in S2)** must be handled with SQLite's default WAL mode; this is a
+  one-line configuration, but it is a constraint to remember.
+- **No native JSON operators** (SQLite has `json_*` but they require the
+  JSON1 extension; it is bundled on modern builds but pinning matters).
+  We store JSON blobs in `metadata_json` / `tags_json` / `authors_json`
+  TEXT columns and decode in Python.
+
+### Neutral
+
+- The schema is small (four tables in S1, five in S2). SQLite is more than
+  enough; Postgres would be overkill for current scale.
+
+## Alternatives considered
+
+**A. Postgres (dockerized).**
+Rejected. Adds a second service to `docker-compose`, a second volume,
+connection pooling, role management, and a port exposure — none of which
+buys us anything while we remain single-writer. Would be the right choice
+if we ever adopted scenario β (shared library, multiple users pushing via
+S2); at that point this ADR gets revisited.
+
+**B. Flat files (JSON / Parquet).**
+Rejected. We lose atomic transactions, we gain custom locking, and every
+"give me items at stage 3" becomes a full scan and parse. SQLite solves
+exactly this problem.
+
+**C. DuckDB.**
+Rejected for now. DuckDB is excellent for analytical reads but the
+pipeline's hot path is OLTP-ish: per-item inserts, per-item updates,
+per-stage counts. SQLite is purpose-built for that. DuckDB could help
+later for the Etapa 06 validation report if it ever outgrows
+pandas/SQL, but that is a separate decision.
+
+**D. Redis / in-memory with periodic snapshots.**
+Rejected. Redis is a service; the point of this ADR is to avoid services.
+"In-memory with snapshots" is what SQLite is, only worse.
+
+## References
+
+- `CLAUDE.md` §Stack canónico — "Storage local: SQLite para estado del
+  pipeline"
+- `docs/plan_00_overview.md` §5 row 002
+- `docs/plan_01_subsystem1.md` §4 (schema + alembic)
+- `docs/plan_02_subsystem2.md` §5 (candidates.db schema)
+- `src/zotai/state.py` — `S1_TABLES` / `S2_TABLES` grouping, `init_s1` /
+  `init_s2` helpers

--- a/docs/decisions/003-scenario-alpha.md
+++ b/docs/decisions/003-scenario-alpha.md
@@ -1,0 +1,127 @@
+# ADR 003 — Distribution scenario α (personal libraries, shared repo)
+
+**Status**: Accepted
+**Date**: 2026-04-20
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+Early in project design we named three candidate distribution scenarios for
+the toolkit:
+
+- **α — shared repo, personal libraries.** A small group of researchers
+  share this git repo. Each clone the repo and run the toolkit against
+  their own Zotero library. No central server, no shared library, no
+  cross-user state.
+- **β — shared repo, shared Zotero group library.** Same repo, but the
+  target Zotero library is a Zotero Groups library that several
+  researchers push into (S2) and read from (S3).
+- **γ — hosted service.** A cloud-hosted instance that users authenticate
+  into and that processes their libraries remotely.
+
+Each scenario changes load-bearing decisions: multi-user auth, conflict
+handling on S1 re-ingestion, shared cost/budget attribution, PII / research
+ethics at rest, SLA implications, who pays OpenAI bills, etc.
+
+We need to pick one, now, so the rest of the architecture can stop
+hedging.
+
+## Decision
+
+Adopt **scenario α** as the single supported distribution mode for v1 and
+design toward it without compromise.
+
+Concretely this means:
+
+- Each researcher owns their own Zotero library and their own `state.db` /
+  `candidates.db` / ChromaDB.
+- There is no concept of users, roles, or permissions in the code. The
+  implicit user is "whoever has the filesystem and the API keys".
+- The dashboard binds to `127.0.0.1` and has no authentication (see
+  `plan_02` §8.3).
+- API keys (Zotero, OpenAI) live in each user's local `.env`. `.env` is
+  `.gitignored`; only `.env.example` is versioned.
+- Budgets are per-user, enforced locally. There is no aggregate spend view
+  across users.
+- Each user customises `config/taxonomy.yaml`, `config/feeds.yaml`, and
+  `config/scoring.yaml` in their own clone. Merging those back is not a
+  project concern — users diverge on purpose.
+- All three subsystems communicate only via Zotero (`plan_00` §3). Even
+  within scenario α, the loose coupling is retained because it is the
+  right shape regardless.
+
+## Consequences
+
+### Positive
+
+- **Radical simplification.** No auth story, no RBAC, no tenant model, no
+  shared-state conflicts, no "whose budget did that embed call charge
+  against". Entire problem categories evaporate.
+- **Privacy by default.** Each user's PDFs and metadata never leave their
+  machine (except to the APIs they explicitly configure — OpenAI,
+  OpenAlex, Semantic Scholar, Zotero). No multi-tenant data isolation
+  concerns because there is only one tenant.
+- **Per-user cost model matches per-user value.** Each researcher pays
+  their own OpenAI bill and gets their own tailored library. No
+  attribution problem.
+- **Onboarding is linear:** `git clone` → `cp .env.example .env` →
+  `docker compose run onboarding zotai s1 run-all`. No "request access"
+  step.
+- **The three subsystems stay decoupled.** S2 and S3 can run on users who
+  never ran S1 (they degrade gracefully); S1 can run without S3 ever
+  having been installed. This is a direct consequence of "communication
+  only via Zotero" and is preserved by scenario α by construction.
+
+### Negative
+
+- **No knowledge sharing across researchers.** If two users in the same
+  lab curate their libraries separately, each does its own triage work in
+  S2 and its own tagging in S1. There is no "Alice accepted this paper,
+  so Bob sees it pre-vetted." Accepted; this is a v1.1+ feature in
+  scenario β.
+- **Feed lists and taxonomies diverge.** Users who want to keep their
+  `config/` files aligned must do so manually (a shared Slack snippet, a
+  fork, a config repo). Not a project concern.
+- **No operational visibility across the group.** If three users all hit
+  budget issues, nothing aggregates that.
+- **α is not a migration path to β/γ for free.** Moving to β requires
+  rethinking auth, concurrent writes to one Zotero library, de-duplication
+  across user pushes, and shared budget policy. Some of that work will be
+  wasted if β is ever adopted, but less than the inverse (designing for β
+  upfront and never using it).
+
+### Neutral
+
+- Scenario γ is explicitly out of scope. If the project ever offers a
+  hosted mode, it will be a new product, not a refactor of this one.
+
+## Alternatives considered
+
+**A. Scenario β (shared library) from v1.**
+Rejected. Requires auth (Basic Auth minimum, OIDC realistically), a
+policy for conflicting pushes to the same DOI, shared budget accounting,
+write permissions to one library from multiple users, and probably a
+central server to arbitrate. That is 3–6× the scope of v1. The underlying
+user need ("I want my lab to share a library") can also be served by
+Zotero Groups directly, without this toolkit; our S2 could be pointed at
+a Zotero Groups library later with modest adjustment.
+
+**B. Scenario γ (hosted).**
+Rejected. Requires operational commitment (uptime, billing, compliance,
+PII handling at rest for other people's PDFs) that is not what this
+project is. The product is a toolkit, not a service.
+
+**C. "Supports all three, user picks at runtime".**
+Rejected. Every degree of freedom in distribution mode bloats the code and
+the test matrix. Pick one, build it well; migrate if demand appears.
+
+## References
+
+- `CLAUDE.md` §Identidad del proyecto — "Escenario de distribución: α"
+- `docs/plan_00_overview.md` §5 row 003
+- `docs/plan_02_subsystem2.md` §8.3 (dashboard auth posture)
+- `docs/plan_03_subsystem3.md` §1 (S3 runs on the user's host)


### PR DESCRIPTION
## Summary

Backfill the three architectural decisions listed in `docs/plan_00_overview.md` §5 that predate the scaffolding PR but whose rationale has not been captured in the repo yet:

- **ADR 001** — Docker as the distribution medium
- **ADR 002** — SQLite for pipeline state
- **ADR 003** — Scenario α (personal libraries, shared repo)

## Why now

Each of these was a real decision with a real alternative set, but the reasoning lives only in the owner's head today. Writing them before Phase 9 (which was nominally going to create them) avoids rationale decay and gives the remaining ADRs a consistent template.

## Format

Each ADR follows the same structure — context / decision / consequences (positive / negative / neutral) / alternatives considered / references — so the remaining ADRs (004 embedding model, 005 gpt-4o-mini, 006 zotero-mcp, 007 FastAPI+HTMX, 008 quarantine policy, 009 zotero-mcp scope) can reuse it as they land during Phases 9 and 10.

## Test plan

- [x] Three new files under `docs/decisions/`.
- [x] No changes to any other file (no README links added yet; indexing happens when the full set is filled in).
- [x] Content traced to existing sources: `CLAUDE.md`, `plan_00_overview.md` §5, `plan_01_subsystem1.md` §4, `plan_02_subsystem2.md` §5 + §8.3, `plan_03_subsystem3.md` §1.

## References

- `docs/plan_00_overview.md` §5 (decision table)
- Found during the 2026-04-22 alignment review