### PR TITLE
docs(readme): clarify S1 status + mark pending s3-setup reference

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,7 +67,7 @@ Ver `docs/plan_01_subsystem1.md` §3.1 para el detalle del clasificador.
 
 | Subsistema | Estado | Plan |
 |---|---|---|
-| S1 – Retroactive | 🟢 En implementación (Phase 2 / Stage 01 mergeado) | `docs/plan_01_subsystem1.md` |
+| S1 – Retroactive | 🟢 En implementación (Stage 01 inventory mergeado; classifier pendiente [#24](https://github.com/igalkej/auto_zotero/issues/24)) | `docs/plan_01_subsystem1.md` |
 | S3 – MCP access | 🟡 Spec, pendiente implementación | `docs/plan_03_subsystem3.md` |
 | S2 – Prospective | 🟡 Spec, pendiente implementación | `docs/plan_02_subsystem2.md` |
 
@@ -85,7 +85,7 @@ cp .env.example .env
 docker compose run onboarding zotai s1 run-all
 
 # Configurar S3 (MCP para Claude Desktop) - guía manual
-# ver docs/s3-setup.md
+# ver docs/s3-setup.md  (pendiente — Phase 10, #11)
 
 # Arrancar S2 (dashboard + worker)
 docker compose up dashboard


### PR DESCRIPTION
## Summary

Two one-line fixes from the 2026-04-22 alignment review:

- **S1 status** in "Estado del proyecto" table: replaced the ambiguous "Phase 2 / Stage 01 mergeado" — which reads as if Stage 01 is fully shipped — with "Stage 01 inventory mergeado; classifier pendiente (#24)" + inline issue link. The classifier spec (plan_01 §3.1, PR #23) is merged, but the code (#24) is not.
- **Quickstart**: the `ver docs/s3-setup.md` line pointed at a file that does not exist yet. Added "(pendiente — Phase 10, #11)" next to it so readers know where the guide comes from without hiding the planned UX.

## Test plan

- [x] `git diff` scoped to README.md, two lines changed.
- [x] Issue #24 link renders to the classifier implementation ticket.
- [x] Issue #11 link renders to the S3 MCP phase.