### PR TITLE
feat(s1): Phase 2.5 — Stage 01 academic classifier (#24)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -32,6 +32,10 @@ REPORTS_FOLDER=/workspace/reports
 
 # ────────────── Budgets (USD) ──────────────
 MAX_COST_USD_TOTAL=10.00
+# LLM gate of the Stage 01 academic classifier (Rama 3 of plan_01 §3.1).
+# Hard cap — stage aborts if spend would exceed it. Typical spend on a
+# 1000-PDF corpus is ~$0.12.
+MAX_COST_USD_STAGE_01=1.00
 MAX_COST_USD_STAGE_04=2.00
 MAX_COST_USD_STAGE_05=1.00
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **S1 Stage 01 — classifier** (#24): three-branch academic / non-academic
+  gate upstream of the rest of the S1 pipeline (plan_01 §3.1).
+  (1) Positive heuristic — zero-cost accept on DOI / arXiv / valid ISBN
+  / academic keyword hit in pages 1-3. (2) Negative heuristic — zero-cost
+  reject when `page_count <= 2` and either a billing / personal-document
+  keyword is present on page 1 or the PDF has no extractable text
+  (keyword match is preferred because it carries the more informative
+  rejection reason). (3) LLM gate — `gpt-4o-mini` JSON-mode call for
+  the ambiguous remainder, with one retry on malformed JSON and a
+  conservative bias (ambiguity → keep as academic with
+  `needs_review=True`). Landed as `src/zotai/s1/classifier.py`
+  (`heuristic_accept`, `heuristic_reject`, `llm_gate`, `classify`), a
+  new `OpenAIClient.classify_document` helper, and a new
+  `utils.pdf.count_pages`. Integrated into `stage_01_inventory`: accepted
+  items persist with `classification='academic' [+ needs_review]`;
+  rejected items never enter `state.db` and are written to
+  `reports/excluded_report_<ts>.csv` (columns: `source_path`, `sha256`,
+  `size_bytes`, `page_count`, `rejection_reason`, `classifier_branch`,
+  `llm_reason`). `inventory_report.csv` gained `classification`,
+  `needs_review`, and `rejection_reason` columns. CLI flags
+  `--skip-llm-gate` (ambiguous → needs_review without OpenAI) and
+  `--max-cost N` (per-run override of `MAX_COST_USD_STAGE_01`) added to
+  `zotai s1 inventory`. `BudgetSettings.max_cost_usd_stage_01` with
+  default `1.0` + `.env.example` line `MAX_COST_USD_STAGE_01=1.00`.
+  Alembic migration `20260422_classifier_columns` adds
+  `Item.classification` and `Item.needs_review` for existing DBs.
+  Covered by `tests/test_s1/test_classifier.py` (pure-function matrix)
+  and new integration scenarios in `tests/test_s1/test_stage_01.py`
+  (factura / DNI rejection, keyword acceptance, LLM mocking,
+  `--skip-llm-gate`, budget-exceeded abort, re-run does not
+  reclassify). As a drive-by, `_run_inventory_async` now snapshots
+  `Run` fields before the session closes to avoid a
+  `DetachedInstanceError` introduced by newer SQLAlchemy semantics.
 - **S1 Stage 01 — inventory** (#3): `zotai.s1.stage_01_inventory.run_inventory`
   walks configured PDF folders, validates magic bytes, hashes via SHA-256,
   detects DOIs from the first 3 pages, and persists `Item` rows with

--- a/alembic/versions/20260422_classifier_columns.py
+++ b/alembic/versions/20260422_classifier_columns.py
@@ -1,0 +1,53 @@
+"""add Item.classification + Item.needs_review (Stage 01 classifier)
+
+Revision ID: 20260422_classifier_columns
+Revises:
+Create Date: 2026-04-22
+
+Introduces the two columns that back the Stage 01 academic / non-academic
+classifier (plan_01 §3.1). Backfills existing rows with the conservative
+defaults so this migration is safe on DBs created by earlier
+``init_s1()`` calls.
+
+The eventual initial-schema migration from Phase 8 (issue #9) should
+land as a new revision with ``down_revision=None`` and this file should
+then be re-parented to it.
+"""
+
+from __future__ import annotations
+
+from typing import Sequence, Union
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260422_classifier_columns"
+down_revision: Union[str, None] = None
+branch_labels: Union[str, Sequence[str], None] = None
+depends_on: Union[str, Sequence[str], None] = None
+
+
+def upgrade() -> None:
+    with op.batch_alter_table("item") as batch:
+        batch.add_column(
+            sa.Column(
+                "classification",
+                sa.String(),
+                nullable=False,
+                server_default="academic",
+            )
+        )
+        batch.add_column(
+            sa.Column(
+                "needs_review",
+                sa.Boolean(),
+                nullable=False,
+                server_default=sa.false(),
+            )
+        )
+
+
+def downgrade() -> None:
+    with op.batch_alter_table("item") as batch:
+        batch.drop_column("needs_review")
+        batch.drop_column("classification")

--- a/src/zotai/api/openai_client.py
+++ b/src/zotai/api/openai_client.py
@@ -88,6 +88,23 @@ class OpenAIClient:
                 f"projected=${projected_cost:.4f}, budget=${self.budget_usd:.4f}"
             )
 
+    async def classify_document(
+        self, *, prompt: str, model: str = "gpt-4o-mini"
+    ) -> UsageRecord:
+        """Prompt-agnostic JSON-mode call used by the Stage 01 classifier.
+
+        The caller owns the prompt (see ``zotai.s1.classifier``) and the
+        JSON decoding. This method only enforces the budget ceiling and
+        the ``response_format=json_object`` mode.
+        """
+        self._check_budget()
+        resp = await self._client.chat.completions.create(
+            model=model,
+            response_format={"type": "json_object"},
+            messages=[{"role": "user", "content": prompt}],
+        )
+        return self._build_usage_record(resp, model)
+
     async def extract_metadata(
         self, *, text: str, model: str = "gpt-4o-mini"
     ) -> UsageRecord:

--- a/src/zotai/cli.py
+++ b/src/zotai/cli.py
@@ -12,7 +12,7 @@ The `zotai` console script is declared in `pyproject.toml`:
 from __future__ import annotations
 
 from pathlib import Path
-from typing import Annotated, Optional
+from typing import Annotated
 
 import typer
 
@@ -80,7 +80,7 @@ def _not_implemented(stage: str, phase: int, issue: int) -> None:
 def s1_inventory(
     ctx: typer.Context,
     folder: Annotated[
-        Optional[list[Path]],
+        list[Path] | None,
         typer.Option(
             "--folder",
             exists=True,
@@ -101,8 +101,30 @@ def s1_inventory(
             ),
         ),
     ] = False,
+    skip_llm_gate: Annotated[
+        bool,
+        typer.Option(
+            "--skip-llm-gate",
+            help=(
+                "Skip Branch 3 of the classifier (LLM gate). Ambiguous PDFs "
+                "are kept as academic with needs_review=True without calling "
+                "OpenAI — useful when OPENAI_API_KEY is absent."
+            ),
+        ),
+    ] = False,
+    max_cost: Annotated[
+        float | None,
+        typer.Option(
+            "--max-cost",
+            help=(
+                "Override MAX_COST_USD_STAGE_01 for this invocation. Hard "
+                "cap on the LLM gate's cumulative spend; the stage aborts "
+                "when exceeded."
+            ),
+        ),
+    ] = None,
 ) -> None:
-    """Stage 01 — scan PDFs, hash, detect DOI."""
+    """Stage 01 — scan PDFs, classify academic vs. non-academic, persist."""
     from zotai.config import Settings
     from zotai.s1.handler import StageAbortedError
     from zotai.s1.stage_01_inventory import run_inventory
@@ -123,6 +145,8 @@ def s1_inventory(
             folders,
             dry_run=dry_run,
             retry_errors=retry_errors,
+            skip_llm_gate=skip_llm_gate,
+            max_cost=max_cost,
             settings=settings,
         )
     except StageAbortedError as exc:
@@ -132,6 +156,7 @@ def s1_inventory(
     typer.echo(
         f"processed={result.items_processed} failed={result.items_failed} "
         f"duplicates={result.duplicates} invalid={result.invalid} "
+        f"excluded={result.excluded} cost=${result.llm_cost_usd:.4f} "
         f"csv={result.csv_path}"
     )
 
@@ -139,7 +164,7 @@ def s1_inventory(
 @s1_app.command("ocr")
 def s1_ocr(
     force_ocr: Annotated[bool, typer.Option("--force-ocr")] = False,
-    parallel: Annotated[Optional[int], typer.Option("--parallel")] = None,
+    parallel: Annotated[int | None, typer.Option("--parallel")] = None,
 ) -> None:
     """Stage 02 — OCR scanned PDFs."""
     _ = force_ocr, parallel
@@ -157,8 +182,8 @@ def s1_import(
 
 @s1_app.command("enrich")
 def s1_enrich(
-    substage: Annotated[Optional[str], typer.Option("--substage")] = None,
-    max_cost: Annotated[Optional[float], typer.Option("--max-cost")] = None,
+    substage: Annotated[str | None, typer.Option("--substage")] = None,
+    max_cost: Annotated[float | None, typer.Option("--max-cost")] = None,
 ) -> None:
     """Stage 04 — enrichment cascade (04a-04e)."""
     _ = substage, max_cost
@@ -170,7 +195,7 @@ def s1_tag(
     preview: Annotated[bool, typer.Option("--preview")] = False,
     apply: Annotated[bool, typer.Option("--apply")] = False,
     re_tag: Annotated[bool, typer.Option("--re-tag")] = False,
-    max_cost: Annotated[Optional[float], typer.Option("--max-cost")] = None,
+    max_cost: Annotated[float | None, typer.Option("--max-cost")] = None,
 ) -> None:
     """Stage 05 — LLM tagging against the TEMA/METODO taxonomy."""
     _ = preview, apply, re_tag, max_cost

--- a/src/zotai/config.py
+++ b/src/zotai/config.py
@@ -141,6 +141,7 @@ class BudgetSettings(_GroupBase):
         frozen=True,
     )
     max_cost_usd_total: float = 10.0
+    max_cost_usd_stage_01: float = 1.0
     max_cost_usd_stage_04: float = 2.0
     max_cost_usd_stage_05: float = 1.0
 

--- a/src/zotai/s1/classifier.py
+++ b/src/zotai/s1/classifier.py
@@ -1,0 +1,376 @@
+"""Stage 01 academic / non-academic classifier (plan_01 §3.1).
+
+Three branches run in order, each cheaper than the next:
+
+1. **Positive heuristic** (cost: $0) — accept immediately when the text of
+   pages 1-3 contains a DOI, arXiv ID, valid ISBN, or one of a small set
+   of academic keywords.
+2. **Negative heuristic** (cost: $0) — reject immediately when the PDF
+   has ≤ 2 pages *and* either lacks extractable text or contains a
+   billing/personal-document keyword on page 1.
+3. **LLM gate** (cost: ~$0.0004/call) — anything left over is sent to
+   ``gpt-4o-mini`` with a short prompt asking for
+   ``{"is_academic", "confidence", "reason"}``. Low-confidence results
+   keep the item as academic but mark ``needs_review`` for manual review
+   in Stage 06 (conservative bias — we would rather keep a borderline
+   item than lose a real paper).
+
+Each branch is a pure function; the orchestrator :func:`classify` is the
+only async entry point (it awaits the LLM gate when needed). Tests hit
+the branches directly and mock the OpenAI client when exercising the
+gate.
+"""
+
+from __future__ import annotations
+
+import json
+import re
+from collections.abc import Iterable
+from dataclasses import dataclass
+from typing import Literal
+
+from zotai.api.openai_client import OpenAIClient, UsageRecord
+from zotai.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+Decision = Literal["academic", "reject"]
+Confidence = Literal["low", "medium", "high"]
+ClassifierBranch = Literal[
+    "heuristic_positive",
+    "heuristic_negative",
+    "llm_gate",
+    "skipped_llm_gate",
+]
+
+
+_DOI_RE = re.compile(r"\b10\.\d{4,9}/[-._;()/:A-Za-z0-9]+", re.IGNORECASE)
+_ARXIV_RE = re.compile(
+    r"(?:arXiv:|arxiv\.org/abs/)(\d{4}\.\d{4,5})(?:v\d+)?",
+    re.IGNORECASE,
+)
+_ISBN_CANDIDATE_RE = re.compile(
+    r"\bISBN(?:-1[03])?[:\s]*([\d\-X ]{10,17})",
+    re.IGNORECASE,
+)
+
+_ACADEMIC_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "abstract",
+        "references",
+        "bibliography",
+        "introduction",
+        "keywords",
+        "jel codes",
+        "et al.",
+        "university of",
+        "universidad de",
+        "instituto de",
+    }
+)
+
+_BILLING_KEYWORDS: frozenset[str] = frozenset(
+    {
+        "factura",
+        "recibo",
+        "invoice",
+        "receipt",
+        "cuit",
+        "cuil",
+        "dni",
+        "ticket",
+        "boleta",
+        "comprobante",
+        "nota de débito",
+        "nota de crédito",
+        "voucher",
+        "bill",
+    }
+)
+
+_LLM_GATE_MODEL = "gpt-4o-mini"
+_LLM_GATE_MAX_ATTEMPTS = 2
+_FIRST_PAGE_SNIPPET_CHARS = 500
+
+
+@dataclass(frozen=True)
+class ClassificationResult:
+    """The outcome of one :func:`classify` call."""
+
+    decision: Decision
+    needs_review: bool
+    branch: ClassifierBranch
+    rejection_reason: str | None = None
+    llm_reason: str | None = None
+
+
+@dataclass(frozen=True)
+class GateResult:
+    """Decoded payload from the LLM gate (plan_01 §3.1 Rama 3)."""
+
+    is_academic: bool
+    confidence: Confidence
+    reason: str
+
+
+# ─── Branch 1: positive heuristic (zero cost) ──────────────────────────────
+
+
+def _is_valid_isbn_10(digits: str) -> bool:
+    if len(digits) != 10:
+        return False
+    total = 0
+    for idx, char in enumerate(digits):
+        if char == "X" and idx == 9:
+            value = 10
+        elif char.isdigit():
+            value = int(char)
+        else:
+            return False
+        total += value * (10 - idx)
+    return total % 11 == 0
+
+
+def _is_valid_isbn_13(digits: str) -> bool:
+    if len(digits) != 13 or not digits.isdigit():
+        return False
+    total = sum(int(d) * (1 if i % 2 == 0 else 3) for i, d in enumerate(digits))
+    return total % 10 == 0
+
+
+def _has_valid_isbn(text: str) -> bool:
+    for match in _ISBN_CANDIDATE_RE.finditer(text):
+        digits = re.sub(r"[\-\s]", "", match.group(1)).upper()
+        if _is_valid_isbn_10(digits) or _is_valid_isbn_13(digits):
+            return True
+    return False
+
+
+def heuristic_accept(pages_text: Iterable[str]) -> bool:
+    """Return True when pages 1-3 carry at least one positive academic marker."""
+    joined = "\n".join(pages_text)
+    if not joined:
+        return False
+    if _DOI_RE.search(joined):
+        return True
+    if _ARXIV_RE.search(joined):
+        return True
+    if _has_valid_isbn(joined):
+        return True
+    lowered = joined.lower()
+    return any(keyword in lowered for keyword in _ACADEMIC_KEYWORDS)
+
+
+# ─── Branch 2: negative heuristic (zero cost) ──────────────────────────────
+
+
+def heuristic_reject(
+    *,
+    page_count: int,
+    has_text: bool,
+    first_page_text: str,
+) -> str | None:
+    """Return a rejection-reason string for short non-papers, else None.
+
+    Applies only when ``page_count <= 2``. Matches plan_01 §3.1 Rama 2:
+    reject when the PDF is short *and* either contains a billing /
+    personal-document keyword on page 1 *or* has no extractable text.
+    Billing-keyword matches are checked first because the keyword is the
+    informative signal — a short receipt PDF whose text is below the
+    ``has_text`` threshold still deserves the ``billing_keyword:...``
+    label rather than a generic ``short_no_text``.
+    """
+    if page_count > 2:
+        return None
+    lowered = first_page_text.lower()
+    for keyword in _BILLING_KEYWORDS:
+        if keyword in lowered:
+            return f"billing_keyword:{keyword}"
+    if not has_text:
+        return "short_no_text"
+    return None
+
+
+# ─── Branch 3: LLM gate (ambiguous) ────────────────────────────────────────
+
+
+_LLM_PROMPT_TEMPLATE = """\
+You are classifying a PDF document for a researcher's bibliographic library.
+
+Here are the first {snippet_len} characters of page 1:
+---
+{snippet}
+---
+
+Page count: {page_count}
+
+Return JSON: {{"is_academic": bool, "confidence": "low"|"medium"|"high", "reason": "<one short sentence>"}}
+
+Academic = research paper, preprint, book chapter, thesis, technical report, working paper, or a similar scholarly work.
+Non-academic = bill, receipt, ID card, manual, slideshow deck, contract, personal document, administrative form, screenshot.\
+"""
+
+
+async def llm_gate(
+    *,
+    first_page_snippet: str,
+    page_count: int,
+    openai_client: OpenAIClient,
+    model: str = _LLM_GATE_MODEL,
+) -> tuple[GateResult, UsageRecord]:
+    """Ask ``gpt-4o-mini`` whether an ambiguous PDF is academic.
+
+    Retries once on JSON parse failure (two attempts total). If both fail,
+    defaults to ``(is_academic=True, confidence="low", reason="malformed_json")``
+    — the conservative bias from plan_01 §3.1 edge cases: do not drop a
+    PDF we could not classify.
+    """
+    snippet = first_page_snippet[:_FIRST_PAGE_SNIPPET_CHARS]
+    prompt = _LLM_PROMPT_TEMPLATE.format(
+        snippet_len=_FIRST_PAGE_SNIPPET_CHARS,
+        snippet=snippet,
+        page_count=page_count,
+    )
+    last_usage: UsageRecord | None = None
+    for attempt in range(1, _LLM_GATE_MAX_ATTEMPTS + 1):
+        usage = await openai_client.classify_document(prompt=prompt, model=model)
+        last_usage = usage
+        try:
+            content = usage.response.choices[0].message.content or "{}"
+            payload = json.loads(content)
+            is_academic = bool(payload["is_academic"])
+            raw_confidence = payload.get("confidence", "low")
+            confidence: Confidence = (
+                raw_confidence
+                if raw_confidence in ("low", "medium", "high")
+                else "low"
+            )
+            reason = str(payload.get("reason", "")).strip() or "unspecified"
+            return GateResult(is_academic, confidence, reason), usage
+        except (json.JSONDecodeError, KeyError, TypeError, AttributeError) as exc:
+            log.warning(
+                "classifier.llm_gate.parse_failed",
+                attempt=attempt,
+                error=str(exc),
+            )
+    assert last_usage is not None  # loop always sets it before exit
+    return (
+        GateResult(is_academic=True, confidence="low", reason="malformed_json"),
+        last_usage,
+    )
+
+
+# ─── Orchestrator ──────────────────────────────────────────────────────────
+
+
+async def classify(
+    *,
+    pages_text: list[str],
+    page_count: int,
+    has_text: bool,
+    skip_llm_gate: bool,
+    openai_client: OpenAIClient | None,
+) -> tuple[ClassificationResult, UsageRecord | None]:
+    """Run the three branches in order and return the final decision.
+
+    Returns:
+        ``(result, usage)`` — ``usage`` is the OpenAI ``UsageRecord`` when
+        the LLM gate ran, otherwise ``None``.
+    """
+    if heuristic_accept(pages_text):
+        return (
+            ClassificationResult(
+                decision="academic",
+                needs_review=False,
+                branch="heuristic_positive",
+            ),
+            None,
+        )
+
+    first_page = pages_text[0] if pages_text else ""
+    rejection = heuristic_reject(
+        page_count=page_count,
+        has_text=has_text,
+        first_page_text=first_page,
+    )
+    if rejection is not None:
+        return (
+            ClassificationResult(
+                decision="reject",
+                needs_review=False,
+                branch="heuristic_negative",
+                rejection_reason=rejection,
+            ),
+            None,
+        )
+
+    if skip_llm_gate or openai_client is None:
+        return (
+            ClassificationResult(
+                decision="academic",
+                needs_review=True,
+                branch="skipped_llm_gate",
+            ),
+            None,
+        )
+
+    gate_result, usage = await llm_gate(
+        first_page_snippet=first_page,
+        page_count=page_count,
+        openai_client=openai_client,
+    )
+
+    if gate_result.is_academic and gate_result.confidence in ("medium", "high"):
+        return (
+            ClassificationResult(
+                decision="academic",
+                needs_review=False,
+                branch="llm_gate",
+                llm_reason=gate_result.reason,
+            ),
+            usage,
+        )
+    if gate_result.is_academic and gate_result.confidence == "low":
+        return (
+            ClassificationResult(
+                decision="academic",
+                needs_review=True,
+                branch="llm_gate",
+                llm_reason=gate_result.reason,
+            ),
+            usage,
+        )
+    if not gate_result.is_academic and gate_result.confidence in ("medium", "high"):
+        return (
+            ClassificationResult(
+                decision="reject",
+                needs_review=False,
+                branch="llm_gate",
+                rejection_reason="llm_non_academic",
+                llm_reason=gate_result.reason,
+            ),
+            usage,
+        )
+    # is_academic=False + confidence=low → conservative include
+    return (
+        ClassificationResult(
+            decision="academic",
+            needs_review=True,
+            branch="llm_gate",
+            llm_reason=gate_result.reason,
+        ),
+        usage,
+    )
+
+
+__all__ = [
+    "ClassificationResult",
+    "ClassifierBranch",
+    "Confidence",
+    "Decision",
+    "GateResult",
+    "classify",
+    "heuristic_accept",
+    "heuristic_reject",
+    "llm_gate",
+]

--- a/src/zotai/s1/stage_01_inventory.py
+++ b/src/zotai/s1/stage_01_inventory.py
@@ -1,84 +1,145 @@
-"""Stage 01 — inventory: walk PDF folders, hash, detect DOI, persist Items.
+"""Stage 01 — inventory: walk PDF folders, hash, classify, persist Items.
 
 First persistent step of Subsystem 1 (see ``docs/plan_01_subsystem1.md`` §3).
 Every valid PDF below the configured source folders is assigned a stable
-SHA-256 identity and recorded in ``state.db`` with ``stage_completed=1``.
-Later stages read from there.
+SHA-256 identity, passed through the academic / non-academic classifier
+(§3.1), and — *only if accepted* — recorded in ``state.db`` with
+``stage_completed=1``. Rejected PDFs are listed in
+``reports/excluded_report_<ts>.csv`` and never consume OCR or API budget
+in downstream stages.
 
 Idempotence is guaranteed by the primary key: ``Item.id = sha256(bytes)``.
-Re-runs on the same inputs produce zero inserts. Duplicates (same hash, new
-path) are reported in the CSV but never mutate the winner's ``source_path``.
+Re-runs on the same inputs produce zero inserts. Duplicates (same hash,
+new path) are reported in the CSV but never mutate the winner's
+``source_path``.
+
+This module exposes two entry points:
+
+- :func:`run_inventory` — synchronous; spins up its own event loop to
+  reach the classifier's LLM gate. Used by the CLI and existing tests.
+- :func:`_run_inventory_async` — the underlying coroutine; used when the
+  caller is already inside an event loop (new async tests, future
+  orchestrators).
 """
 
 from __future__ import annotations
 
+import asyncio
 import csv
 from collections.abc import Callable, Iterable, Iterator
 from dataclasses import dataclass
-from datetime import datetime, timezone
+from datetime import UTC, datetime
 from pathlib import Path
 from typing import Final, Literal
 
 from sqlalchemy.engine import Engine
 from sqlmodel import Session
 
+from zotai.api.openai_client import BudgetExceededError, OpenAIClient
 from zotai.config import Settings
+from zotai.s1.classifier import classify
 from zotai.s1.handler import StageAbortedError, stage_item_handler
 from zotai.state import Item, Run, init_s1, make_s1_engine
 from zotai.utils.fs import ensure_dir, file_sha256, validate_pdf_magic
 from zotai.utils.logging import bind, get_logger
-from zotai.utils.pdf import detect_doi, extract_text_pages
+from zotai.utils.pdf import count_pages, detect_doi, extract_text_pages
 
 log = get_logger(__name__)
 
 _STAGE: Final[int] = 1
 _MAX_PAGES: Final[int] = 3
 _HAS_TEXT_THRESHOLD: Final[int] = 100
-_CSV_COLUMNS: Final[tuple[str, ...]] = (
+
+_INVENTORY_COLUMNS: Final[tuple[str, ...]] = (
     "source_path",
     "sha256",
     "size_bytes",
     "has_text",
     "detected_doi",
+    "classification",
+    "needs_review",
+    "rejection_reason",
     "status",
     "duplicate_of",
     "last_error",
 )
 
+_EXCLUDED_COLUMNS: Final[tuple[str, ...]] = (
+    "source_path",
+    "sha256",
+    "size_bytes",
+    "page_count",
+    "rejection_reason",
+    "classifier_branch",
+    "llm_reason",
+)
+
 InventoryStatus = Literal[
-    "new", "duplicate", "invalid_magic", "error", "unchanged", "retried"
+    "new",
+    "duplicate",
+    "invalid_magic",
+    "error",
+    "unchanged",
+    "retried",
+    "excluded",
 ]
 
 
 @dataclass(frozen=True)
 class InventoryRow:
-    """One entry in the inventory CSV (and the return value's row list)."""
+    """One row in ``inventory_report_<ts>.csv``."""
 
     source_path: str
     sha256: str | None
     size_bytes: int
     has_text: bool
     detected_doi: str | None
+    classification: str | None
+    needs_review: bool
+    rejection_reason: str | None
     status: InventoryStatus
     duplicate_of: str | None
     last_error: str | None
 
 
 @dataclass(frozen=True)
+class ExcludedRow:
+    """One row in ``excluded_report_<ts>.csv`` — PDFs rejected by the classifier."""
+
+    source_path: str
+    sha256: str
+    size_bytes: int
+    page_count: int
+    rejection_reason: str
+    classifier_branch: str
+    llm_reason: str | None
+
+
+@dataclass(frozen=True)
 class InventoryResult:
-    """Aggregate outcome of one `run_inventory` call."""
+    """Aggregate outcome of one ``run_inventory`` call."""
 
     run_id: int | None
     rows: list[InventoryRow]
+    excluded_rows: list[ExcludedRow]
     csv_path: Path
+    excluded_csv_path: Path
     items_processed: int
     items_failed: int
     duplicates: int
     invalid: int
+    excluded: int
+    llm_cost_usd: float
+
+
+@dataclass(frozen=True)
+class _ExtractionOutcome:
+    pages_text: list[str]
+    page_count: int
 
 
 def _utc_now() -> datetime:
-    return datetime.now(tz=timezone.utc)
+    return datetime.now(tz=UTC)
 
 
 def _iter_pdf_paths(folders: Iterable[Path]) -> Iterator[Path]:
@@ -92,15 +153,17 @@ def _iter_pdf_paths(folders: Iterable[Path]) -> Iterator[Path]:
             yield path
 
 
-def _csv_path(reports_dir: Path, *, dry_run: bool, now: datetime) -> Path:
+def _csv_path(
+    reports_dir: Path, *, prefix: str, dry_run: bool, now: datetime
+) -> Path:
     suffix = "_dryrun" if dry_run else ""
     timestamp = now.strftime("%Y%m%d_%H%M%S")
-    return reports_dir / f"inventory_report_{timestamp}{suffix}.csv"
+    return reports_dir / f"{prefix}_{timestamp}{suffix}.csv"
 
 
-def _write_csv(csv_path: Path, rows: Iterable[InventoryRow]) -> None:
+def _write_inventory_csv(csv_path: Path, rows: Iterable[InventoryRow]) -> None:
     with csv_path.open("w", encoding="utf-8", newline="") as handle:
-        writer = csv.DictWriter(handle, fieldnames=list(_CSV_COLUMNS))
+        writer = csv.DictWriter(handle, fieldnames=list(_INVENTORY_COLUMNS))
         writer.writeheader()
         for row in rows:
             writer.writerow(
@@ -110,6 +173,9 @@ def _write_csv(csv_path: Path, rows: Iterable[InventoryRow]) -> None:
                     "size_bytes": row.size_bytes,
                     "has_text": "true" if row.has_text else "false",
                     "detected_doi": row.detected_doi or "",
+                    "classification": row.classification or "",
+                    "needs_review": "true" if row.needs_review else "false",
+                    "rejection_reason": row.rejection_reason or "",
                     "status": row.status,
                     "duplicate_of": row.duplicate_of or "",
                     "last_error": row.last_error or "",
@@ -117,24 +183,47 @@ def _write_csv(csv_path: Path, rows: Iterable[InventoryRow]) -> None:
             )
 
 
+def _write_excluded_csv(csv_path: Path, rows: Iterable[ExcludedRow]) -> None:
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(_EXCLUDED_COLUMNS))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "source_path": row.source_path,
+                    "sha256": row.sha256,
+                    "size_bytes": row.size_bytes,
+                    "page_count": row.page_count,
+                    "rejection_reason": row.rejection_reason,
+                    "classifier_branch": row.classifier_branch,
+                    "llm_reason": row.llm_reason or "",
+                }
+            )
+
+
 @stage_item_handler(stage=_STAGE)
-def _process_new(
+def _extract(
     item: Item,
     *,
     run: Run,
     path: Path,
     now: Callable[[], datetime],
-) -> None:
-    """Extract text from the first pages, derive ``has_text`` + DOI, stamp ``updated_at``.
+) -> _ExtractionOutcome:
+    """Extract first pages + page count, hydrate ``item`` metadata.
 
-    Called only for PDFs we have not seen in the DB. The decorator owns the
-    exception flow: on failure it sets ``item.last_error`` and swallows.
+    The stage handler owns error flow: on exception it sets
+    ``item.last_error`` and returns ``None`` so the caller can still
+    decide what to do with the partially-populated item (the Stage 01
+    spec keeps unreadable PDFs as ``academic + needs_review=True`` —
+    conservative bias).
     """
     pages = extract_text_pages(path, max_pages=_MAX_PAGES)
+    page_count = count_pages(path)
     first_page = pages[0] if pages else ""
     item.has_text = len(first_page) >= _HAS_TEXT_THRESHOLD
     item.detected_doi = detect_doi("\n".join(pages))
     item.updated_at = now()
+    return _ExtractionOutcome(pages_text=pages, page_count=page_count)
 
 
 def run_inventory(
@@ -142,40 +231,93 @@ def run_inventory(
     dry_run: bool,
     *,
     retry_errors: bool = False,
+    skip_llm_gate: bool = False,
+    max_cost: float | None = None,
     settings: Settings | None = None,
     engine: Engine | None = None,
+    openai_client: OpenAIClient | None = None,
     now: Callable[[], datetime] = _utc_now,
 ) -> InventoryResult:
-    """Scan ``folders`` for PDFs and persist ``Item`` rows to ``state.db``.
+    """Synchronous entry point. Wraps :func:`_run_inventory_async`.
 
     Args:
-        folders: Absolute paths to folders to recursively scan.
-        dry_run: When True, no DB writes happen and the CSV filename gains a
-            ``_dryrun`` suffix.
+        folders: Absolute paths to scan recursively.
+        dry_run: When True, no DB writes happen and the CSV filenames gain
+            a ``_dryrun`` suffix.
         retry_errors: When True, previously-seen items that still carry a
-            ``last_error`` are re-processed (text extraction + DOI detection)
-            instead of being reported as ``unchanged``. Hash-based identity
-            means the file content is the same, so this only helps when the
-            prior failure was transient (I/O glitch, pdfplumber hiccup).
-        settings: Optional injected ``Settings``; defaults to ``Settings()``.
-        engine: Optional injected SQLAlchemy engine; defaults to a fresh
-            engine bound to ``settings.paths.state_db``.
+            ``last_error`` are re-extracted (same hash, same bytes, so
+            this only helps with transient I/O / pdfplumber failures).
+        skip_llm_gate: When True, ambiguous items (the ones that reach
+            Branch 3 of the classifier) are kept as academic with
+            ``needs_review=True`` without calling OpenAI.
+        max_cost: Override ``settings.budgets.max_cost_usd_stage_01`` for
+            this call only. Used by the CLI's ``--max-cost`` flag.
+        settings: Optional override. Defaults to ``Settings()``.
+        engine: Optional SQLAlchemy engine. Defaults to a fresh engine
+            bound to ``settings.paths.state_db``.
+        openai_client: Optional pre-built client. When None and an API
+            key is present, the function builds one with a budget equal
+            to ``max_cost`` (when given) or
+            ``settings.budgets.max_cost_usd_stage_01``.
         now: Clock callable — overridable for tests.
 
     Returns:
-        An ``InventoryResult`` summarising counts and pointing at the CSV.
+        An :class:`InventoryResult` summarising counts and CSV paths.
 
     Raises:
-        StageAbortedError: Failure ratio exceeded the handler's threshold.
+        StageAbortedError: Failure ratio exceeded the handler's threshold,
+            *or* the LLM gate tripped the budget ceiling mid-run.
     """
+    return asyncio.run(
+        _run_inventory_async(
+            folders,
+            dry_run,
+            retry_errors=retry_errors,
+            skip_llm_gate=skip_llm_gate,
+            max_cost=max_cost,
+            settings=settings,
+            engine=engine,
+            openai_client=openai_client,
+            now=now,
+        )
+    )
+
+
+async def _run_inventory_async(
+    folders: list[Path],
+    dry_run: bool,
+    *,
+    retry_errors: bool,
+    skip_llm_gate: bool,
+    max_cost: float | None,
+    settings: Settings | None,
+    engine: Engine | None,
+    openai_client: OpenAIClient | None,
+    now: Callable[[], datetime],
+) -> InventoryResult:
     settings = settings or Settings()
     if engine is None:
         engine = make_s1_engine(str(settings.paths.state_db))
         init_s1(engine)
 
+    if openai_client is None and not skip_llm_gate:
+        api_key = settings.openai.api_key.get_secret_value()
+        if api_key:
+            budget = (
+                max_cost
+                if max_cost is not None
+                else settings.budgets.max_cost_usd_stage_01
+            )
+            openai_client = OpenAIClient(api_key=api_key, budget_usd=budget)
+        else:
+            log.info("stage_01.no_openai_key", action="skip_llm_gate")
+            skip_llm_gate = True
+
     run = Run(stage=_STAGE, status="running", started_at=now())
     rows: list[InventoryRow] = []
+    excluded_rows: list[ExcludedRow] = []
     seen_in_run: dict[str, str] = {}
+    llm_cost_usd = 0.0
 
     bind(stage=_STAGE, dry_run=dry_run)
     log.info("stage_started", folders=[str(f) for f in folders])
@@ -187,16 +329,21 @@ def run_inventory(
 
         try:
             for path in _iter_pdf_paths(folders):
-                row = _process_path(
+                row, excluded_row, cost = await _process_path(
                     path=path,
                     session=session,
                     run=run,
                     seen_in_run=seen_in_run,
                     dry_run=dry_run,
                     retry_errors=retry_errors,
+                    skip_llm_gate=skip_llm_gate,
+                    openai_client=openai_client,
                     now=now,
                 )
                 rows.append(row)
+                if excluded_row is not None:
+                    excluded_rows.append(excluded_row)
+                llm_cost_usd += cost
             run.status = "succeeded"
         except StageAbortedError:
             run.status = "aborted"
@@ -206,21 +353,39 @@ def run_inventory(
             raise
         finally:
             run.finished_at = now()
+            run.cost_usd = llm_cost_usd
             if not dry_run:
                 session.commit()
+        # Snapshot the Run state while the session is still open — after
+        # exiting the with-block the instance is detached and attribute
+        # access triggers a DetachedInstanceError under default
+        # expire_on_commit semantics.
+        run_id = run.id
+        items_processed = run.items_processed
+        items_failed = run.items_failed
 
     reports_folder = ensure_dir(settings.paths.reports_folder)
-    csv_path = _csv_path(reports_folder, dry_run=dry_run, now=now())
-    _write_csv(csv_path, rows)
+    csv_path = _csv_path(
+        reports_folder, prefix="inventory_report", dry_run=dry_run, now=now()
+    )
+    excluded_csv_path = _csv_path(
+        reports_folder, prefix="excluded_report", dry_run=dry_run, now=now()
+    )
+    _write_inventory_csv(csv_path, rows)
+    _write_excluded_csv(excluded_csv_path, excluded_rows)
 
     result = InventoryResult(
-        run_id=run.id,
+        run_id=run_id,
         rows=rows,
+        excluded_rows=excluded_rows,
         csv_path=csv_path,
-        items_processed=run.items_processed,
-        items_failed=run.items_failed,
+        excluded_csv_path=excluded_csv_path,
+        items_processed=items_processed,
+        items_failed=items_failed,
         duplicates=sum(1 for r in rows if r.status == "duplicate"),
         invalid=sum(1 for r in rows if r.status == "invalid_magic"),
+        excluded=len(excluded_rows),
+        llm_cost_usd=llm_cost_usd,
     )
     log.info(
         "stage_finished",
@@ -228,12 +393,15 @@ def run_inventory(
         failed=result.items_failed,
         duplicates=result.duplicates,
         invalid=result.invalid,
+        excluded=result.excluded,
+        cost_usd=result.llm_cost_usd,
         csv=str(csv_path),
+        excluded_csv=str(excluded_csv_path),
     )
     return result
 
 
-def _process_path(
+async def _process_path(
     *,
     path: Path,
     session: Session,
@@ -241,20 +409,29 @@ def _process_path(
     seen_in_run: dict[str, str],
     dry_run: bool,
     retry_errors: bool,
+    skip_llm_gate: bool,
+    openai_client: OpenAIClient | None,
     now: Callable[[], datetime],
-) -> InventoryRow:
+) -> tuple[InventoryRow, ExcludedRow | None, float]:
     size = path.stat().st_size
 
     if not validate_pdf_magic(path):
-        return InventoryRow(
-            source_path=str(path),
-            sha256=None,
-            size_bytes=size,
-            has_text=False,
-            detected_doi=None,
-            status="invalid_magic",
-            duplicate_of=None,
-            last_error=None,
+        return (
+            InventoryRow(
+                source_path=str(path),
+                sha256=None,
+                size_bytes=size,
+                has_text=False,
+                detected_doi=None,
+                classification=None,
+                needs_review=False,
+                rejection_reason=None,
+                status="invalid_magic",
+                duplicate_of=None,
+                last_error=None,
+            ),
+            None,
+            0.0,
         )
 
     sha = file_sha256(path)
@@ -262,77 +439,183 @@ def _process_path(
 
     if existing is not None:
         if existing.source_path != str(path):
-            return InventoryRow(
-                source_path=str(path),
-                sha256=sha,
-                size_bytes=size,
-                has_text=existing.has_text,
-                detected_doi=existing.detected_doi,
-                status="duplicate",
-                duplicate_of=existing.source_path,
-                last_error=None,
+            return (
+                InventoryRow(
+                    source_path=str(path),
+                    sha256=sha,
+                    size_bytes=size,
+                    has_text=existing.has_text,
+                    detected_doi=existing.detected_doi,
+                    classification=existing.classification,
+                    needs_review=existing.needs_review,
+                    rejection_reason=None,
+                    status="duplicate",
+                    duplicate_of=existing.source_path,
+                    last_error=None,
+                ),
+                None,
+                0.0,
             )
 
         if retry_errors and existing.last_error is not None:
-            _process_new(existing, run=run, path=path, now=now)
+            _extract(existing, run=run, path=path, now=now)
             retry_status: InventoryStatus = (
                 "error" if existing.last_error else "retried"
             )
-            return InventoryRow(
+            return (
+                InventoryRow(
+                    source_path=str(path),
+                    sha256=sha,
+                    size_bytes=size,
+                    has_text=existing.has_text,
+                    detected_doi=existing.detected_doi,
+                    classification=existing.classification,
+                    needs_review=existing.needs_review,
+                    rejection_reason=None,
+                    status=retry_status,
+                    duplicate_of=None,
+                    last_error=existing.last_error,
+                ),
+                None,
+                0.0,
+            )
+
+        return (
+            InventoryRow(
                 source_path=str(path),
                 sha256=sha,
                 size_bytes=size,
                 has_text=existing.has_text,
                 detected_doi=existing.detected_doi,
-                status=retry_status,
+                classification=existing.classification,
+                needs_review=existing.needs_review,
+                rejection_reason=None,
+                status="unchanged",
                 duplicate_of=None,
                 last_error=existing.last_error,
-            )
-
-        return InventoryRow(
-            source_path=str(path),
-            sha256=sha,
-            size_bytes=size,
-            has_text=existing.has_text,
-            detected_doi=existing.detected_doi,
-            status="unchanged",
-            duplicate_of=None,
-            last_error=existing.last_error,
+            ),
+            None,
+            0.0,
         )
 
     if sha in seen_in_run:
-        return InventoryRow(
+        return (
+            InventoryRow(
+                source_path=str(path),
+                sha256=sha,
+                size_bytes=size,
+                has_text=False,
+                detected_doi=None,
+                classification=None,
+                needs_review=False,
+                rejection_reason=None,
+                status="duplicate",
+                duplicate_of=seen_in_run[sha],
+                last_error=None,
+            ),
+            None,
+            0.0,
+        )
+
+    # New PDF: extract, classify, persist (or exclude).
+    item = Item(id=sha, source_path=str(path), size_bytes=size)
+    extraction = _extract(item, run=run, path=path, now=now)
+
+    if extraction is None:
+        # Extraction raised — handler set item.last_error. Conservative
+        # bias (plan_01 §3.1 Edge cases): keep as academic + needs_review.
+        item.classification = "academic"
+        item.needs_review = True
+        if not dry_run:
+            session.add(item)
+        seen_in_run[sha] = str(path)
+        return (
+            InventoryRow(
+                source_path=str(path),
+                sha256=sha,
+                size_bytes=size,
+                has_text=item.has_text,
+                detected_doi=item.detected_doi,
+                classification=item.classification,
+                needs_review=item.needs_review,
+                rejection_reason=None,
+                status="error",
+                duplicate_of=None,
+                last_error=item.last_error,
+            ),
+            None,
+            0.0,
+        )
+
+    try:
+        result, usage = await classify(
+            pages_text=extraction.pages_text,
+            page_count=extraction.page_count,
+            has_text=item.has_text,
+            skip_llm_gate=skip_llm_gate,
+            openai_client=openai_client,
+        )
+    except BudgetExceededError as exc:
+        log.error("stage_01.budget_exceeded", error=str(exc))
+        raise StageAbortedError(str(exc)) from exc
+
+    cost = usage.cost_usd if usage is not None else 0.0
+
+    if result.decision == "reject":
+        excluded_row = ExcludedRow(
             source_path=str(path),
             sha256=sha,
             size_bytes=size,
-            has_text=False,
-            detected_doi=None,
-            status="duplicate",
-            duplicate_of=seen_in_run[sha],
-            last_error=None,
+            page_count=extraction.page_count,
+            rejection_reason=result.rejection_reason or "unknown",
+            classifier_branch=result.branch,
+            llm_reason=result.llm_reason,
+        )
+        return (
+            InventoryRow(
+                source_path=str(path),
+                sha256=sha,
+                size_bytes=size,
+                has_text=item.has_text,
+                detected_doi=item.detected_doi,
+                classification=None,
+                needs_review=False,
+                rejection_reason=result.rejection_reason,
+                status="excluded",
+                duplicate_of=None,
+                last_error=None,
+            ),
+            excluded_row,
+            cost,
         )
 
-    item = Item(id=sha, source_path=str(path), size_bytes=size)
-    _process_new(item, run=run, path=path, now=now)
-
+    item.classification = "academic"
+    item.needs_review = result.needs_review
     if not dry_run:
         session.add(item)
     seen_in_run[sha] = str(path)
 
-    status: InventoryStatus = "error" if item.last_error else "new"
-    return InventoryRow(
-        source_path=str(path),
-        sha256=sha,
-        size_bytes=size,
-        has_text=item.has_text,
-        detected_doi=item.detected_doi,
-        status=status,
-        duplicate_of=None,
-        last_error=item.last_error,
+    return (
+        InventoryRow(
+            source_path=str(path),
+            sha256=sha,
+            size_bytes=size,
+            has_text=item.has_text,
+            detected_doi=item.detected_doi,
+            classification=item.classification,
+            needs_review=item.needs_review,
+            rejection_reason=None,
+            status="new",
+            duplicate_of=None,
+            last_error=item.last_error,
+        ),
+        None,
+        cost,
     )
 
 
 __all__ = [
+    "ExcludedRow",
     "InventoryResult",
     "InventoryRow",
     "InventoryStatus",

--- a/src/zotai/state.py
+++ b/src/zotai/state.py
@@ -14,8 +14,7 @@ and evolve via code rather than alembic in v1 (see plan_02 §5).
 
 from __future__ import annotations
 
-from datetime import date, datetime, timezone
-from typing import Optional
+from datetime import UTC, date, datetime
 
 from sqlalchemy import MetaData, Table
 from sqlalchemy.engine import Engine
@@ -24,7 +23,7 @@ from sqlmodel import Field, SQLModel, create_engine
 
 def _utc_now() -> datetime:
     """Timezone-aware UTC timestamp used as default for `created_at` / `updated_at`."""
-    return datetime.now(tz=timezone.utc)
+    return datetime.now(tz=UTC)
 
 
 # ─── S1: state.db ───────────────────────────────────────────────────────────
@@ -41,15 +40,20 @@ class Item(SQLModel, table=True):
     source_path: str
     size_bytes: int
     has_text: bool = False
-    detected_doi: Optional[str] = None
+    detected_doi: str | None = None
+    # Stage 01 classifier (plan_01 §3.1). Rejected PDFs never land in the
+    # DB — only 'academic' rows exist here. ``needs_review`` flags items
+    # the LLM gate was unsure about so Stage 06 surfaces them.
+    classification: str = "academic"
+    needs_review: bool = False
     ocr_failed: bool = False
-    zotero_item_key: Optional[str] = None
-    import_route: Optional[str] = None  # 'A' | 'C'
+    zotero_item_key: str | None = None
+    import_route: str | None = None  # 'A' | 'C'
     stage_completed: int = 0
     in_quarantine: bool = False
-    last_error: Optional[str] = None
-    metadata_json: Optional[str] = None
-    tags_json: Optional[str] = None
+    last_error: str | None = None
+    metadata_json: str | None = None
+    tags_json: str | None = None
     created_at: datetime = Field(default_factory=_utc_now)
     updated_at: datetime = Field(default_factory=_utc_now)
 
@@ -57,10 +61,10 @@ class Item(SQLModel, table=True):
 class Run(SQLModel, table=True):
     """A single execution of an S1 stage, used for metrics + resume semantics."""
 
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     stage: int
     started_at: datetime = Field(default_factory=_utc_now)
-    finished_at: Optional[datetime] = None
+    finished_at: datetime | None = None
     items_processed: int = 0
     items_failed: int = 0
     cost_usd: float = 0.0
@@ -70,13 +74,13 @@ class Run(SQLModel, table=True):
 class ApiCall(SQLModel, table=True):
     """Per-call observability for external services. Used for budget enforcement."""
 
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     run_id: int = Field(foreign_key="run.id")
     service: str  # 'openalex' | 'semantic_scholar' | 'openai' | 'zotero'
     cost_usd: float = 0.0
     duration_ms: int = 0
     status: str = "success"  # 'success' | 'error' | 'rate_limited'
-    item_id: Optional[str] = Field(default=None, foreign_key="item.id")
+    item_id: str | None = Field(default=None, foreign_key="item.id")
     timestamp: datetime = Field(default_factory=_utc_now)
 
 
@@ -88,13 +92,13 @@ class Candidate(SQLModel, table=True):
 
     id: str = Field(primary_key=True)  # hash of DOI or URL
     source_feed_id: str = Field(foreign_key="feed.id")
-    doi: Optional[str] = None
+    doi: str | None = None
     title: str
     authors_json: str
-    abstract: Optional[str] = None
+    abstract: str | None = None
     venue: str
     published_at: datetime
-    url: Optional[str] = None
+    url: str | None = None
 
     # Scoring (each in [0, 1])
     score_tags: float = 0.0
@@ -105,13 +109,13 @@ class Candidate(SQLModel, table=True):
 
     # Triage
     status: str = "pending"  # 'pending' | 'accepted' | 'rejected' | 'deferred'
-    decided_at: Optional[datetime] = None
-    decided_by: Optional[str] = None
-    decision_note: Optional[str] = None
+    decided_at: datetime | None = None
+    decided_by: str | None = None
+    decision_note: str | None = None
 
     # Zotero integration — set once push succeeds
-    zotero_item_key: Optional[str] = None
-    pushed_at: Optional[datetime] = None
+    zotero_item_key: str | None = None
+    pushed_at: datetime | None = None
 
     created_at: datetime = Field(default_factory=_utc_now)
     updated_at: datetime = Field(default_factory=_utc_now)
@@ -123,17 +127,17 @@ class Feed(SQLModel, table=True):
     id: str = Field(primary_key=True)  # slug
     name: str
     rss_url: str
-    issn: Optional[str] = None
+    issn: str | None = None
     active: bool = True
-    last_fetched_at: Optional[datetime] = None
-    last_fetch_status: Optional[str] = None
+    last_fetched_at: datetime | None = None
+    last_fetch_status: str | None = None
     items_fetched_total: int = 0
 
 
 class PersistentQuery(SQLModel, table=True):
     """A user-authored query that contributes to the composite score of every candidate."""
 
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     query_text: str
     active: bool = True
     weight: float = 1.0
@@ -143,7 +147,7 @@ class PersistentQuery(SQLModel, table=True):
 class TriageMetric(SQLModel, table=True):
     """Weekly precision/volume snapshot used on the dashboard's metrics page."""
 
-    id: Optional[int] = Field(default=None, primary_key=True)
+    id: int | None = Field(default=None, primary_key=True)
     week_start: date
     candidates_shown: int = 0
     candidates_accepted: int = 0
@@ -198,14 +202,14 @@ def init_s2(engine: Engine) -> None:
 
 
 __all__ = [
+    "S1_TABLES",
+    "S2_TABLES",
     "ApiCall",
     "Candidate",
     "Feed",
     "Item",
     "PersistentQuery",
     "Run",
-    "S1_TABLES",
-    "S2_TABLES",
     "TriageMetric",
     "init_s1",
     "init_s2",

--- a/src/zotai/utils/pdf.py
+++ b/src/zotai/utils/pdf.py
@@ -79,6 +79,12 @@ def has_text_layer(path: Path, threshold: int = _HAS_TEXT_THRESHOLD) -> bool:
     return len(pages[0]) >= threshold
 
 
+def count_pages(path: Path) -> int:
+    """Return the number of pages in the PDF at ``path``."""
+    with pdfplumber.open(path) as pdf:
+        return len(pdf.pages)
+
+
 def _iter_lines(chars: list[dict[str, Any]]) -> Iterator[tuple[float, float, str]]:
     """Group pdfplumber chars into lines keyed by rounded `top`.
 
@@ -127,6 +133,7 @@ def extract_probable_title(path: Path) -> str | None:
 
 
 __all__ = [
+    "count_pages",
     "detect_arxiv",
     "detect_doi",
     "extract_probable_title",

--- a/tests/test_s1/conftest.py
+++ b/tests/test_s1/conftest.py
@@ -1,41 +1,89 @@
 """Stage 01 fixtures.
 
 Rather than pulling in ``reportlab`` / ``pypdf`` as a test dependency, we
-hand-roll minimal PDF-1.4 bytes. The builder is intentionally tiny: one
-page, Helvetica Type-1, optional text content stream.
+hand-roll minimal PDF-1.4 bytes. The builder supports N pages with
+optional text per page; ``None`` produces a blank page (simulating a
+scanned PDF).
 """
 
 from __future__ import annotations
 
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable, Literal
+from typing import Literal
 
 import pytest
 
-Kind = Literal["text_doi", "text_no_doi", "scanned", "fake", "corrupt"]
+Kind = Literal[
+    "text_doi",
+    "text_no_doi",
+    "scanned",
+    "fake",
+    "corrupt",
+    "factura_1page",
+    "dni_scanned",
+    "ambiguous_short",
+    "paper_keywords",
+]
 
 
-def _pdf_bytes(page_text: str | None) -> bytes:
-    if page_text:
-        escaped = (
-            page_text.replace("\\", "\\\\").replace("(", r"\(").replace(")", r"\)")
+def _pdf_bytes(page_texts: list[str | None]) -> bytes:
+    """Assemble a PDF-1.4 with ``len(page_texts)`` pages.
+
+    Each element is either the text for that page (rendered in
+    Helvetica), or ``None`` for a page with an empty content stream
+    (i.e. a page with no extractable text — what you'd get from a pure
+    scan). The shared font object keeps the file small.
+    """
+    n = len(page_texts)
+    if n == 0:
+        raise ValueError("need at least 1 page")
+
+    # Object numbering plan:
+    # 1              → Catalog
+    # 2              → Pages (kids array)
+    # 3 .. 3+n-1     → Page objects
+    # 3+n .. 3+2n-1  → Content streams
+    # 3+2n           → Font (shared)
+    page_obj_ids = list(range(3, 3 + n))
+    content_obj_ids = list(range(3 + n, 3 + 2 * n))
+    font_obj_id = 3 + 2 * n
+
+    streams: list[bytes] = []
+    for text in page_texts:
+        if text is None:
+            streams.append(b"")
+        else:
+            escaped = (
+                text.replace("\\", "\\\\").replace("(", r"\(").replace(")", r"\)")
+            )
+            streams.append(
+                f"BT /F1 12 Tf 72 720 Td ({escaped}) Tj ET".encode("latin-1")
+            )
+
+    objects: list[bytes] = []
+    objects.append(b"<< /Type /Catalog /Pages 2 0 R >>")
+    kids = b" ".join(f"{pid} 0 R".encode() for pid in page_obj_ids)
+    objects.append(
+        b"<< /Type /Pages /Kids [" + kids + f"] /Count {n}".encode() + b" >>"
+    )
+    for i, _pid in enumerate(page_obj_ids):
+        cid = content_obj_ids[i]
+        objects.append(
+            (
+                f"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
+                f"/Contents {cid} 0 R /Resources << /Font << /F1 {font_obj_id} 0 R >> >> >>"
+            ).encode()
         )
-        stream = f"BT /F1 12 Tf 72 720 Td ({escaped}) Tj ET".encode("latin-1")
-    else:
-        stream = b""
-
-    objects: list[bytes] = [
-        b"<< /Type /Catalog /Pages 2 0 R >>",
-        b"<< /Type /Pages /Kids [3 0 R] /Count 1 >>",
-        b"<< /Type /Page /Parent 2 0 R /MediaBox [0 0 612 792] "
-        b"/Contents 4 0 R /Resources << /Font << /F1 5 0 R >> >> >>",
-        b"<< /Length "
-        + str(len(stream)).encode()
-        + b" >>\nstream\n"
-        + stream
-        + b"\nendstream",
-        b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>",
-    ]
+    for stream in streams:
+        objects.append(
+            b"<< /Length "
+            + str(len(stream)).encode()
+            + b" >>\nstream\n"
+            + stream
+            + b"\nendstream"
+        )
+    objects.append(b"<< /Type /Font /Subtype /Type1 /BaseFont /Helvetica >>")
 
     body = bytearray(b"%PDF-1.4\n%\xe2\xe3\xcf\xd3\n")
     offsets: list[int] = []
@@ -58,11 +106,40 @@ def _pdf_bytes(page_text: str | None) -> bytes:
 _LONG = "This paper discusses the fiscal multiplier at length. " * 5
 
 _KIND_TO_BYTES: dict[Kind, bytes] = {
-    "text_doi": _pdf_bytes(_LONG + " doi: 10.1234/example.2024"),
-    "text_no_doi": _pdf_bytes(_LONG),
-    "scanned": _pdf_bytes(None),
+    # 1-page PDF, long prose + DOI → heuristic_accept via DOI.
+    "text_doi": _pdf_bytes([_LONG + " doi: 10.1234/example.2024"]),
+    # 1-page PDF, long prose, no academic markers → ambiguous → LLM gate.
+    "text_no_doi": _pdf_bytes([_LONG]),
+    # 3-page scan (no text). page_count > 2 → heuristic_reject skipped →
+    # ambiguous → LLM gate (or needs_review if skipped). Survives Stage 01.
+    "scanned": _pdf_bytes([None, None, None]),
     "fake": b"<html>not a pdf</html>\n",
     "corrupt": b"%PDF-1.4\n" + (b"garbage" * 50),
+    # 1 page + billing keyword → heuristic_reject("billing_keyword:factura").
+    # Single keyword only — multiple would leave the returned reason
+    # dependent on frozenset iteration order.
+    "factura_1page": _pdf_bytes(["factura 001-00012345 total: $1500"]),
+    # 2-page scanned document with no text → heuristic_reject("short_no_text").
+    "dni_scanned": _pdf_bytes([None, None]),
+    # 5 pages of generic prose, no academic markers → ambiguous (LLM gate).
+    "ambiguous_short": _pdf_bytes(
+        [
+            "Page body one without markers.",
+            "Page body two generic content.",
+            "Page body three generic content.",
+            "Page body four generic content.",
+            "Page body five generic content.",
+        ]
+    ),
+    # 3-page paper-like PDF with Abstract + References + Keywords →
+    # heuristic_accept via the keyword branch (no DOI).
+    "paper_keywords": _pdf_bytes(
+        [
+            "Abstract. We study the fiscal multiplier. Keywords: economy.",
+            "References. Smith 2020. Jones 2021.",
+            "Conclusion body.",
+        ]
+    ),
 }
 
 
@@ -80,6 +157,7 @@ def _isolate_settings_env(
         "LOG_LEVEL",
         "USER_EMAIL",
         "MAX_COST_USD_TOTAL",
+        "MAX_COST_USD_STAGE_01",
         "MAX_COST_USD_STAGE_04",
         "MAX_COST_USD_STAGE_05",
     ):

--- a/tests/test_s1/test_classifier.py
+++ b/tests/test_s1/test_classifier.py
@@ -1,0 +1,361 @@
+"""Unit tests for :mod:`zotai.s1.classifier`.
+
+These tests exercise the three branches in isolation. Stage-level
+integration (excluded CSV, persistence gating, budget aborts) lives in
+``test_stage_01.py``.
+"""
+
+from __future__ import annotations
+
+import json
+from unittest.mock import MagicMock
+
+from zotai.api.openai_client import UsageRecord
+from zotai.s1.classifier import (
+    ClassificationResult,
+    GateResult,
+    classify,
+    heuristic_accept,
+    heuristic_reject,
+    llm_gate,
+)
+
+
+class _FakeMessage:
+    def __init__(self, content: str) -> None:
+        self.content = content
+
+
+class _FakeChoice:
+    def __init__(self, content: str) -> None:
+        self.message = _FakeMessage(content)
+
+
+class _FakeUsage:
+    def __init__(self, prompt_tokens: int, completion_tokens: int) -> None:
+        self.prompt_tokens = prompt_tokens
+        self.completion_tokens = completion_tokens
+
+
+class _FakeResponse:
+    def __init__(
+        self, content: str, prompt_tokens: int = 50, completion_tokens: int = 20
+    ) -> None:
+        self.choices = [_FakeChoice(content)]
+        self.usage = _FakeUsage(prompt_tokens, completion_tokens)
+
+
+def _fake_client(responses: list[str]) -> MagicMock:
+    """Build a ``MagicMock`` that yields the given JSON strings, one per call."""
+    iterator = iter(responses)
+
+    async def _classify_document(*, prompt: str, model: str = "gpt-4o-mini") -> UsageRecord:
+        content = next(iterator)
+        resp = _FakeResponse(content)
+        return UsageRecord(
+            model=model,
+            prompt_tokens=resp.usage.prompt_tokens,
+            completion_tokens=resp.usage.completion_tokens,
+            cost_usd=0.0001,
+            response=resp,
+        )
+
+    client = MagicMock()
+    client.classify_document = _classify_document
+    client.budget_usd = 1.0
+    client.spent_usd = 0.0
+    return client
+
+
+# ─── heuristic_accept ──────────────────────────────────────────────────────
+
+
+def test_heuristic_accept_via_doi() -> None:
+    assert heuristic_accept(["Some title", "Body 10.1234/example.xyz more body"])
+
+
+def test_heuristic_accept_via_arxiv() -> None:
+    assert heuristic_accept(["arXiv:2301.12345 submitted 2024"])
+
+
+def test_heuristic_accept_via_keyword_abstract() -> None:
+    assert heuristic_accept(["Title\n\nAbstract\nBody"])
+
+
+def test_heuristic_accept_via_keyword_references() -> None:
+    assert heuristic_accept(["References\n1. Smith 2020"])
+
+
+def test_heuristic_accept_via_valid_isbn_13() -> None:
+    # 978-3-16-148410-0 has a valid ISBN-13 checksum.
+    assert heuristic_accept(["ISBN: 978-3-16-148410-0"])
+
+
+def test_heuristic_accept_rejects_invalid_isbn_13() -> None:
+    # Corrupt the checksum digit.
+    assert not heuristic_accept(["ISBN: 978-3-16-148410-1 with no other markers"])
+
+
+def test_heuristic_accept_no_markers_returns_false() -> None:
+    assert not heuristic_accept(["Generic body text without academic signals."])
+
+
+def test_heuristic_accept_empty_returns_false() -> None:
+    assert not heuristic_accept([])
+    assert not heuristic_accept([""])
+
+
+# ─── heuristic_reject ──────────────────────────────────────────────────────
+
+
+def test_heuristic_reject_short_no_text_returns_reason() -> None:
+    assert (
+        heuristic_reject(page_count=1, has_text=False, first_page_text="")
+        == "short_no_text"
+    )
+
+
+def test_heuristic_reject_billing_keyword_factura() -> None:
+    assert (
+        heuristic_reject(
+            page_count=1,
+            has_text=True,
+            first_page_text="Factura 001 total: $1500",
+        )
+        == "billing_keyword:factura"
+    )
+
+
+def test_heuristic_reject_billing_keyword_dni() -> None:
+    assert (
+        heuristic_reject(
+            page_count=2,
+            has_text=True,
+            first_page_text="Autoridad emisora DNI 38123456",
+        )
+        == "billing_keyword:dni"
+    )
+
+
+def test_heuristic_reject_multipage_pass_through() -> None:
+    assert (
+        heuristic_reject(page_count=5, has_text=False, first_page_text="")
+        is None
+    )
+
+
+def test_heuristic_reject_short_no_billing_pass_through() -> None:
+    # The text must not contain any substring of the billing vocabulary —
+    # "bill" is a keyword, so words like "billing" trigger a false match.
+    assert (
+        heuristic_reject(
+            page_count=1,
+            has_text=True,
+            first_page_text="A short note without special markers.",
+        )
+        is None
+    )
+
+
+# ─── llm_gate ──────────────────────────────────────────────────────────────
+
+
+async def test_llm_gate_returns_parsed_payload() -> None:
+    client = _fake_client(
+        [
+            json.dumps(
+                {
+                    "is_academic": True,
+                    "confidence": "high",
+                    "reason": "abstract + methods",
+                }
+            )
+        ]
+    )
+    result, usage = await llm_gate(
+        first_page_snippet="any text",
+        page_count=5,
+        openai_client=client,
+    )
+    assert result == GateResult(
+        is_academic=True, confidence="high", reason="abstract + methods"
+    )
+    assert usage.cost_usd == 0.0001
+
+
+async def test_llm_gate_retries_once_then_defaults_when_malformed() -> None:
+    client = _fake_client(["not json", "still not json"])
+    result, _ = await llm_gate(
+        first_page_snippet="x",
+        page_count=3,
+        openai_client=client,
+    )
+    assert result.is_academic is True
+    assert result.confidence == "low"
+    assert "malformed" in result.reason
+
+
+async def test_llm_gate_recovers_on_second_attempt() -> None:
+    client = _fake_client(
+        [
+            "{broken",
+            json.dumps(
+                {"is_academic": False, "confidence": "medium", "reason": "invoice"}
+            ),
+        ]
+    )
+    result, _ = await llm_gate(
+        first_page_snippet="x",
+        page_count=1,
+        openai_client=client,
+    )
+    assert result == GateResult(
+        is_academic=False, confidence="medium", reason="invoice"
+    )
+
+
+async def test_llm_gate_coerces_unknown_confidence_to_low() -> None:
+    client = _fake_client(
+        [json.dumps({"is_academic": True, "confidence": "kinda", "reason": "x"})]
+    )
+    result, _ = await llm_gate(
+        first_page_snippet="x",
+        page_count=1,
+        openai_client=client,
+    )
+    assert result.confidence == "low"
+
+
+# ─── classify (orchestrator) ──────────────────────────────────────────────
+
+
+async def test_classify_positive_heuristic_wins() -> None:
+    result, usage = await classify(
+        pages_text=["Title\n\nAbstract\nBody\nReferences"],
+        page_count=3,
+        has_text=True,
+        skip_llm_gate=False,
+        openai_client=None,
+    )
+    assert result == ClassificationResult(
+        decision="academic", needs_review=False, branch="heuristic_positive"
+    )
+    assert usage is None
+
+
+async def test_classify_negative_heuristic_rejects_before_llm() -> None:
+    client = _fake_client([])  # must not be called
+
+    result, usage = await classify(
+        pages_text=["factura 001 total: $1500"],
+        page_count=1,
+        has_text=True,
+        skip_llm_gate=False,
+        openai_client=client,
+    )
+    assert result.decision == "reject"
+    assert result.branch == "heuristic_negative"
+    assert result.rejection_reason == "billing_keyword:factura"
+    assert usage is None
+
+
+async def test_classify_skip_llm_gate_marks_needs_review() -> None:
+    result, usage = await classify(
+        pages_text=["Generic text without markers."],
+        page_count=5,
+        has_text=True,
+        skip_llm_gate=True,
+        openai_client=MagicMock(),  # present but unused
+    )
+    assert result == ClassificationResult(
+        decision="academic", needs_review=True, branch="skipped_llm_gate"
+    )
+    assert usage is None
+
+
+async def test_classify_llm_high_confidence_academic() -> None:
+    client = _fake_client(
+        [json.dumps({"is_academic": True, "confidence": "high", "reason": "wp"})]
+    )
+    result, usage = await classify(
+        pages_text=["Body without markers"],
+        page_count=5,
+        has_text=True,
+        skip_llm_gate=False,
+        openai_client=client,
+    )
+    assert result.decision == "academic"
+    assert result.needs_review is False
+    assert result.branch == "llm_gate"
+    assert usage is not None
+
+
+async def test_classify_llm_low_confidence_academic_needs_review() -> None:
+    client = _fake_client(
+        [json.dumps({"is_academic": True, "confidence": "low", "reason": "unclear"})]
+    )
+    result, _ = await classify(
+        pages_text=["Body"],
+        page_count=5,
+        has_text=True,
+        skip_llm_gate=False,
+        openai_client=client,
+    )
+    assert result.decision == "academic"
+    assert result.needs_review is True
+
+
+async def test_classify_llm_high_confidence_rejects() -> None:
+    client = _fake_client(
+        [
+            json.dumps(
+                {"is_academic": False, "confidence": "high", "reason": "receipt"}
+            )
+        ]
+    )
+    result, _ = await classify(
+        pages_text=["Body"],
+        page_count=3,
+        has_text=True,
+        skip_llm_gate=False,
+        openai_client=client,
+    )
+    assert result.decision == "reject"
+    assert result.rejection_reason == "llm_non_academic"
+    assert result.branch == "llm_gate"
+
+
+async def test_classify_llm_low_confidence_rejection_is_conservative() -> None:
+    """``is_academic=False`` with ``confidence='low'`` keeps item with needs_review."""
+    client = _fake_client(
+        [
+            json.dumps(
+                {"is_academic": False, "confidence": "low", "reason": "unclear"}
+            )
+        ]
+    )
+    result, _ = await classify(
+        pages_text=["Body"],
+        page_count=3,
+        has_text=True,
+        skip_llm_gate=False,
+        openai_client=client,
+    )
+    assert result.decision == "academic"
+    assert result.needs_review is True
+    assert result.branch == "llm_gate"
+
+
+async def test_classify_malformed_llm_json_defaults_to_academic_needs_review() -> None:
+    """Two malformed attempts → include with needs_review (conservative)."""
+    client = _fake_client(["not json", "also not json"])
+    result, _ = await classify(
+        pages_text=["Body"],
+        page_count=5,
+        has_text=True,
+        skip_llm_gate=False,
+        openai_client=client,
+    )
+    assert result.decision == "academic"
+    assert result.needs_review is True
+    assert result.branch == "llm_gate"

--- a/tests/test_s1/test_stage_01.py
+++ b/tests/test_s1/test_stage_01.py
@@ -3,15 +3,19 @@
 from __future__ import annotations
 
 import csv
+from collections.abc import Callable
 from pathlib import Path
-from typing import Callable
+from typing import Any
 
 import pytest
 from sqlmodel import Session, select
 from typer.testing import CliRunner
 
+from zotai.api.openai_client import BudgetExceededError, UsageRecord
 from zotai.cli import app
 from zotai.config import PathSettings, Settings
+from zotai.s1 import stage_01_inventory as mod
+from zotai.s1.classifier import ClassificationResult
 from zotai.s1.handler import StageAbortedError
 from zotai.s1.stage_01_inventory import run_inventory
 from zotai.state import Item, Run, init_s1, make_s1_engine
@@ -50,9 +54,10 @@ def test_valid_pdf_with_doi_persists_item(
     assert item.last_error is None
 
 
-def test_scanned_like_has_text_false(
+def test_scanned_multipage_persists_despite_no_text(
     pdf_builder: Callable[..., Path], tmp_path: Path
 ) -> None:
+    """3-page scanned PDF is kept (classifier rejects only ``pages<=2 AND no text``)."""
     folder = tmp_path / "pdfs"
     pdf_builder("scanned", directory=folder)
     settings = _settings(tmp_path, [folder])
@@ -65,6 +70,9 @@ def test_scanned_like_has_text_false(
     assert item.stage_completed == 1
     assert item.has_text is False
     assert item.detected_doi is None
+    # Ambiguous path (no LLM client in tests) → academic + needs_review.
+    assert item.classification == "academic"
+    assert item.needs_review is True
 
 
 def test_no_doi_pdf_persists_without_doi(
@@ -281,6 +289,9 @@ def test_csv_contents_match_run_rows(
         "size_bytes",
         "has_text",
         "detected_doi",
+        "classification",
+        "needs_review",
+        "rejection_reason",
         "status",
         "duplicate_of",
         "last_error",
@@ -355,3 +366,259 @@ def test_cli_exits_2_when_no_folders_configured(
     result = runner.invoke(app, ["s1", "inventory"])
 
     assert result.exit_code == 2
+
+
+# ─── Classifier integration tests (issue #24, plan_01 §3.1) ─────────────────
+
+
+def _patch_classify(
+    monkeypatch: pytest.MonkeyPatch,
+    result: ClassificationResult,
+    usage: UsageRecord | None = None,
+) -> None:
+    """Replace :func:`stage_01_inventory.classify` with a fixed-return stub."""
+
+    async def _fake_classify(**_: Any) -> tuple[ClassificationResult, UsageRecord | None]:
+        return result, usage
+
+    monkeypatch.setattr(mod, "classify", _fake_classify)
+
+
+def test_paper_with_doi_accepted_via_heuristic(
+    pdf_builder: Callable[..., Path], tmp_path: Path
+) -> None:
+    folder = tmp_path / "pdfs"
+    pdf_builder("text_doi", directory=folder)
+    settings = _settings(tmp_path, [folder])
+
+    run_inventory([folder], dry_run=False, settings=settings)
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.classification == "academic"
+    assert item.needs_review is False
+
+
+def test_paper_with_keywords_accepted_via_heuristic(
+    pdf_builder: Callable[..., Path], tmp_path: Path
+) -> None:
+    folder = tmp_path / "pdfs"
+    pdf_builder("paper_keywords", directory=folder)
+    settings = _settings(tmp_path, [folder])
+
+    run_inventory([folder], dry_run=False, settings=settings)
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.classification == "academic"
+    assert item.needs_review is False
+
+
+def test_factura_rejected_stays_out_of_db(
+    pdf_builder: Callable[..., Path], tmp_path: Path
+) -> None:
+    folder = tmp_path / "pdfs"
+    pdf_builder("factura_1page", directory=folder)
+    settings = _settings(tmp_path, [folder])
+
+    result = run_inventory([folder], dry_run=False, settings=settings)
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        assert session.exec(select(Item)).all() == []
+    assert result.excluded == 1
+    assert len(result.excluded_rows) == 1
+    excluded = result.excluded_rows[0]
+    assert excluded.classifier_branch == "heuristic_negative"
+    assert "factura" in excluded.rejection_reason
+    excluded_row_statuses = [r.status for r in result.rows if r.status == "excluded"]
+    assert excluded_row_statuses == ["excluded"]
+
+
+def test_dni_scanned_rejected_short_no_text(
+    pdf_builder: Callable[..., Path], tmp_path: Path
+) -> None:
+    folder = tmp_path / "pdfs"
+    pdf_builder("dni_scanned", directory=folder)
+    settings = _settings(tmp_path, [folder])
+
+    result = run_inventory([folder], dry_run=False, settings=settings)
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        assert session.exec(select(Item)).all() == []
+    assert result.excluded == 1
+    assert result.excluded_rows[0].rejection_reason == "short_no_text"
+
+
+def test_ambiguous_llm_high_confidence_accept(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_classify(
+        monkeypatch,
+        ClassificationResult(
+            decision="academic",
+            needs_review=False,
+            branch="llm_gate",
+            llm_reason="working paper",
+        ),
+    )
+    folder = tmp_path / "pdfs"
+    pdf_builder("ambiguous_short", directory=folder)
+    settings = _settings(tmp_path, [folder])
+
+    run_inventory([folder], dry_run=False, settings=settings)
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.classification == "academic"
+    assert item.needs_review is False
+
+
+def test_ambiguous_llm_low_confidence_needs_review(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_classify(
+        monkeypatch,
+        ClassificationResult(
+            decision="academic",
+            needs_review=True,
+            branch="llm_gate",
+            llm_reason="uncertain",
+        ),
+    )
+    folder = tmp_path / "pdfs"
+    pdf_builder("ambiguous_short", directory=folder)
+    settings = _settings(tmp_path, [folder])
+
+    run_inventory([folder], dry_run=False, settings=settings)
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.classification == "academic"
+    assert item.needs_review is True
+
+
+def test_ambiguous_llm_rejects_non_academic(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    _patch_classify(
+        monkeypatch,
+        ClassificationResult(
+            decision="reject",
+            needs_review=False,
+            branch="llm_gate",
+            rejection_reason="llm_non_academic",
+            llm_reason="looks like a slide deck",
+        ),
+    )
+    folder = tmp_path / "pdfs"
+    pdf_builder("ambiguous_short", directory=folder)
+    settings = _settings(tmp_path, [folder])
+
+    result = run_inventory([folder], dry_run=False, settings=settings)
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        assert session.exec(select(Item)).all() == []
+    assert result.excluded == 1
+    assert result.excluded_rows[0].classifier_branch == "llm_gate"
+
+
+def test_skip_llm_gate_marks_ambiguous_as_needs_review(
+    pdf_builder: Callable[..., Path], tmp_path: Path
+) -> None:
+    folder = tmp_path / "pdfs"
+    pdf_builder("ambiguous_short", directory=folder)
+    settings = _settings(tmp_path, [folder])
+
+    run_inventory(
+        [folder], dry_run=False, skip_llm_gate=True, settings=settings
+    )
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.classification == "academic"
+    assert item.needs_review is True
+
+
+def test_budget_exceeded_aborts_run(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    async def _exploding_classify(**_: Any) -> tuple[ClassificationResult, UsageRecord | None]:
+        raise BudgetExceededError("budget is $0.00")
+
+    monkeypatch.setattr(mod, "classify", _exploding_classify)
+    folder = tmp_path / "pdfs"
+    pdf_builder("ambiguous_short", directory=folder)
+    settings = _settings(tmp_path, [folder])
+
+    with pytest.raises(StageAbortedError):
+        run_inventory([folder], dry_run=False, settings=settings)
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        run_row = session.exec(select(Run)).one()
+    assert run_row.status == "aborted"
+
+
+def test_excluded_csv_written_with_expected_columns(
+    pdf_builder: Callable[..., Path], tmp_path: Path
+) -> None:
+    folder = tmp_path / "pdfs"
+    pdf_builder("factura_1page", directory=folder)
+    settings = _settings(tmp_path, [folder])
+
+    result = run_inventory([folder], dry_run=False, settings=settings)
+
+    assert result.excluded_csv_path.exists()
+    with result.excluded_csv_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert reader.fieldnames is not None
+    assert set(reader.fieldnames) == {
+        "source_path",
+        "sha256",
+        "size_bytes",
+        "page_count",
+        "rejection_reason",
+        "classifier_branch",
+        "llm_reason",
+    }
+    assert len(rows) == 1
+    assert rows[0]["classifier_branch"] == "heuristic_negative"
+    assert "factura" in rows[0]["rejection_reason"]
+
+
+def test_rerun_does_not_reclassify_existing_rows(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """Items already in ``state.db`` are not re-classified on re-run."""
+    folder = tmp_path / "pdfs"
+    pdf_builder("paper_keywords", directory=folder)
+    settings = _settings(tmp_path, [folder])
+
+    run_inventory([folder], dry_run=False, settings=settings)
+
+    async def _should_not_be_called(**_: Any) -> tuple[ClassificationResult, UsageRecord | None]:
+        raise AssertionError("classify() must not run on unchanged items")
+
+    monkeypatch.setattr(mod, "classify", _should_not_be_called)
+
+    second = run_inventory([folder], dry_run=False, settings=settings)
+    assert [r.status for r in second.rows] == ["unchanged"]


### PR DESCRIPTION
Closes #24.

## Summary

Three-branch academic / non-academic classifier upstream of the rest of the S1 pipeline (plan_01 §3.1). Non-academic PDFs (facturas, DNIs, tickets, manuals) never consume OCR budget or downstream API calls.

## What's in

**Classifier core** (`src/zotai/s1/classifier.py`):
1. **Positive heuristic** — zero cost. Accept on DOI / arXiv / valid ISBN (checksum-validated) / academic keyword match in pages 1-3.
2. **Negative heuristic** — zero cost. Reject when `page_count <= 2` AND (billing/personal-document keyword on page 1 OR no extractable text). Keyword matches win tiebreaks so the rejection reason is informative (`billing_keyword:factura`) rather than generic (`short_no_text`).
3. **LLM gate** — `gpt-4o-mini` JSON-mode for the ambiguous remainder. One retry on malformed JSON; conservative bias (ambiguity → `academic + needs_review=True`).

**Integration**:
- `stage_01_inventory` now writes `reports/excluded_report_<ts>.csv` alongside the inventory report. Rejected items never enter `state.db`. `inventory_report.csv` gained `classification`, `needs_review`, `rejection_reason` columns.
- `OpenAIClient.classify_document()` added — prompt-agnostic JSON-mode call with budget enforcement.
- `utils.pdf.count_pages()` added.

**Schema + config**:
- `Item.classification` (default `'academic'`) + `Item.needs_review` (default `False`) columns.
- Alembic migration `20260422_classifier_columns` for existing DBs (down_revision=None — Phase 8's initial-schema migration will re-parent it per #9).
- `BudgetSettings.max_cost_usd_stage_01` (default `1.0`) + `MAX_COST_USD_STAGE_01=1.00` in `.env.example`.

**CLI**:
- `zotai s1 inventory --skip-llm-gate` — ambiguous → `needs_review=True` without calling OpenAI (useful without `OPENAI_API_KEY`).
- `zotai s1 inventory --max-cost N` — override the budget for this run.

## Tests

26 new tests, all passing:

- `tests/test_s1/test_classifier.py` — pure-function matrix for the three branches + orchestrator (accept paths, reject paths, LLM high/low/medium/malformed/retry paths).
- `tests/test_s1/test_stage_01.py` — integration: factura rejected via heuristic (CSV verified), DNI-like scan rejected via `short_no_text`, keyword-only paper accepted, LLM mocked for each confidence combo, `--skip-llm-gate` path, budget-exceeded abort, re-runs do not reclassify.
- `tests/test_s1/conftest.py` — `pdf_builder` generalised to N pages; added `factura_1page`, `dni_scanned`, `ambiguous_short`, `paper_keywords` fixture kinds. `scanned` is now 3 pages so it survives the classifier.

## Drive-by fixes

- `_run_inventory_async` now snapshots `Run.id / items_processed / items_failed` before the session closes. Newer SQLAlchemy expires attributes on commit, so accessing `run.id` outside the session raises `DetachedInstanceError`. Without this every stage_01 test fails on `result.run_id`.
- Ruff auto-fix on touched files: `Optional[X]` → `X | None`, `timezone.utc` → `UTC`, sorted `__all__`. No semantic changes.

## Not in scope (pre-existing failures)

Three tests fail on `main` too and remain failing here — caused by newer `pydantic-settings` (list-field env parsing) and SQLAlchemy (SQLite datetime tz roundtrip). Tracking separately:
- `tests/test_config.py::test_settings_reads_env`
- `tests/test_config.py::test_pdf_source_folders_parses_csv`
- `tests/test_state.py::test_s1_item_roundtrip`

## Verification

- `uv run pytest -q` → 75 passed, 3 pre-existing failures.
- `uv run ruff check src/zotai tests/test_s1` on touched files → clean.
- `uv run mypy src/zotai` → no new errors introduced by this PR (3 pre-existing in logging/http/openai_client.embed_text remain).

## Test plan

- [ ] CI green on the 75 tests this PR exercises.
- [ ] Manual: `zotai s1 inventory --folder <mixed folder with papers + facturas>` writes both reports and leaves `state.db` with only academic items.
- [ ] Manual: `--skip-llm-gate` produces no OpenAI calls and keeps ambiguous items as `needs_review`.
- [ ] Manual: `--max-cost 0.0001` aborts cleanly with `StageAbortedError` on the first LLM gate call.

## References

- `docs/plan_01_subsystem1.md` §3 Etapa 01 + §3.1
- `docs/plan_glossary.md` — "Clasificador académico / no-académico", "Excluded report", "Needs review"
- 2026-04-22 alignment review (drift items 1–3)