### PR TITLE
chore: green the test suite — list-env parsing + SQLite tz roundtrip

### DIFF
--- a/src/zotai/config.py
+++ b/src/zotai/config.py
@@ -27,7 +27,7 @@ from pathlib import Path
 from typing import Annotated, Literal
 
 from pydantic import Field, SecretStr, field_validator
-from pydantic_settings import BaseSettings, SettingsConfigDict
+from pydantic_settings import BaseSettings, NoDecode, SettingsConfigDict
 
 _ENV_FILE = ".env"
 _ENV_ENCODING = "utf-8"
@@ -117,7 +117,9 @@ class PathSettings(_GroupBase):
         extra="ignore",
         frozen=True,
     )
-    pdf_source_folders: list[Path] = Field(default_factory=list)
+    # ``NoDecode`` stops pydantic-settings 2.3+ from trying to JSON-parse the
+    # comma-separated env value before our ``_split_csv`` validator runs.
+    pdf_source_folders: Annotated[list[Path], NoDecode] = Field(default_factory=list)
     staging_folder: Path = Path("/workspace/staging")
     state_db: Path = Path("/workspace/state.db")
     reports_folder: Path = Path("/workspace/reports")
@@ -176,7 +178,9 @@ class S2Settings(_GroupBase):
     candidates_db: Path = Path("/workspace/candidates.db")
     chroma_path: Path = Path("/workspace/chroma_db")
     zotero_inbox_collection: str = "Inbox S2"
-    pdf_sources: list[str] = Field(
+    # ``NoDecode`` stops pydantic-settings 2.3+ from trying to JSON-parse the
+    # comma-separated env value before our ``_split_csv`` validator runs.
+    pdf_sources: Annotated[list[str], NoDecode] = Field(
         default_factory=lambda: ["openaccess", "doi", "annas", "libgen", "scihub", "rss"]
     )
     dashboard_host: str = "127.0.0.1"

--- a/src/zotai/state.py
+++ b/src/zotai/state.py
@@ -15,8 +15,10 @@ and evolve via code rather than alembic in v1 (see plan_02 §5).
 from __future__ import annotations
 
 from datetime import UTC, date, datetime
+from typing import Any
 
-from sqlalchemy import MetaData, Table
+from sqlalchemy import DateTime as SADateTime
+from sqlalchemy import MetaData, Table, TypeDecorator
 from sqlalchemy.engine import Engine
 from sqlmodel import Field, SQLModel, create_engine
 
@@ -24,6 +26,35 @@ from sqlmodel import Field, SQLModel, create_engine
 def _utc_now() -> datetime:
     """Timezone-aware UTC timestamp used as default for `created_at` / `updated_at`."""
     return datetime.now(tz=UTC)
+
+
+class UTCDateTime(TypeDecorator[datetime]):
+    """SQLite-safe UTC-aware datetime column.
+
+    SQLite has no native datetime type and SQLAlchemy stores ``datetime``
+    values as ISO-8601 text *without* timezone information, so a
+    roundtrip strips the ``tzinfo`` we set on ``default_factory``. This
+    decorator re-attaches UTC on read and coerces naive binds to UTC on
+    write, so every datetime column behaves as if SQLite supported
+    timezone-aware datetimes natively.
+    """
+
+    impl = SADateTime
+    cache_ok = True
+
+    def process_bind_param(
+        self, value: datetime | None, dialect: Any
+    ) -> datetime | None:
+        if value is not None and value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
+
+    def process_result_value(
+        self, value: datetime | None, dialect: Any
+    ) -> datetime | None:
+        if value is not None and value.tzinfo is None:
+            return value.replace(tzinfo=UTC)
+        return value
 
 
 # ─── S1: state.db ───────────────────────────────────────────────────────────
@@ -54,8 +85,8 @@ class Item(SQLModel, table=True):
     last_error: str | None = None
     metadata_json: str | None = None
     tags_json: str | None = None
-    created_at: datetime = Field(default_factory=_utc_now)
-    updated_at: datetime = Field(default_factory=_utc_now)
+    created_at: datetime = Field(default_factory=_utc_now, sa_type=UTCDateTime)
+    updated_at: datetime = Field(default_factory=_utc_now, sa_type=UTCDateTime)
 
 
 class Run(SQLModel, table=True):
@@ -63,8 +94,8 @@ class Run(SQLModel, table=True):
 
     id: int | None = Field(default=None, primary_key=True)
     stage: int
-    started_at: datetime = Field(default_factory=_utc_now)
-    finished_at: datetime | None = None
+    started_at: datetime = Field(default_factory=_utc_now, sa_type=UTCDateTime)
+    finished_at: datetime | None = Field(default=None, sa_type=UTCDateTime)
     items_processed: int = 0
     items_failed: int = 0
     cost_usd: float = 0.0
@@ -81,7 +112,7 @@ class ApiCall(SQLModel, table=True):
     duration_ms: int = 0
     status: str = "success"  # 'success' | 'error' | 'rate_limited'
     item_id: str | None = Field(default=None, foreign_key="item.id")
-    timestamp: datetime = Field(default_factory=_utc_now)
+    timestamp: datetime = Field(default_factory=_utc_now, sa_type=UTCDateTime)
 
 
 # ─── S2: candidates.db ──────────────────────────────────────────────────────
@@ -97,7 +128,7 @@ class Candidate(SQLModel, table=True):
     authors_json: str
     abstract: str | None = None
     venue: str
-    published_at: datetime
+    published_at: datetime = Field(sa_type=UTCDateTime)
     url: str | None = None
 
     # Scoring (each in [0, 1])
@@ -109,16 +140,16 @@ class Candidate(SQLModel, table=True):
 
     # Triage
     status: str = "pending"  # 'pending' | 'accepted' | 'rejected' | 'deferred'
-    decided_at: datetime | None = None
+    decided_at: datetime | None = Field(default=None, sa_type=UTCDateTime)
     decided_by: str | None = None
     decision_note: str | None = None
 
     # Zotero integration — set once push succeeds
     zotero_item_key: str | None = None
-    pushed_at: datetime | None = None
+    pushed_at: datetime | None = Field(default=None, sa_type=UTCDateTime)
 
-    created_at: datetime = Field(default_factory=_utc_now)
-    updated_at: datetime = Field(default_factory=_utc_now)
+    created_at: datetime = Field(default_factory=_utc_now, sa_type=UTCDateTime)
+    updated_at: datetime = Field(default_factory=_utc_now, sa_type=UTCDateTime)
 
 
 class Feed(SQLModel, table=True):
@@ -129,7 +160,7 @@ class Feed(SQLModel, table=True):
     rss_url: str
     issn: str | None = None
     active: bool = True
-    last_fetched_at: datetime | None = None
+    last_fetched_at: datetime | None = Field(default=None, sa_type=UTCDateTime)
     last_fetch_status: str | None = None
     items_fetched_total: int = 0
 
@@ -141,7 +172,7 @@ class PersistentQuery(SQLModel, table=True):
     query_text: str
     active: bool = True
     weight: float = 1.0
-    created_at: datetime = Field(default_factory=_utc_now)
+    created_at: datetime = Field(default_factory=_utc_now, sa_type=UTCDateTime)
 
 
 class TriageMetric(SQLModel, table=True):


### PR DESCRIPTION
## Summary

Three tests were failing on `main`, all from upstream library behaviour changes:

- `tests/test_config.py::test_settings_reads_env`
- `tests/test_config.py::test_pdf_source_folders_parses_csv`
- `tests/test_state.py::test_s1_item_roundtrip`

After this PR: `uv run pytest -q` → **78 passed, 0 failed** (was 75 passed, 3 failed).

## Fix 1 — pydantic-settings list-field env parsing (#1, #2)

Starting in `pydantic-settings` 2.3, the settings source tries to JSON-decode complex-typed fields (`list[str]`, `list[Path]`) *before* any `@field_validator(mode="before")` runs. The project passes **comma-separated** env values for these:

- `PDF_SOURCE_FOLDERS=/data/a,/data/b`
- `S2_PDF_SOURCES=openaccess,doi,scihub`

Those aren't JSON, so the decode throws `JSONDecodeError`.

Fix: annotate with `pydantic_settings.NoDecode`, which tells the source to hand the raw string through to our existing `_split_csv` validators untouched. Two fields touched (`PathSettings.pdf_source_folders`, `S2Settings.pdf_sources`).

## Fix 2 — SQLite tz roundtrip (#3)

SQLite has no native datetime type; SQLAlchemy stores datetimes as ISO-8601 text without timezone info, so the `tzinfo` set by `_utc_now()` (`datetime.now(tz=UTC)`) is stripped on roundtrip. The test asserts `fetched.created_at.tzinfo is not None`, which fails.

Fix: a tiny `TypeDecorator[datetime]` called `UTCDateTime` in `zotai.state`. It re-attaches `UTC` on read and coerces naive binds to `UTC` on write, so every datetime column behaves as if SQLite supported tz-aware datetimes natively. Applied via `sa_type=UTCDateTime` on every datetime column across `Item`, `Run`, `ApiCall`, `Candidate`, `Feed`, `PersistentQuery`.

Applying it to all columns instead of just the failing one keeps the behaviour uniform — any future code that compares a DB-fetched timestamp against `datetime.now(tz=UTC)` will see tz-aware values on both sides.

## Not in scope

- `uv.lock` is still untracked on `main` — separate chore if you want it in.
- The three remaining mypy errors (`logging.py:90`, `http.py:84`, `openai_client.py:180`) pre-date this PR and this PR doesn't touch those files.

## Test plan

- [x] `uv run pytest -q` → 78 passed.
- [x] `uv run ruff check` on touched files → clean.
- [x] `uv run mypy src/zotai` → no new errors (3 pre-existing remain, unrelated to this PR).