### PR TITLE
feat(s1): Phase 3 — Stage 02 OCR (#4)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **S1 Stage 02 — OCR** (#4): `zotai.s1.stage_02_ocr.run_ocr` walks every
+  item with `has_text=False AND stage_completed=1`, copies the source
+  PDF to `staging/<sha256>.pdf`, runs `ocrmypdf.ocr()` (default
+  `skip_text=True`; `force_ocr=True` with the `--force-ocr` flag), and
+  batches DB updates at the end. OCR happens on `multiprocessing.Pool`
+  with `OCR_PARALLEL_PROCESSES` workers (default 4, overridable with
+  `--parallel N`; `N<=1` runs sequentially). Before the first copy the
+  stage verifies free disk on the staging volume ≥ 2× the corpus size;
+  if not, it aborts cleanly with `StageAbortedError`. Resume-safe: when
+  `staging/<hash>.pdf` already exists with a text layer, the worker
+  skips the `ocrmypdf` call. Items where OCR fails advance to
+  `stage_completed=2` anyway with `ocr_failed=True` and the error in
+  `last_error` so Stage 03 sees them. The CLI command `zotai s1 ocr
+  [--force-ocr] [--parallel N]` is now functional and honours the root
+  `--dry-run` flag (no file I/O, no DB writes, `_dryrun`-suffixed CSV).
+  Per-item reports land in `reports/ocr_report_<ts>.csv`. Tests cover
+  the happy path, the two failure modes (`ocrmypdf` exception + OCR
+  produces no text), no-op on already-processed items, disk-space
+  abort, dry-run, resume semantics, `--force-ocr` flag plumbing, and
+  CLI wiring. `ocrmypdf` is monkeypatched in every test so Tesseract
+  is not a test dependency.
 - **S1 Stage 01 — classifier** (#24): three-branch academic / non-academic
   gate upstream of the rest of the S1 pipeline (plan_01 §3.1).
   (1) Positive heuristic — zero-cost accept on DOI / arXiv / valid ISBN

--- a/src/zotai/cli.py
+++ b/src/zotai/cli.py
@@ -163,12 +163,52 @@ def s1_inventory(
 
 @s1_app.command("ocr")
 def s1_ocr(
-    force_ocr: Annotated[bool, typer.Option("--force-ocr")] = False,
-    parallel: Annotated[int | None, typer.Option("--parallel")] = None,
+    ctx: typer.Context,
+    force_ocr: Annotated[
+        bool,
+        typer.Option(
+            "--force-ocr",
+            help=(
+                "Re-OCR pages that already carry text. Default mode passes "
+                "skip_text=True to ocrmypdf so existing text layers survive."
+            ),
+        ),
+    ] = False,
+    parallel: Annotated[
+        int | None,
+        typer.Option(
+            "--parallel",
+            help=(
+                "Number of ocrmypdf workers. Defaults to "
+                "OCR_PARALLEL_PROCESSES; pass 1 to run sequentially."
+            ),
+        ),
+    ] = None,
 ) -> None:
-    """Stage 02 — OCR scanned PDFs."""
-    _ = force_ocr, parallel
-    _not_implemented("s1 ocr", 3, 4)
+    """Stage 02 — OCR scanned PDFs into the staging volume."""
+    from zotai.config import Settings
+    from zotai.s1.handler import StageAbortedError
+    from zotai.s1.stage_02_ocr import run_ocr
+
+    settings = Settings()
+    dry_run = bool(ctx.obj.get("dry_run", False)) or settings.behavior.dry_run
+
+    try:
+        result = run_ocr(
+            force_ocr=force_ocr,
+            parallel=parallel,
+            dry_run=dry_run,
+            settings=settings,
+        )
+    except StageAbortedError as exc:
+        typer.secho(f"Stage aborted: {exc}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=2) from exc
+
+    typer.echo(
+        f"processed={result.items_processed} failed={result.items_failed} "
+        f"applied={result.items_applied} resumed={result.items_resumed} "
+        f"csv={result.csv_path}"
+    )
 
 
 @s1_app.command("import")

--- a/src/zotai/s1/stage_02_ocr.py
+++ b/src/zotai/s1/stage_02_ocr.py
@@ -1,0 +1,441 @@
+"""Stage 02 — OCR: apply Tesseract to scanned PDFs via ``ocrmypdf``.
+
+Runs on items left by Stage 01 with ``has_text=False`` and
+``stage_completed=1`` — the PDFs the academic classifier accepted but
+that `pdfplumber` could not extract text from. After this stage those
+items either have a text layer (``has_text=True``, copy lives at
+``staging/<hash>.pdf``) or are flagged ``ocr_failed=True`` with a
+``last_error`` message. Either way ``stage_completed`` advances to 2 so
+Stage 03 can decide what to do with them.
+
+Cross-cutting rules from plan_01 §3 Etapa 02:
+
+- **Idempotent.** Items already at ``stage_completed >= 2`` are not
+  re-queried. Re-running the stage on the same DB is a no-op.
+- **Resume-safe.** If ``staging/<hash>.pdf`` already exists *and* has a
+  text layer, the worker skips the ``ocrmypdf`` call entirely — an
+  earlier partial run already did the expensive work.
+- **Originals are never mutated.** All OCR happens on a copy under the
+  ``STAGING_FOLDER`` volume; the user's source PDFs stay untouched.
+- **Disk-aware.** Before running, the stage checks that the free space
+  on the staging volume is at least ``2 * sum(size_bytes)`` of the
+  eligible items. If not, it aborts with a clear message *before* any
+  copy or OCR happens.
+- **CPU-bound parallelism.** OCR is the only stage with meaningful
+  internal parallelism (``multiprocessing.Pool`` with
+  ``OCR_PARALLEL_PROCESSES`` workers, default 4). SQLite is not
+  thread-safe, so workers return plain dataclasses; the main process
+  applies them in a single DB transaction at the end.
+- **``--force-ocr`` reprocesses.** Default mode passes ``skip_text=True``
+  to ``ocrmypdf`` so pages that already carry text are left alone.
+  Passing ``force_ocr=True`` re-OCRs everything — useful when a prior
+  OCR pass produced junk (plan_01 §3 Etapa 02 Edge cases).
+"""
+
+from __future__ import annotations
+
+import csv
+import shutil
+import time
+from collections.abc import Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from multiprocessing import Pool
+from pathlib import Path
+from typing import Final, Literal
+
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, select
+
+from zotai.config import Settings
+from zotai.s1.handler import StageAbortedError
+from zotai.state import Item, Run, init_s1, make_s1_engine
+from zotai.utils.fs import disk_space_available, ensure_dir
+from zotai.utils.logging import bind, get_logger
+from zotai.utils.pdf import has_text_layer
+
+log = get_logger(__name__)
+
+_STAGE: Final[int] = 2
+_PREREQ_STAGE: Final[int] = 1
+_DISK_SAFETY_MULTIPLIER: Final[int] = 2
+
+
+OcrStatus = Literal[
+    "ok",
+    "resumed",
+    "failed",
+    "dry_run",
+]
+
+_CSV_COLUMNS: Final[tuple[str, ...]] = (
+    "sha256",
+    "source_path",
+    "staging_path",
+    "status",
+    "has_text_post",
+    "duration_ms",
+    "error",
+)
+
+
+@dataclass(frozen=True)
+class _WorkUnit:
+    """Immutable input to ``_process_one`` — picklable for ``multiprocessing.Pool``."""
+
+    sha256: str
+    source_path: str
+    staging_path: str
+    languages: str
+    force_ocr: bool
+
+
+@dataclass(frozen=True)
+class _WorkResult:
+    """Immutable output from ``_process_one``. The main process applies it to the DB."""
+
+    sha256: str
+    status: OcrStatus
+    has_text_post: bool
+    duration_ms: int
+    error: str | None
+
+
+@dataclass(frozen=True)
+class OcrRow:
+    """One row in ``ocr_report_<ts>.csv``."""
+
+    sha256: str
+    source_path: str
+    staging_path: str
+    status: OcrStatus
+    has_text_post: bool
+    duration_ms: int
+    error: str | None
+
+
+@dataclass(frozen=True)
+class OcrResult:
+    """Aggregate outcome of one ``run_ocr`` call."""
+
+    run_id: int | None
+    rows: list[OcrRow]
+    csv_path: Path
+    items_processed: int
+    items_failed: int
+    items_applied: int
+    items_resumed: int
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _csv_path(reports_dir: Path, *, dry_run: bool, now: datetime) -> Path:
+    suffix = "_dryrun" if dry_run else ""
+    timestamp = now.strftime("%Y%m%d_%H%M%S")
+    return reports_dir / f"ocr_report_{timestamp}{suffix}.csv"
+
+
+def _write_csv(csv_path: Path, rows: Iterable[OcrRow]) -> None:
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(_CSV_COLUMNS))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "sha256": row.sha256,
+                    "source_path": row.source_path,
+                    "staging_path": row.staging_path,
+                    "status": row.status,
+                    "has_text_post": "true" if row.has_text_post else "false",
+                    "duration_ms": row.duration_ms,
+                    "error": row.error or "",
+                }
+            )
+
+
+def _process_one(unit: _WorkUnit) -> _WorkResult:
+    """Worker: copy source → staging, run ``ocrmypdf.ocr``, verify, return result.
+
+    Kept at module top level so it can be pickled by ``multiprocessing``
+    when ``parallel > 1``. Does *not* touch the database. The main
+    process applies the returned ``_WorkResult`` in a single transaction.
+
+    ``ocrmypdf`` is imported lazily: the import hooks into ``pdfminer.six``
+    (used by ``pdfplumber``) and changes how Type-1 fonts without a
+    ``ToUnicode`` map decode back to text. Our hand-crafted fixture PDFs
+    rely on the default decoder, so deferring the import keeps Stage 01
+    tests (which run before Stage 02 tests) safe.
+    """
+    import ocrmypdf
+
+    start = time.monotonic()
+    staging = Path(unit.staging_path)
+    source = Path(unit.source_path)
+
+    # Ensure the staging copy exists. If it's already there from a prior
+    # (interrupted) run *and* already carries a text layer, skip the
+    # expensive OCR call.
+    try:
+        if not staging.exists():
+            staging.parent.mkdir(parents=True, exist_ok=True)
+            shutil.copy2(source, staging)
+        elif not unit.force_ocr and has_text_layer(staging):
+            duration = int((time.monotonic() - start) * 1000)
+            return _WorkResult(
+                sha256=unit.sha256,
+                status="resumed",
+                has_text_post=True,
+                duration_ms=duration,
+                error=None,
+            )
+    except OSError as exc:
+        duration = int((time.monotonic() - start) * 1000)
+        return _WorkResult(
+            sha256=unit.sha256,
+            status="failed",
+            has_text_post=False,
+            duration_ms=duration,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    languages = [part.strip() for part in unit.languages.split("+") if part.strip()]
+    try:
+        if unit.force_ocr:
+            ocrmypdf.ocr(
+                str(staging),
+                str(staging),
+                language=languages,
+                force_ocr=True,
+                progress_bar=False,
+            )
+        else:
+            ocrmypdf.ocr(
+                str(staging),
+                str(staging),
+                language=languages,
+                skip_text=True,
+                progress_bar=False,
+            )
+    except Exception as exc:  # OCR failures are per-item, not fatal
+        duration = int((time.monotonic() - start) * 1000)
+        return _WorkResult(
+            sha256=unit.sha256,
+            status="failed",
+            has_text_post=False,
+            duration_ms=duration,
+            error=f"{type(exc).__name__}: {exc}",
+        )
+
+    post_has_text = has_text_layer(staging)
+    duration = int((time.monotonic() - start) * 1000)
+    if post_has_text:
+        return _WorkResult(
+            sha256=unit.sha256,
+            status="ok",
+            has_text_post=True,
+            duration_ms=duration,
+            error=None,
+        )
+    return _WorkResult(
+        sha256=unit.sha256,
+        status="failed",
+        has_text_post=False,
+        duration_ms=duration,
+        error="no_text_after_ocr",
+    )
+
+
+def _select_eligible(session: Session) -> list[Item]:
+    """Items that Stage 01 left without text, still waiting for Stage 02."""
+    stmt = (
+        select(Item)
+        .where(Item.has_text == False)  # noqa: E712 — SQL boolean compare
+        .where(Item.stage_completed == _PREREQ_STAGE)
+    )
+    return list(session.exec(stmt))
+
+
+def run_ocr(
+    *,
+    force_ocr: bool = False,
+    parallel: int | None = None,
+    dry_run: bool = False,
+    settings: Settings | None = None,
+    engine: Engine | None = None,
+    worker: Callable[[_WorkUnit], _WorkResult] = _process_one,
+    now: Callable[[], datetime] = _utc_now,
+) -> OcrResult:
+    """Run Stage 02 over every eligible item in ``state.db``.
+
+    Args:
+        force_ocr: When True, ``ocrmypdf`` is called with
+            ``force_ocr=True`` (re-OCR pages that already carry text).
+            Default mode passes ``skip_text=True`` so pages with text
+            survive untouched.
+        parallel: Number of workers. ``None`` reads
+            ``settings.ocr.parallel_processes``. ``parallel <= 1``
+            skips ``multiprocessing.Pool`` and runs the workers
+            sequentially in the calling process — useful under tests
+            where pytest monkeypatches don't cross process boundaries.
+        dry_run: Reports what would be done. No file copies, no OCR
+            calls, no DB writes. Writes a ``_dryrun``-suffixed CSV.
+        settings: Override for ``Settings()``.
+        engine: Override for the default engine bound to
+            ``settings.paths.state_db``.
+        worker: Worker callable. Tests inject a fake; production uses
+            :func:`_process_one`.
+        now: Clock — overridable for tests.
+
+    Raises:
+        StageAbortedError: Free disk on the staging volume is under
+            ``2 * sum(size_bytes)`` of the eligible items. Raised
+            *before* any copy or OCR happens.
+    """
+    settings = settings or Settings()
+    effective_parallel = (
+        parallel if parallel is not None else settings.ocr.parallel_processes
+    )
+    if engine is None:
+        engine = make_s1_engine(str(settings.paths.state_db))
+        init_s1(engine)
+
+    run = Run(stage=_STAGE, status="running", started_at=now())
+    rows: list[OcrRow] = []
+
+    bind(stage=_STAGE, dry_run=dry_run)
+    log.info("stage_started", parallel=effective_parallel, force_ocr=force_ocr)
+
+    with Session(engine) as session:
+        if not dry_run:
+            session.add(run)
+            session.flush()
+
+        try:
+            items = _select_eligible(session)
+            log.info("stage_02.eligible_items", count=len(items))
+
+            if items:
+                staging_dir = ensure_dir(settings.paths.staging_folder)
+                required_bytes = (
+                    sum(i.size_bytes for i in items) * _DISK_SAFETY_MULTIPLIER
+                )
+                available_bytes = disk_space_available(staging_dir)
+                if available_bytes < required_bytes:
+                    raise StageAbortedError(
+                        "Insufficient disk space on staging volume: "
+                        f"need {required_bytes} bytes (2x corpus size), "
+                        f"have {available_bytes}."
+                    )
+
+                units = [
+                    _WorkUnit(
+                        sha256=item.id,
+                        source_path=item.source_path,
+                        staging_path=str(staging_dir / f"{item.id}.pdf"),
+                        languages=settings.ocr.languages,
+                        force_ocr=force_ocr,
+                    )
+                    for item in items
+                ]
+
+                if dry_run:
+                    results = [
+                        _WorkResult(
+                            sha256=u.sha256,
+                            status="dry_run",
+                            has_text_post=False,
+                            duration_ms=0,
+                            error=None,
+                        )
+                        for u in units
+                    ]
+                elif effective_parallel <= 1:
+                    results = [worker(u) for u in units]
+                else:
+                    with Pool(effective_parallel) as pool:
+                        results = list(pool.map(worker, units))
+
+                by_id = {item.id: item for item in items}
+                for unit, work_result in zip(units, results, strict=True):
+                    item = by_id[work_result.sha256]
+                    rows.append(
+                        OcrRow(
+                            sha256=work_result.sha256,
+                            source_path=item.source_path,
+                            staging_path=unit.staging_path,
+                            status=work_result.status,
+                            has_text_post=work_result.has_text_post,
+                            duration_ms=work_result.duration_ms,
+                            error=work_result.error,
+                        )
+                    )
+                    if dry_run or work_result.status == "dry_run":
+                        continue
+
+                    item.updated_at = now()
+                    if work_result.status in ("ok", "resumed"):
+                        item.has_text = True
+                        item.ocr_failed = False
+                        item.last_error = None
+                        item.stage_completed = max(item.stage_completed, _STAGE)
+                        run.items_processed += 1
+                    elif work_result.status == "failed":
+                        # Spec: advance stage_completed to 2 anyway so
+                        # Stage 03 sees the item, but leave ocr_failed
+                        # set so downstream stages can route it.
+                        item.has_text = False
+                        item.ocr_failed = True
+                        item.last_error = work_result.error
+                        item.stage_completed = max(item.stage_completed, _STAGE)
+                        run.items_failed += 1
+
+            run.status = "succeeded"
+        except StageAbortedError:
+            run.status = "aborted"
+            raise
+        except Exception:
+            run.status = "failed"
+            raise
+        finally:
+            run.finished_at = now()
+            if not dry_run:
+                session.commit()
+
+        # Snapshot Run state while the session is still open — same
+        # DetachedInstanceError workaround as Stage 01.
+        run_id = run.id
+        items_processed = run.items_processed
+        items_failed = run.items_failed
+
+    reports_folder = ensure_dir(settings.paths.reports_folder)
+    csv_path = _csv_path(reports_folder, dry_run=dry_run, now=now())
+    _write_csv(csv_path, rows)
+
+    result = OcrResult(
+        run_id=run_id,
+        rows=rows,
+        csv_path=csv_path,
+        items_processed=items_processed,
+        items_failed=items_failed,
+        items_applied=sum(1 for r in rows if r.status == "ok"),
+        items_resumed=sum(1 for r in rows if r.status == "resumed"),
+    )
+    log.info(
+        "stage_finished",
+        processed=result.items_processed,
+        failed=result.items_failed,
+        applied=result.items_applied,
+        resumed=result.items_resumed,
+        csv=str(csv_path),
+    )
+    return result
+
+
+__all__ = [
+    "OcrResult",
+    "OcrRow",
+    "OcrStatus",
+    "run_ocr",
+]

--- a/tests/test_s1/test_stage_02.py
+++ b/tests/test_s1/test_stage_02.py
@@ -1,0 +1,405 @@
+"""Tests for :mod:`zotai.s1.stage_02_ocr`.
+
+These tests run sequentially (``parallel=1``) so pytest monkeypatches
+apply: ``multiprocessing.Pool`` spawns fresh processes that would lose
+module-level patches. The sequential path exercises the same worker
+function (:func:`_process_one`) so the coverage is the same.
+"""
+
+from __future__ import annotations
+
+import csv
+from collections.abc import Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlmodel import Session, select
+from typer.testing import CliRunner
+
+from zotai.cli import app
+from zotai.config import OcrSettings, PathSettings, Settings
+from zotai.s1 import stage_02_ocr as mod
+from zotai.s1.handler import StageAbortedError
+from zotai.s1.stage_02_ocr import run_ocr
+from zotai.state import Item, Run, init_s1, make_s1_engine
+
+
+def _settings(tmp_path: Path, *, parallel: int = 1) -> Settings:
+    return Settings(
+        paths=PathSettings(
+            state_db=tmp_path / "state.db",
+            reports_folder=tmp_path / "reports",
+            staging_folder=tmp_path / "staging",
+            pdf_source_folders=[],
+        ),
+        ocr=OcrSettings(languages="spa+eng", parallel_processes=parallel),
+    )
+
+
+def _seed_item(
+    settings: Settings,
+    pdf_path: Path,
+    *,
+    has_text: bool = False,
+    stage_completed: int = 1,
+    sha: str | None = None,
+    size_bytes: int = 4096,
+) -> str:
+    """Insert one Item row that Stage 02 will pick up; return its sha256."""
+    engine = make_s1_engine(str(settings.paths.state_db))
+    init_s1(engine)
+    item_id = sha or ("a" * 64)
+    with Session(engine) as session:
+        session.add(
+            Item(
+                id=item_id,
+                source_path=str(pdf_path),
+                size_bytes=size_bytes,
+                has_text=has_text,
+                stage_completed=stage_completed,
+            )
+        )
+        session.commit()
+    return item_id
+
+
+def _fake_ocr_success(*_: Any, **__: Any) -> int:
+    """Stand-in for ``ocrmypdf.ocr`` that silently succeeds."""
+    return 0
+
+
+def _fake_ocr_failure(*_: Any, **__: Any) -> int:
+    raise RuntimeError("tesseract exploded")
+
+
+# ─── happy paths ────────────────────────────────────────────────────────────
+
+
+def test_eligible_item_gets_ocr_applied(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_pdf = pdf_builder("scanned", directory=tmp_path / "pdfs")
+    settings = _settings(tmp_path)
+    _seed_item(settings, source_pdf)
+
+    monkeypatch.setattr("ocrmypdf.ocr", _fake_ocr_success)
+    # Simulate that post-OCR the staging copy has text.
+    monkeypatch.setattr(mod, "has_text_layer", lambda _p: True)
+
+    result = run_ocr(settings=settings, parallel=1)
+
+    assert result.items_processed == 1
+    assert result.items_failed == 0
+    assert result.items_applied == 1
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.has_text is True
+    assert item.ocr_failed is False
+    assert item.stage_completed == 2
+    assert (settings.paths.staging_folder / f"{item.id}.pdf").exists()
+
+
+def test_ocr_failure_advances_stage_and_marks_ocr_failed(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_pdf = pdf_builder("scanned", directory=tmp_path / "pdfs")
+    settings = _settings(tmp_path)
+    _seed_item(settings, source_pdf)
+
+    monkeypatch.setattr("ocrmypdf.ocr", _fake_ocr_failure)
+    # has_text_layer wouldn't be called on the failure path, but be safe.
+    monkeypatch.setattr(mod, "has_text_layer", lambda _p: False)
+
+    result = run_ocr(settings=settings, parallel=1)
+
+    assert result.items_processed == 0
+    assert result.items_failed == 1
+    assert result.items_applied == 0
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    # Spec: advance stage_completed anyway so Stage 03 sees the item.
+    assert item.stage_completed == 2
+    assert item.ocr_failed is True
+    assert item.has_text is False
+    assert item.last_error is not None and "tesseract" in item.last_error
+
+
+def test_ocr_produces_no_text_is_failure(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """OCR call returns cleanly but post-verify finds no text → ``failed``."""
+    source_pdf = pdf_builder("scanned", directory=tmp_path / "pdfs")
+    settings = _settings(tmp_path)
+    _seed_item(settings, source_pdf)
+
+    monkeypatch.setattr("ocrmypdf.ocr", _fake_ocr_success)
+    monkeypatch.setattr(mod, "has_text_layer", lambda _p: False)
+
+    result = run_ocr(settings=settings, parallel=1)
+
+    assert result.items_failed == 1
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.ocr_failed is True
+    assert item.last_error == "no_text_after_ocr"
+
+
+# ─── filtering / no-op paths ────────────────────────────────────────────────
+
+
+def test_no_eligible_items_is_noop(tmp_path: Path) -> None:
+    """Empty DB → no rows, no CSV error, run marked succeeded."""
+    settings = _settings(tmp_path)
+    # Create empty DB.
+    engine = make_s1_engine(str(settings.paths.state_db))
+    init_s1(engine)
+
+    result = run_ocr(settings=settings, parallel=1)
+
+    assert result.items_processed == 0
+    assert result.items_failed == 0
+    assert result.rows == []
+    assert result.csv_path.exists()
+
+
+def test_item_with_has_text_true_is_skipped(
+    pdf_builder: Callable[..., Path], tmp_path: Path
+) -> None:
+    """Stage 01 already extracted text → OCR must not touch it."""
+    source_pdf = pdf_builder("text_doi", directory=tmp_path / "pdfs")
+    settings = _settings(tmp_path)
+    _seed_item(settings, source_pdf, has_text=True)
+
+    result = run_ocr(settings=settings, parallel=1)
+
+    assert result.rows == []
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.stage_completed == 1  # unchanged — Stage 02 skipped it
+
+
+def test_item_at_stage_2_is_skipped(
+    pdf_builder: Callable[..., Path], tmp_path: Path
+) -> None:
+    """Re-running the stage on already-processed items is a no-op."""
+    source_pdf = pdf_builder("scanned", directory=tmp_path / "pdfs")
+    settings = _settings(tmp_path)
+    _seed_item(settings, source_pdf, stage_completed=2)
+
+    result = run_ocr(settings=settings, parallel=1)
+
+    assert result.rows == []
+
+
+# ─── resume-safety ──────────────────────────────────────────────────────────
+
+
+def test_resumed_path_skips_ocr_when_staging_has_text(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_pdf = pdf_builder("scanned", directory=tmp_path / "pdfs")
+    settings = _settings(tmp_path)
+    sha = _seed_item(settings, source_pdf)
+
+    # Pre-populate staging with an arbitrary PDF and pretend it has text.
+    settings.paths.staging_folder.mkdir(parents=True, exist_ok=True)
+    (settings.paths.staging_folder / f"{sha}.pdf").write_bytes(b"%PDF-1.4\n")
+    monkeypatch.setattr(mod, "has_text_layer", lambda _p: True)
+
+    calls: dict[str, int] = {"ocr": 0}
+
+    def _ocr_counted(*_: Any, **__: Any) -> int:
+        calls["ocr"] += 1
+        return 0
+
+    monkeypatch.setattr("ocrmypdf.ocr", _ocr_counted)
+
+    result = run_ocr(settings=settings, parallel=1)
+
+    assert calls["ocr"] == 0, "ocrmypdf must not run on resumed path"
+    assert result.items_resumed == 1
+    assert result.items_processed == 1
+
+
+# ─── disk-space guard ──────────────────────────────────────────────────────
+
+
+def test_insufficient_disk_space_aborts(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_pdf = pdf_builder("scanned", directory=tmp_path / "pdfs")
+    settings = _settings(tmp_path)
+    _seed_item(settings, source_pdf, size_bytes=10_000_000)
+
+    monkeypatch.setattr(mod, "disk_space_available", lambda _p: 1024)
+
+    with pytest.raises(StageAbortedError):
+        run_ocr(settings=settings, parallel=1)
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        run_row = session.exec(select(Run)).one()
+    assert run_row.status == "aborted"
+
+
+# ─── dry-run ───────────────────────────────────────────────────────────────
+
+
+def test_dry_run_makes_no_filesystem_or_db_writes(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_pdf = pdf_builder("scanned", directory=tmp_path / "pdfs")
+    settings = _settings(tmp_path)
+    _seed_item(settings, source_pdf)
+
+    def _forbidden(*_: Any, **__: Any) -> int:
+        raise AssertionError("ocrmypdf must not be called in dry-run")
+
+    monkeypatch.setattr("ocrmypdf.ocr", _forbidden)
+
+    result = run_ocr(settings=settings, parallel=1, dry_run=True)
+
+    assert result.csv_path.name.endswith("_dryrun.csv")
+    # No staging copy written.
+    assert not (settings.paths.staging_folder / f"{'a' * 64}.pdf").exists()
+    # DB row unchanged.
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.stage_completed == 1
+    assert item.has_text is False
+
+
+# ─── CSV shape ──────────────────────────────────────────────────────────────
+
+
+def test_csv_has_expected_columns(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_pdf = pdf_builder("scanned", directory=tmp_path / "pdfs")
+    settings = _settings(tmp_path)
+    _seed_item(settings, source_pdf)
+
+    monkeypatch.setattr("ocrmypdf.ocr", _fake_ocr_success)
+    monkeypatch.setattr(mod, "has_text_layer", lambda _p: True)
+
+    result = run_ocr(settings=settings, parallel=1)
+
+    with result.csv_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert reader.fieldnames is not None
+    assert set(reader.fieldnames) == {
+        "sha256",
+        "source_path",
+        "staging_path",
+        "status",
+        "has_text_post",
+        "duration_ms",
+        "error",
+    }
+    assert len(rows) == 1
+    assert rows[0]["status"] == "ok"
+
+
+# ─── force-ocr flag ────────────────────────────────────────────────────────
+
+
+def test_force_ocr_sets_force_flag_and_skips_skip_text(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    """--force-ocr passes force_ocr=True and omits skip_text (they're exclusive)."""
+    source_pdf = pdf_builder("scanned", directory=tmp_path / "pdfs")
+    settings = _settings(tmp_path)
+    _seed_item(settings, source_pdf)
+
+    captured_kwargs: dict[str, Any] = {}
+
+    def _capture(*args: Any, **kwargs: Any) -> int:
+        captured_kwargs.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("ocrmypdf.ocr", _capture)
+    monkeypatch.setattr(mod, "has_text_layer", lambda _p: True)
+
+    run_ocr(settings=settings, parallel=1, force_ocr=True)
+
+    assert captured_kwargs.get("force_ocr") is True
+    assert "skip_text" not in captured_kwargs
+
+
+def test_default_mode_uses_skip_text(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_pdf = pdf_builder("scanned", directory=tmp_path / "pdfs")
+    settings = _settings(tmp_path)
+    _seed_item(settings, source_pdf)
+
+    captured_kwargs: dict[str, Any] = {}
+
+    def _capture(*args: Any, **kwargs: Any) -> int:
+        captured_kwargs.update(kwargs)
+        return 0
+
+    monkeypatch.setattr("ocrmypdf.ocr", _capture)
+    monkeypatch.setattr(mod, "has_text_layer", lambda _p: True)
+
+    run_ocr(settings=settings, parallel=1, force_ocr=False)
+
+    assert captured_kwargs.get("skip_text") is True
+    assert "force_ocr" not in captured_kwargs
+    # Languages are split on "+" because ocrmypdf's Python API wants a list.
+    assert captured_kwargs.get("language") == ["spa", "eng"]
+
+
+# ─── CLI ───────────────────────────────────────────────────────────────────
+
+
+def test_cli_runs_stage_02(
+    pdf_builder: Callable[..., Path],
+    tmp_path: Path,
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    source_pdf = pdf_builder("scanned", directory=tmp_path / "pdfs")
+    settings = _settings(tmp_path)
+    _seed_item(settings, source_pdf)
+
+    monkeypatch.setattr("ocrmypdf.ocr", _fake_ocr_success)
+    monkeypatch.setattr(mod, "has_text_layer", lambda _p: True)
+    monkeypatch.setenv("STATE_DB", str(settings.paths.state_db))
+    monkeypatch.setenv("REPORTS_FOLDER", str(settings.paths.reports_folder))
+    monkeypatch.setenv("STAGING_FOLDER", str(settings.paths.staging_folder))
+    monkeypatch.setenv("OCR_PARALLEL_PROCESSES", "1")
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["s1", "ocr"])
+
+    assert result.exit_code == 0, result.output
+    assert "processed=1" in result.output
+    assert "applied=1" in result.output


### PR DESCRIPTION
Closes #4.

## Summary

Apply Tesseract via `ocrmypdf` to items Stage 01 accepted but `pdfplumber` could not read (`has_text=False AND stage_completed=1`). After this stage, those items either gain a text layer (`has_text=True`, copy at `staging/<sha>.pdf`) or are flagged `ocr_failed=True` with the error in `last_error`; either way `stage_completed` advances to 2 so Stage 03 sees them.

## Key design points

- **Originals are never mutated.** Everything OCR'd is a copy under `STAGING_FOLDER`.
- **Disk-aware.** Before the first copy, free bytes on the staging volume must be ≥ `2 * sum(size_bytes)`. Otherwise `StageAbortedError` before any work.
- **Resume-safe.** If `staging/<hash>.pdf` already exists *and* has a text layer from a prior interrupted run, the worker skips the `ocrmypdf` call.
- **CPU-bound parallelism.** `multiprocessing.Pool` with `OCR_PARALLEL_PROCESSES` workers (default 4). `parallel=1` short-circuits to a sequential loop so pytest monkeypatches cross the boundary cleanly.
- **Lazy `ocrmypdf` import.** See the gotcha below.

## The `ocrmypdf` / `pdfplumber` gotcha

Importing `ocrmypdf` at module level *reconfigures `pdfminer.six`* (the PDF parser `pdfplumber` uses internally). Type-1 fonts without a `ToUnicode` map stop decoding back to ASCII — our hand-crafted Stage 01 fixture PDFs end up returning `(cid:NN)` sequences instead of text, which breaks DOI extraction in Stage 01 tests when both files are collected together.

Fix: defer `import ocrmypdf` to the body of `_process_one` (module-level import removed). Tests monkeypatch via the string path `"ocrmypdf.ocr"`, which also imports ocrmypdf lazily at test run-time. Because test files collect alphabetically, `test_stage_01.py` runs before `test_stage_02.py`, so by the time ocrmypdf is imported the Stage 01 suite is done.

Commented in `_process_one`'s docstring so the next reader doesn't try to hoist the import back to module level.

## Files

- `src/zotai/s1/stage_02_ocr.py` — new module. `run_ocr`, `_process_one`, `_WorkUnit`/`_WorkResult` dataclasses, `OcrResult`, CSV writer.
- `src/zotai/cli.py` — `zotai s1 ocr [--force-ocr] [--parallel N]` wired to `run_ocr`; replaces the previous `_not_implemented` stub.
- `tests/test_s1/test_stage_02.py` — 13 new tests.
- `CHANGELOG.md` — Unreleased entry.

## Test plan

- [x] `uv run pytest -q` → **91 passed, 0 failed**.
- [x] `uv run ruff check` on touched files → clean.
- [x] `uv run mypy src/zotai` → 3 pre-existing errors remain (`logging.py:90`, `http.py:84`, `openai_client.py:180`), none introduced by this PR.

Coverage added:
- happy path (OCR applied)
- `ocrmypdf` raises → marked `ocr_failed`, advance stage anyway
- OCR call succeeds but produces no text → marked `ocr_failed`
- no-op paths: no eligible items; items with `has_text=True`; items already at stage 2
- resume: staging file exists with text → skip ocrmypdf
- disk-space abort
- dry-run: no copies, no ocr calls, `_dryrun`-suffixed CSV
- kwargs plumbing: `--force-ocr` passes `force_ocr=True`; default passes `skip_text=True`; `language` is split to `["spa", "eng"]`
- CLI smoke test

## References

- `docs/plan_01_subsystem1.md` §3 Etapa 02
- Issue #4