### PR TITLE
docs(s1): Ruta A uses OpenAlex for DOI → metadata (ADR 010)

### DIFF
--- a/docs/decisions/010-ruta-a-openalex-not-zotero-translator.md
+++ b/docs/decisions/010-ruta-a-openalex-not-zotero-translator.md
@@ -1,0 +1,189 @@
+# ADR 010 — Ruta A uses OpenAlex, not Zotero's translator chain
+
+**Status**: Accepted
+**Date**: 2026-04-22
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+Stage 03 of Subsystem 1 (plan_01 §3 Etapa 03) imports PDFs into Zotero
+via two routes: **Ruta A** when a DOI was detected in Stage 01, and
+**Ruta C** (orphan attachment, enriched later in Stage 04) for
+everything else. The purpose of Ruta A is to produce a fully-populated
+bibliographic item in one shot — title, authors, year, venue, abstract
+— without waiting for the enrichment cascade.
+
+Earlier versions of the spec described Ruta A as:
+
+> Llamar Zotero API `POST /items` con `{itemType: 'journalArticle',
+> DOI: detected_doi}` via translator chain → recupera metadata.
+
+This phrasing implies that posting an item with only a DOI to Zotero's
+standard API will trigger Zotero's **translator** to fetch and fill in
+the metadata. That implication is incorrect. Zotero's translator
+machinery lives in two places:
+
+- The Zotero Desktop UI ("Retrieve metadata for this item" / the
+  magic-wand icon).
+- The local connector endpoints at `http://localhost:23119/connector/*`
+  that Zotero's browser extensions use when a user hits "Save to Zotero"
+  on a journal page.
+
+The standard data API (`/users/<id>/items`, which is what `pyzotero`
+wraps) simply stores the fields you give it. A POST with only
+`{itemType, DOI}` creates a barebones item whose only populated field is
+the DOI — useless as a bibliographic record.
+
+So the spec as written could not be implemented literally. We have to
+pick an actual mechanism for DOI → metadata.
+
+This is exactly the same situation we faced with **Ruta B** earlier in
+the project (see `plan_01_subsystem1.md` §3 Etapa 03 "Nota — ausencia
+de Ruta B" and the PR #22 discussion): a route that depends on Zotero's
+connector/recognizer endpoints is depending on a non-public,
+version-fragile surface. Ruta B was removed for that reason; the same
+reasoning applies here to any "use Zotero's translator" implementation
+of Ruta A.
+
+## Decision
+
+**Ruta A resolves DOI → metadata via OpenAlex's public API**
+(`GET https://api.openalex.org/works/doi:<doi>`), then writes the full
+bibliographic record to Zotero using `pyzotero.create_items([{...}])`.
+
+Concretely:
+
+1. `zotai.api.openalex.OpenAlexClient.work_by_doi(doi)` → returns an
+   OpenAlex `Work` object (JSON) or `None` on 404.
+2. A small mapper translates OpenAlex fields to Zotero's item schema
+   (title, authors as `[{creatorType: 'author', firstName, lastName}]`,
+   DOI, year from `publication_year`, venue from
+   `primary_location.source.display_name`, abstract from
+   `abstract_inverted_index` reconstructed, item_type from OpenAlex's
+   `type` field mapped onto Zotero's `itemType` enum).
+3. Quality gate: if the mapped record lacks a non-empty `title` or has
+   zero authors, the item is *not* created via Ruta A — it falls through
+   to Ruta C (orphan attachment) and Stage 04 takes over.
+4. On a valid record: `pyzotero.create_items([record])` → Zotero returns
+   the new `item_key` → we attach the PDF with
+   `pyzotero.attachment_simple([pdf_path], parent_key=item_key)`.
+
+Ruta C absorbs the failure modes: DOI not in OpenAlex, OpenAlex returns
+a record without title/authors, network error after retries.
+
+## Consequences
+
+### Positive
+
+- **Reliable interface.** OpenAlex's REST API is documented, versioned,
+  and rate-limited predictably. No dependency on Zotero Desktop
+  internals.
+- **Reuses existing code.** `OpenAlexClient.work_by_doi` was implemented
+  in Phase 1 as part of the shared infrastructure (`#2`). Stage 03 does
+  not need a new HTTP client or schema.
+- **Symmetric with Stage 04b.** Stage 04b also queries OpenAlex (by
+  title instead of DOI) when Ruta C items need enrichment. Items
+  processed via Ruta A and items recovered via Stage 04b end up with
+  metadata from the same source — uniform quality and vocabulary across
+  the library.
+- **Covers the target audience.** OpenAlex ingests CrossRef, DataCite,
+  arXiv, PMC, and PubMed. Coverage of DOIs for journal articles,
+  preprints, and theses in the researcher's corpus is expected to
+  exceed 98%. The remaining ~2% (monographs with publisher-specific
+  DOIs, very recent DOIs not yet propagated) fall to Ruta C → Stage 04
+  cascade, which tries multiple fallbacks.
+- **Consistent failure semantics.** When Ruta A fails, Ruta C creates
+  an orphan attachment that Stage 04's five-stage cascade handles. The
+  user never ends up with a Zotero item that has a DOI but no other
+  metadata.
+- **Clear blast radius.** A Zotero library built by this pipeline is
+  traceable to two external sources (OpenAlex + OpenAI) and two local
+  ones (pyzotero + pdfplumber). No hidden dependency on Zotero's
+  in-process translator state.
+
+### Negative
+
+- **Single upstream source for Ruta A's metadata.** OpenAlex is free
+  and reliable today, but it is one organisation. If it becomes
+  unavailable, Ruta A breaks. Mitigation: all failures cascade to Ruta
+  C → Stage 04, which includes Semantic Scholar and LLM extraction as
+  alternative sources. The pipeline still produces a Zotero library;
+  just slower.
+- **Metadata diverges from what Zotero's translator would have
+  produced.** Zotero's translators are maintained per-publisher and can
+  extract publisher-specific details that OpenAlex might miss (e.g.,
+  corrigendum status, specific editor for book chapters). For the
+  researcher's core use case (economics / LATAM papers), this
+  difference is marginal.
+- **No "book chapter retrieved via DOI" path.** OpenAlex has weaker
+  coverage for book chapters than journal articles. Chapters with DOIs
+  may be missed by Ruta A and fall to Ruta C. Stage 04d (LLM extracting
+  from the PDF text) handles this — a chapter's first two pages usually
+  contain its own front matter.
+
+### Neutral
+
+- This ADR does not preclude a future **CrossRef fallback**. If
+  empirical use shows OpenAlex misses a meaningful fraction of real
+  DOIs, adding `habanero.Crossref().works(ids=doi)` as a secondary try
+  between "OpenAlex 404" and "fall to Ruta C" is a small change. Not
+  scoped for v1 because the expected gap (~1-2% over OpenAlex's
+  coverage) does not currently justify the added client.
+
+## Alternatives considered
+
+**A. Zotero connector endpoints (`/connector/savePageViaDOI` or
+equivalent).**
+Rejected. Same rationale as Ruta B's removal: non-public API, version-
+fragile, undocumented across Zotero Desktop releases. Worth revisiting
+only if Zotero publishes a stable contract for these endpoints.
+
+**B. CrossRef directly as Ruta A's primary source.**
+Rejected as the default. CrossRef is the authoritative registry for
+DOIs but OpenAlex covers >98% of what CrossRef has *and* covers arXiv
+preprints that CrossRef does not. Adding CrossRef as a v1.1 fallback
+stays open (see "Neutral" above).
+
+**C. LLM lookup by DOI (give an LLM the DOI, ask for the paper
+metadata).**
+Rejected. LLMs hallucinate bibliographic citations at rates documented
+at 15-30% depending on model and corpus ([Dahl et al. 2024 on
+hallucinated legal citations](https://hai.stanford.edu/news/hallucinating-law-legal-mistakes-large-language-models-are-pervasive);
+similar rates observed in scholarly citation benchmarks). Because the
+LLM is not grounded in any verifiable source when given only a DOI,
+wrong metadata is indistinguishable from right metadata downstream —
+exactly the "trabajo silencioso" antipattern that
+`plan_glossary.md` names as prohibited. Contrast with Stage 04d, where
+the LLM extracts metadata **from the PDF's own first pages**; there the
+LLM is bounded by what the document says about itself and the risk is
+manageable.
+
+**D. Barebones item with only DOI, enrich later in Stage 04.**
+Rejected because it collapses the distinction between Ruta A and Ruta
+C, losing the point of having a "fast, high-quality path" when a DOI
+is available. Stage 04 is a costly cascade (API calls, LLM
+extraction); Ruta A exists to bypass most of it. Posting DOI-only items
+would also pollute Zotero's library during the window between Stage 03
+and Stage 04 — items would appear with no title, no authors, no venue,
+which is jarring for a user who inspects Zotero mid-pipeline.
+
+**E. User triggers Zotero Desktop's "Retrieve metadata" manually per
+item.**
+Rejected. Violates the pipeline's automation goal and the CLAUDE.md
+budget of "2-3h total of human time". Also does not scale to 1000
+PDFs.
+
+## References
+
+- `docs/plan_01_subsystem1.md` §3 Etapa 03 (this ADR's direct consumer)
+- `docs/plan_glossary.md` — "Ruta A/C"
+- `docs/decisions/002-sqlite-for-state.md` — the same "depend only on
+  stable, documented surfaces" principle applied there
+- PR #22 — removal of Ruta B (`docs(s1): drop Ruta B from Etapa 03,
+  consolidate into Etapa 04 cascade`). The analogous rationale.
+- `src/zotai/api/openalex.py` — the `OpenAlexClient.work_by_doi`
+  implementation shipped in Phase 1 (`#2`)

--- a/docs/plan_01_subsystem1.md
+++ b/docs/plan_01_subsystem1.md
@@ -152,16 +152,18 @@ zotai s1 ocr [--force-ocr] [--parallel N]
 **Lógica por item**, en orden:
 
 **Ruta A** (si `detected_doi is not null`):
-1. Llamar Zotero API `POST /items` con `{itemType: 'journalArticle', DOI: detected_doi}` via translator chain → recupera metadata.
-2. Si éxito, adjuntar PDF al item creado.
-3. Persistir `zotero_item_key`, marcar `import_route='A'`.
+1. Resolver el DOI a metadata bibliográfica completa via `OpenAlexClient.work_by_doi(doi)` (endpoint `GET https://api.openalex.org/works/doi:<doi>`). OpenAlex ingiere CrossRef, DataCite, arXiv, PMC y PubMed, con cobertura >98% de DOIs académicos.
+2. Validar calidad de la metadata antes de escribir a Zotero: debe tener al menos `title` no vacío y `authorships` con al menos un autor. Si cualquiera falla, el item se redirige a Ruta C.
+3. Llamar Zotero API vía `pyzotero.create_items([{...full_metadata}])` con los campos mapeados desde OpenAlex (title, authors, DOI, year, venue, abstract, item_type).
+4. Adjuntar el PDF (`staging/<hash>.pdf` si Stage 02 corrió OCR, si no `Item.source_path`) como hijo del item creado via `pyzotero.attachment_simple([path], parent_key=item_key)`. Zotero copia el archivo a `~/Zotero/storage/<attach_key>/` (modo **Stored** — Zotero gestiona el archivo, el original queda intacto, la biblioteca es self-contained y compatible con cloud sync). No usamos modo *linked_file* en v1.
+5. Persistir `zotero_item_key` en `state.db`, marcar `import_route='A'`.
 
 **Ruta C** (fallback — captura todo lo que no entra por A):
-1. Aplica cuando `detected_doi is null` **o** cuando Ruta A falla (el translator no recupera metadata utilizable).
-2. Subir PDF como attachment huérfano sin parent via Zotero API.
-3. Marcar `import_route='C'`, item queda pendiente de enrichment en Etapa 04.
+1. Aplica cuando `detected_doi is null`, cuando OpenAlex devuelve 404/no-match para el DOI, o cuando la metadata devuelta es insuficiente (sin título o sin autores).
+2. Subir PDF como attachment huérfano sin parent via `pyzotero.attachment_simple([path], parent_key=None)`. Zotero copia el PDF a su storage igual que en Ruta A; el item queda como attachment top-level sin metadata bibliográfica.
+3. Marcar `import_route='C'`, item queda pendiente de enrichment en Etapa 04. La cascada 04a-d intenta recuperar metadata por identificadores alternativos (arXiv/ISBN), título fuzzy-match contra OpenAlex/Semantic Scholar, y finalmente LLM extrayendo metadata del texto del PDF (grounded). 04e envía los que fallan a `Quarantine`.
 
-**Nota — ausencia de Ruta B**: versiones previas de este plan incluían una Ruta B que, para items sin DOI, subía el PDF huérfano y llamaba al endpoint "Retrieve Metadata for PDFs" de Zotero Desktop. Se eliminó en favor de consolidar toda recuperación de metadata en la cascada de Etapa 04 (04a identifiers → 04b OpenAlex → 04c Semantic Scholar → 04d LLM). Motivos: (a) el endpoint del recognizer de Zotero no es API pública estable y su invocación programática es frágil entre versiones; (b) la cascada de 04 ya resuelve el mismo problema con múltiples fuentes y mayor cobertura del corpus LATAM/ES; (c) reducir de 3 rutas a 2 baja el blast radius de Etapa 03.
+**Nota — ausencia de Ruta B y fuente de metadata en Ruta A**: versiones previas de este plan (a) incluían una Ruta B que llamaba al endpoint "Retrieve Metadata for PDFs" de Zotero Desktop y (b) describían la resolución de DOI en Ruta A como "via translator chain" de la Zotero API. Ambas decisiones implicaban depender de endpoints del Zotero connector / recognizer que no son API pública estable y son frágiles entre versiones del desktop. Ambas se eliminaron con el mismo rationale: consolidar la recuperación de metadata en clientes HTTP documentados (OpenAlex/Semantic Scholar) y en la cascada de Etapa 04. Ver ADR 010 para el detalle de por qué Ruta A usa OpenAlex en vez del translator de Zotero.
 
 **Rate limiting**: Zotero API permite ~100 req/sec local. Configurar cliente con `httpx` + `tenacity` retry con exponential backoff.
 

--- a/docs/plan_glossary.md
+++ b/docs/plan_glossary.md
@@ -68,9 +68,9 @@ CSV en `reports/excluded_report_<ts>.csv` que lista los PDFs rechazados por el c
 Flag booleano en `Item.needs_review`. True cuando el clasificador Stage 01 tuvo que decidir con incertidumbre (LLM respondió con `confidence=low`, o tras error transitorio). El item sigue al resto del pipeline como académico, pero se lo surfacea explícitamente en el reporte de Etapa 06 para que el usuario lo revise manualmente.
 
 **Ruta A/C** (S1 Etapa 03)
-Las dos estrategias de import:
-- **A**: import por DOI directo — el translator de Zotero resuelve metadata a partir del DOI detectado en Etapa 01.
-- **C**: import como attachment huérfano sin parent. Absorbe todo lo que no cae por A (items sin DOI detectado, o items donde el translator de A no recuperó metadata utilizable). La recuperación de metadata para estos items sucede después, en la cascada de Etapa 04 (enrichment).
+Las dos estrategias de import a Zotero:
+- **A**: import con metadata via OpenAlex. Resolvemos el DOI detectado en Etapa 01 contra `api.openalex.org/works/doi:<doi>`, recibimos metadata completa (título, autores, año, venue, abstract), y creamos el item en Zotero con `pyzotero.create_items([...])` + attachment del PDF como hijo. Las versiones previas del plan describían esto como "via translator chain" de Zotero; ver ADR 010 para por qué usamos OpenAlex en su lugar.
+- **C**: import como attachment huérfano sin parent. Absorbe todo lo que no cae por A (items sin DOI detectado, o items donde OpenAlex no tiene el DOI o devuelve metadata sin título/autores). La recuperación de metadata para estos items sucede después, en la cascada de Etapa 04 (enrichment).
 
 La Ruta B (recognizer de Zotero Desktop sobre PDF huérfano) existió en versiones previas del plan y fue eliminada. Ver `plan_01_subsystem1.md` §3 Etapa 03 "Nota — ausencia de Ruta B" para el rationale.
 


### PR DESCRIPTION
## Summary

Fix a long-standing ambiguity in `plan_01_subsystem1.md` §3 Etapa 03 and document the rationale in a new ADR. **Docs-only; no code changes.** Follow-up implementation PR for Stage 03 will land against this plan state.

## Background

Earlier plan text described Ruta A as:

> Llamar Zotero API `POST /items` con `{itemType: 'journalArticle', DOI: detected_doi}` via translator chain → recupera metadata.

This implies posting a DOI-only item to Zotero's standard API triggers Zotero's translator to populate the bibliographic record. **That's not how the standard API works.** Zotero's translators live in:
- The desktop UI (manual magic-wand).
- The browser-connector endpoints (`/connector/*`), used by Zotero browser extensions.

Neither is public, versioned API. The standard data API (what `pyzotero` wraps) stores exactly the fields you give it. A DOI-only POST produces a barebones item with no title, no authors, no abstract — useless as a bibliographic record.

This is the same failure mode that caused us to remove **Ruta B** (see PR #22 and plan_01 §3 Etapa 03 "Nota — ausencia de Ruta B"). Same rationale applies to any "use Zotero's translator" implementation of Ruta A.

## What this PR does

- **Rewrites `plan_01` §3 Etapa 03** Ruta A and Ruta C to describe the actual mechanism:
  - Resolve DOI → metadata via `OpenAlexClient.work_by_doi()` (reuses the Phase 1 client).
  - Validate quality: skip Ruta A if the metadata has no title or zero authors.
  - `pyzotero.create_items([{...full_metadata}])` with the mapped fields.
  - `pyzotero.attachment_simple([pdf_path], parent_key=item_key)` to attach the PDF.
  - Stored mode (Zotero copies file to `~/Zotero/storage/`) documented inline — no separate ADR for that choice.
- **Updates `plan_glossary` Ruta A/C entry** to reflect the OpenAlex source and reference the new ADR.
- **Adds `docs/decisions/010-ruta-a-openalex-not-zotero-translator.md`** with the full rationale:
  - Why OpenAlex (reuses Phase 1 client, >98% DOI coverage including arXiv, symmetric with Stage 04b).
  - Why not the Zotero translator (same reason Ruta B was dropped; non-public API surface).
  - Why not LLM lookup by DOI (hallucination risk on ungrounded citation lookups — 15–30% per [Dahl et al. 2024](https://hai.stanford.edu/news/hallucinating-law-legal-mistakes-large-language-models-are-pervasive); violates `plan_glossary.md`'s "trabajo silencioso" antipattern).
  - Why not CrossRef as primary (marginal over OpenAlex; kept open as v1.1 fallback).
  - Why not DOI-only barebones items (collapses the A vs C distinction; pollutes Zotero mid-pipeline).

## Why a separate PR

`CLAUDE.md` §"Reglas sobre los documentos plan_*.md":

> Si Claude Code propone un cambio al plan, hacerlo en PR separado de la implementación.

Implementation PR for Stage 03 will follow once this merges.

## Test plan

- [x] `docs/plan_01_subsystem1.md` §3 Etapa 03 reads cleanly against the "Nota — ausencia de Ruta B" paragraph.
- [x] `docs/plan_glossary.md` "Ruta A/C" entry references ADR 010.
- [x] New ADR renders and follows the established format from ADRs 001–003.
- [x] No code touched; `uv run pytest -q` unchanged from main (91 passed).