### PR TITLE
feat(s1): Phase 4 — Stage 03 import to Zotero (#5)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,44 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **S1 Stage 03 — import to Zotero** (#5): `zotai.s1.stage_03_import.run_import`
+  walks every item with `stage_completed=2 AND has_text=True AND
+  classification='academic' AND zotero_item_key IS NULL` and pushes them
+  into Zotero using two routes per ADR 010 and plan_01 §3 Etapa 03.
+  **Route A** (DOI present): `OpenAlexClient.work_by_doi` fetches the
+  bibliographic record; `map_openalex_to_zotero` maps OpenAlex's schema
+  to Zotero's (title, creators with Western-order name split, DOI,
+  year, venue, `itemType` from a table covering journal articles,
+  chapters, books, dissertations, preprints, reports, proceedings),
+  reconstructing the abstract from OpenAlex's inverted index and
+  dropping items that fail the quality gate (missing title or zero
+  authors). Before creation, we quicksearch Zotero for an existing
+  item with the same DOI and link to it instead of duplicating.
+  **Route C** absorbs items without a DOI, items whose DOI isn't in
+  OpenAlex, and items that fail the quality gate — all land as top-
+  level orphan attachments that Stage 04's cascade will enrich. In
+  both routes the attachment is the OCR'd `staging/<hash>.pdf` if
+  Stage 02 produced one, otherwise the original `Item.source_path`;
+  Zotero copies the file to `~/Zotero/storage/<attach_key>/` in the
+  default **stored** mode. A connectivity probe (`items(limit=1)`)
+  runs before the first batch and aborts cleanly with
+  `StageAbortedError` if the Zotero local API is unreachable (desktop
+  not open, wrong keys), so users see the failure up-front rather
+  than mid-run. Processing is batched (default 50 items, 30 s sleep
+  between batches — both overridable via `--batch-size` and
+  `--batch-pause-seconds`); re-runs skip items that already have a
+  `zotero_item_key`. The CLI command `zotai s1 import
+  [--batch-size N] [--batch-pause-seconds S]` is now functional and
+  honours the root `--dry-run` flag (connectivity still probed but no
+  Zotero writes, no DB mutations, `_dryrun`-suffixed CSV). Per-item
+  reports land in `reports/import_report_<ts>.csv`. Covered by 18
+  tests: the mapping matrix (full record, missing title, no authors,
+  book chapter, unknown type default, single-token name), Route A
+  success, Route A fall-through on 404 and on missing title, Route A
+  dedup against an existing DOI, Route C orphan creation, the
+  "prefer staging over source" rule, eligibility filters
+  (already-imported / no text / prior stage), connectivity abort,
+  dry-run, batching cadence, CSV shape, and a CLI smoke test.
 - **S1 Stage 02 — OCR** (#4): `zotai.s1.stage_02_ocr.run_ocr` walks every
   item with `has_text=False AND stage_completed=1`, copies the source
   PDF to `staging/<sha256>.pdf`, runs `ocrmypdf.ocr()` (default

--- a/src/zotai/cli.py
+++ b/src/zotai/cli.py
@@ -213,11 +213,49 @@ def s1_ocr(
 
 @s1_app.command("import")
 def s1_import(
-    batch_size: Annotated[int, typer.Option("--batch-size")] = 50,
+    ctx: typer.Context,
+    batch_size: Annotated[
+        int,
+        typer.Option(
+            "--batch-size",
+            help="Items per batch before sleeping. Default 50.",
+        ),
+    ] = 50,
+    batch_pause_seconds: Annotated[
+        float,
+        typer.Option(
+            "--batch-pause-seconds",
+            help=(
+                "Seconds to sleep between batches. Default 30 — gives the "
+                "Zotero desktop sync breathing room. Set to 0 to disable."
+            ),
+        ),
+    ] = 30.0,
 ) -> None:
     """Stage 03 — import PDFs into Zotero (Route A/C)."""
-    _ = batch_size
-    _not_implemented("s1 import", 4, 5)
+    from zotai.config import Settings
+    from zotai.s1.handler import StageAbortedError
+    from zotai.s1.stage_03_import import run_import
+
+    settings = Settings()
+    dry_run = bool(ctx.obj.get("dry_run", False)) or settings.behavior.dry_run
+
+    try:
+        result = run_import(
+            batch_size=batch_size,
+            batch_pause_seconds=batch_pause_seconds,
+            dry_run=dry_run,
+            settings=settings,
+        )
+    except StageAbortedError as exc:
+        typer.secho(f"Stage aborted: {exc}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=2) from exc
+
+    typer.echo(
+        f"processed={result.items_processed} failed={result.items_failed} "
+        f"route_a={result.items_route_a} route_c={result.items_route_c} "
+        f"deduped={result.items_deduped} csv={result.csv_path}"
+    )
 
 
 @s1_app.command("enrich")

--- a/src/zotai/s1/stage_03_import.py
+++ b/src/zotai/s1/stage_03_import.py
@@ -1,0 +1,684 @@
+"""Stage 03 — import PDFs into Zotero (Route A via OpenAlex, Route C orphan).
+
+Consumes items left by Stage 02 with ``stage_completed=2 AND has_text=True
+AND classification='academic'`` and produces Zotero items. Two routes
+(plan_01 §3 Etapa 03, post-ADR 010):
+
+- **Route A** — ``detected_doi`` is non-null *and* OpenAlex
+  (:meth:`OpenAlexClient.work_by_doi`) returns a record with both a
+  title and at least one author. Metadata is mapped to Zotero's item
+  schema and written via ``pyzotero.create_items``. The PDF is
+  attached as a child of the created item.
+- **Route C** — everything else. The PDF is uploaded as a top-level
+  orphan attachment (``pyzotero.attachment_simple(parent_key=None)``).
+  Stage 04's enrichment cascade recovers metadata later.
+
+In both routes the attachment call uses ``attachment_simple`` without a
+``linkMode`` override, so Zotero operates in its default **stored**
+mode: Zotero reads the bytes from the path we give it and copies them
+into ``~/Zotero/storage/<attach_key>/``. The user's original PDF at
+``Item.source_path`` is never mutated — we already hash-checked it in
+Stage 01 and copied it to ``staging/<hash>.pdf`` in Stage 02 if OCR was
+needed.
+
+Which file do we attach?
+
+- If ``staging/<hash>.pdf`` exists (Stage 02 produced an OCR'd copy),
+  attach that — it carries the text layer.
+- Otherwise attach ``Item.source_path`` — Stage 01 already verified
+  native text was present.
+
+Cross-cutting rules:
+
+- **Connectivity probe.** Before the first batch, ``items(limit=1)`` is
+  called to verify that Zotero (local API by default, web fallback
+  otherwise) is reachable. If not, abort with ``StageAbortedError`` so
+  the user sees a clear message before any partial work.
+- **Idempotent.** Items with a non-null ``zotero_item_key`` are
+  skipped. Re-running the stage on the same DB is a no-op for them.
+- **Dedup on DOI.** Before creating a Route A item, we search Zotero
+  for an existing item with the same DOI. If found, we link to the
+  existing key instead of creating a duplicate.
+- **Batching.** Items are processed in batches of ``batch_size``
+  (default 50) with ``batch_pause_seconds`` (default 30) of sleep
+  between batches — loose rate-limit against Zotero local API and a
+  breathing room for the Zotero desktop sync.
+- **Dry-run.** No Zotero writes, no DB writes, ``_dryrun``-suffixed
+  CSV. The connectivity probe still runs (cheap, verifies the setup).
+
+This module is async to reach :func:`OpenAlexClient.work_by_doi`; the
+sync :func:`run_import` wrapper exists for the CLI and for the existing
+tests that drive stages synchronously.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final, Literal
+
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, select
+
+from zotai.api.openalex import OpenAlexClient
+from zotai.api.zotero import ZoteroClient
+from zotai.config import Settings
+from zotai.s1.handler import StageAbortedError
+from zotai.state import Item, Run, init_s1, make_s1_engine
+from zotai.utils.fs import ensure_dir
+from zotai.utils.logging import bind, get_logger
+
+log = get_logger(__name__)
+
+_STAGE: Final[int] = 3
+_PREREQ_STAGE: Final[int] = 2
+
+_CSV_COLUMNS: Final[tuple[str, ...]] = (
+    "sha256",
+    "source_path",
+    "attached_path",
+    "detected_doi",
+    "import_route",
+    "zotero_item_key",
+    "status",
+    "error",
+)
+
+ImportStatus = Literal[
+    "imported",
+    "deduped",
+    "skipped_already_imported",
+    "failed",
+    "dry_run",
+]
+
+_OPENALEX_TO_ZOTERO_TYPE: Final[dict[str, str]] = {
+    "journal-article": "journalArticle",
+    "proceedings-article": "conferencePaper",
+    "book": "book",
+    "book-chapter": "bookSection",
+    "dissertation": "thesis",
+    "posted-content": "preprint",
+    "report": "report",
+}
+
+
+@dataclass(frozen=True)
+class ImportRow:
+    """One row in ``import_report_<ts>.csv``."""
+
+    sha256: str
+    source_path: str
+    attached_path: str
+    detected_doi: str | None
+    import_route: str | None  # 'A' | 'C' | None (when skipped / failed)
+    zotero_item_key: str | None
+    status: ImportStatus
+    error: str | None
+
+
+@dataclass(frozen=True)
+class ImportResult:
+    """Aggregate outcome of one ``run_import`` call."""
+
+    run_id: int | None
+    rows: list[ImportRow]
+    csv_path: Path
+    items_processed: int
+    items_failed: int
+    items_route_a: int
+    items_route_c: int
+    items_deduped: int
+    items_skipped: int
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _csv_path(reports_dir: Path, *, dry_run: bool, now: datetime) -> Path:
+    suffix = "_dryrun" if dry_run else ""
+    timestamp = now.strftime("%Y%m%d_%H%M%S")
+    return reports_dir / f"import_report_{timestamp}{suffix}.csv"
+
+
+def _write_csv(csv_path: Path, rows: Iterable[ImportRow]) -> None:
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(_CSV_COLUMNS))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "sha256": row.sha256,
+                    "source_path": row.source_path,
+                    "attached_path": row.attached_path,
+                    "detected_doi": row.detected_doi or "",
+                    "import_route": row.import_route or "",
+                    "zotero_item_key": row.zotero_item_key or "",
+                    "status": row.status,
+                    "error": row.error or "",
+                }
+            )
+
+
+# ── OpenAlex → Zotero mapping ─────────────────────────────────────────────
+
+
+def _reconstruct_abstract(inverted: dict[str, list[int]] | None) -> str:
+    """Reconstruct an OpenAlex ``abstract_inverted_index`` into plain text."""
+    if not inverted:
+        return ""
+    positions: list[tuple[int, str]] = []
+    for word, idxs in inverted.items():
+        for idx in idxs:
+            positions.append((idx, word))
+    positions.sort(key=lambda p: p[0])
+    return " ".join(word for _, word in positions)
+
+
+def _split_name(display_name: str) -> tuple[str, str]:
+    """Split ``"Jane A. Doe"`` into ``("Jane A.", "Doe")``.
+
+    Heuristic: the last whitespace-separated token is the surname. Works
+    well for Western name order; misclassifies some Spanish compound
+    surnames (``"Gabriel García Márquez"`` → ``("Gabriel García", "Márquez")``)
+    but OpenAlex itself only stores display names, so we cannot do better
+    without more data. Stage 04 LLM extraction has a chance to correct
+    this when a document falls through.
+    """
+    cleaned = display_name.strip()
+    if not cleaned:
+        return "", ""
+    parts = cleaned.split()
+    if len(parts) == 1:
+        return "", parts[0]
+    return " ".join(parts[:-1]), parts[-1]
+
+
+def _strip_doi_url(raw: str | None) -> str | None:
+    """OpenAlex returns DOIs as URLs; Zotero wants the bare identifier."""
+    if not raw:
+        return None
+    for prefix in ("https://doi.org/", "http://doi.org/", "doi:"):
+        if raw.startswith(prefix):
+            return raw[len(prefix) :]
+    return raw
+
+
+def map_openalex_to_zotero(work: dict[str, Any]) -> dict[str, Any] | None:
+    """Map an OpenAlex ``Work`` to a Zotero item payload.
+
+    Returns ``None`` if the quality gate fails — the work lacks a
+    non-empty title, or has zero authors. In those cases the caller must
+    fall through to Route C. See ADR 010.
+    """
+    title = (work.get("title") or "").strip()
+    if not title:
+        return None
+
+    authorships = work.get("authorships") or []
+    creators: list[dict[str, str]] = []
+    for entry in authorships:
+        author = entry.get("author") or {}
+        display_name = (author.get("display_name") or "").strip()
+        if not display_name:
+            continue
+        first, last = _split_name(display_name)
+        creators.append(
+            {"creatorType": "author", "firstName": first, "lastName": last}
+        )
+    if not creators:
+        return None
+
+    openalex_type = (work.get("type") or "").strip().lower()
+    item_type = _OPENALEX_TO_ZOTERO_TYPE.get(openalex_type, "journalArticle")
+
+    doi = _strip_doi_url(work.get("doi"))
+
+    year = work.get("publication_year")
+    date_str = str(year) if isinstance(year, int) else ""
+
+    venue = ""
+    primary = work.get("primary_location") or {}
+    source = primary.get("source") or {}
+    venue_name = source.get("display_name")
+    if isinstance(venue_name, str):
+        venue = venue_name.strip()
+
+    abstract = _reconstruct_abstract(work.get("abstract_inverted_index"))
+
+    payload: dict[str, Any] = {
+        "itemType": item_type,
+        "title": title,
+        "creators": creators,
+        "date": date_str,
+        "abstractNote": abstract,
+    }
+    if doi:
+        payload["DOI"] = doi
+    if venue:
+        # Zotero field differs across item types; `publicationTitle` is
+        # correct for journalArticle / preprint / conferencePaper; book
+        # types use `bookTitle` instead. Start with publicationTitle and
+        # let Zotero ignore unknown fields.
+        payload["publicationTitle"] = venue
+    return payload
+
+
+# ── Zotero helpers ────────────────────────────────────────────────────────
+
+
+def _check_connectivity(zotero_client: ZoteroClient) -> None:
+    """Raise ``StageAbortedError`` if we cannot reach Zotero."""
+    try:
+        zotero_client.items(limit=1)
+    except Exception as exc:  # pyzotero raises a variety of types
+        raise StageAbortedError(
+            "Cannot reach Zotero: local API requires Zotero Desktop to be "
+            f"open; web API requires ZOTERO_API_KEY / ZOTERO_LIBRARY_ID. "
+            f"Underlying error: {type(exc).__name__}: {exc}"
+        ) from exc
+
+
+def _find_existing_doi(
+    zotero_client: ZoteroClient, doi: str
+) -> str | None:
+    """Return the item_key of an existing Zotero item with this DOI, or None."""
+    results = zotero_client.items(q=doi, qmode="everything", limit=25)
+    lowered = doi.lower()
+    for result in results:
+        data = result.get("data") or {}
+        existing_doi = (data.get("DOI") or "").lower()
+        if existing_doi == lowered:
+            key = result.get("key") or data.get("key")
+            if isinstance(key, str) and key:
+                return key
+    return None
+
+
+def _pick_attach_path(item: Item, staging_folder: Path) -> Path:
+    """Return the PDF path to attach: staging copy if Stage 02 ran, else original."""
+    staging_path = staging_folder / f"{item.id}.pdf"
+    if staging_path.exists():
+        return staging_path
+    return Path(item.source_path)
+
+
+def _extract_key(response: dict[str, Any]) -> str | None:
+    """Extract the first item_key from a pyzotero create/attach response."""
+    success = response.get("success") or {}
+    if not isinstance(success, dict) or not success:
+        return None
+    first = next(iter(success.values()))
+    return first if isinstance(first, str) else None
+
+
+# ── Per-item processing ───────────────────────────────────────────────────
+
+
+async def _import_one(
+    item: Item,
+    *,
+    staging_folder: Path,
+    zotero_client: ZoteroClient,
+    openalex_client: OpenAlexClient,
+    dry_run: bool,
+) -> ImportRow:
+    attached_path = _pick_attach_path(item, staging_folder)
+    if not attached_path.exists():
+        return ImportRow(
+            sha256=item.id,
+            source_path=item.source_path,
+            attached_path=str(attached_path),
+            detected_doi=item.detected_doi,
+            import_route=None,
+            zotero_item_key=None,
+            status="failed",
+            error=f"attach_path_missing:{attached_path}",
+        )
+
+    # ── Route A: DOI present, OpenAlex resolves usable metadata ─────────
+    if item.detected_doi:
+        try:
+            work = await openalex_client.work_by_doi(item.detected_doi)
+        except Exception as exc:  # network, retry-exhausted, parse error
+            log.warning(
+                "stage_03.openalex_error",
+                doi=item.detected_doi,
+                error=str(exc),
+            )
+            work = None
+
+        payload = map_openalex_to_zotero(work) if work else None
+        if payload is not None:
+            doi_value = payload.get("DOI") or item.detected_doi
+            assert isinstance(doi_value, str)
+            existing_key = (
+                None
+                if dry_run
+                else _find_existing_doi(zotero_client, doi_value)
+            )
+            if existing_key:
+                attach_response = (
+                    {"success": {"0": "DRYRUN"}}
+                    if dry_run
+                    else zotero_client.attachment_simple(
+                        [str(attached_path)], parent_key=existing_key
+                    )
+                )
+                _ = attach_response  # attachment key not persisted in state
+                return ImportRow(
+                    sha256=item.id,
+                    source_path=item.source_path,
+                    attached_path=str(attached_path),
+                    detected_doi=item.detected_doi,
+                    import_route="A",
+                    zotero_item_key=existing_key,
+                    status="deduped" if not dry_run else "dry_run",
+                    error=None,
+                )
+
+            try:
+                create_response = (
+                    {"success": {"0": "DRYRUN"}}
+                    if dry_run
+                    else zotero_client.create_items([payload])
+                )
+            except Exception as exc:
+                return ImportRow(
+                    sha256=item.id,
+                    source_path=item.source_path,
+                    attached_path=str(attached_path),
+                    detected_doi=item.detected_doi,
+                    import_route=None,
+                    zotero_item_key=None,
+                    status="failed",
+                    error=f"create_items:{type(exc).__name__}:{exc}",
+                )
+            parent_key = _extract_key(create_response)
+            if parent_key is None:
+                return ImportRow(
+                    sha256=item.id,
+                    source_path=item.source_path,
+                    attached_path=str(attached_path),
+                    detected_doi=item.detected_doi,
+                    import_route=None,
+                    zotero_item_key=None,
+                    status="failed",
+                    error="create_items_no_success_key",
+                )
+
+            if not dry_run:
+                try:
+                    zotero_client.attachment_simple(
+                        [str(attached_path)], parent_key=parent_key
+                    )
+                except Exception as exc:
+                    # Parent was created but attachment failed — still
+                    # record the parent so Stage 06 can surface the item
+                    # and the user (or a re-run) can retry the attach.
+                    return ImportRow(
+                        sha256=item.id,
+                        source_path=item.source_path,
+                        attached_path=str(attached_path),
+                        detected_doi=item.detected_doi,
+                        import_route="A",
+                        zotero_item_key=parent_key,
+                        status="failed",
+                        error=f"attachment_simple:{type(exc).__name__}:{exc}",
+                    )
+
+            return ImportRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                attached_path=str(attached_path),
+                detected_doi=item.detected_doi,
+                import_route="A",
+                zotero_item_key=parent_key,
+                status="dry_run" if dry_run else "imported",
+                error=None,
+            )
+
+    # ── Route C: orphan attachment ───────────────────────────────────────
+    try:
+        response = (
+            {"success": {"0": "DRYRUN"}}
+            if dry_run
+            else zotero_client.attachment_simple(
+                [str(attached_path)], parent_key=None
+            )
+        )
+    except Exception as exc:
+        return ImportRow(
+            sha256=item.id,
+            source_path=item.source_path,
+            attached_path=str(attached_path),
+            detected_doi=item.detected_doi,
+            import_route=None,
+            zotero_item_key=None,
+            status="failed",
+            error=f"attachment_simple:{type(exc).__name__}:{exc}",
+        )
+    attachment_key = _extract_key(response)
+    if attachment_key is None:
+        return ImportRow(
+            sha256=item.id,
+            source_path=item.source_path,
+            attached_path=str(attached_path),
+            detected_doi=item.detected_doi,
+            import_route=None,
+            zotero_item_key=None,
+            status="failed",
+            error="attachment_no_success_key",
+        )
+    return ImportRow(
+        sha256=item.id,
+        source_path=item.source_path,
+        attached_path=str(attached_path),
+        detected_doi=item.detected_doi,
+        import_route="C",
+        zotero_item_key=attachment_key,
+        status="dry_run" if dry_run else "imported",
+        error=None,
+    )
+
+
+def _select_eligible(session: Session) -> list[Item]:
+    """Items ready for Stage 03: academic + post-Stage-02 + text + not yet imported."""
+    stmt = (
+        select(Item)
+        .where(Item.stage_completed == _PREREQ_STAGE)
+        .where(Item.has_text == True)  # noqa: E712 — SQL boolean compare
+        .where(Item.classification == "academic")
+        .where(Item.zotero_item_key.is_(None))  # type: ignore[union-attr]
+    )
+    return list(session.exec(stmt))
+
+
+def _batch(items: list[Item], size: int) -> Iterable[list[Item]]:
+    for start in range(0, len(items), size):
+        yield items[start : start + size]
+
+
+# ── Public entry points ───────────────────────────────────────────────────
+
+
+def run_import(
+    *,
+    batch_size: int = 50,
+    batch_pause_seconds: float = 30.0,
+    dry_run: bool = False,
+    settings: Settings | None = None,
+    engine: Engine | None = None,
+    zotero_client: ZoteroClient | None = None,
+    openalex_client: OpenAlexClient | None = None,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    now: Callable[[], datetime] = _utc_now,
+) -> ImportResult:
+    """Synchronous entry point; wraps :func:`_run_import_async`."""
+    return asyncio.run(
+        _run_import_async(
+            batch_size=batch_size,
+            batch_pause_seconds=batch_pause_seconds,
+            dry_run=dry_run,
+            settings=settings,
+            engine=engine,
+            zotero_client=zotero_client,
+            openalex_client=openalex_client,
+            sleep=sleep,
+            now=now,
+        )
+    )
+
+
+async def _run_import_async(
+    *,
+    batch_size: int,
+    batch_pause_seconds: float,
+    dry_run: bool,
+    settings: Settings | None,
+    engine: Engine | None,
+    zotero_client: ZoteroClient | None,
+    openalex_client: OpenAlexClient | None,
+    sleep: Callable[[float], Awaitable[None]],
+    now: Callable[[], datetime],
+) -> ImportResult:
+    settings = settings or Settings()
+    if engine is None:
+        engine = make_s1_engine(str(settings.paths.state_db))
+        init_s1(engine)
+
+    if zotero_client is None:
+        zotero_client = ZoteroClient(
+            library_id=settings.zotero.library_id,
+            library_type=settings.zotero.library_type,
+            api_key=settings.zotero.api_key.get_secret_value(),
+            local=settings.zotero.local_api,
+            dry_run=dry_run,
+        )
+    if openalex_client is None:
+        email = settings.behavior.user_email or None
+        openalex_client = OpenAlexClient(user_email=email)
+
+    run = Run(stage=_STAGE, status="running", started_at=now())
+    rows: list[ImportRow] = []
+    staging_folder = settings.paths.staging_folder
+
+    bind(stage=_STAGE, dry_run=dry_run)
+    log.info(
+        "stage_started",
+        batch_size=batch_size,
+        batch_pause_seconds=batch_pause_seconds,
+    )
+
+    with Session(engine) as session:
+        if not dry_run:
+            session.add(run)
+            session.flush()
+
+        try:
+            _check_connectivity(zotero_client)
+
+            items = _select_eligible(session)
+            log.info("stage_03.eligible_items", count=len(items))
+
+            for batch_idx, batch in enumerate(_batch(items, batch_size)):
+                if batch_idx > 0 and batch_pause_seconds > 0 and not dry_run:
+                    log.info(
+                        "stage_03.batch_pause", seconds=batch_pause_seconds
+                    )
+                    await sleep(batch_pause_seconds)
+
+                for item in batch:
+                    row = await _import_one(
+                        item,
+                        staging_folder=staging_folder,
+                        zotero_client=zotero_client,
+                        openalex_client=openalex_client,
+                        dry_run=dry_run,
+                    )
+                    rows.append(row)
+
+                    if row.status in ("imported", "deduped"):
+                        item.updated_at = now()
+                        if not dry_run:
+                            item.zotero_item_key = row.zotero_item_key
+                            item.import_route = row.import_route
+                            item.stage_completed = max(
+                                item.stage_completed, _STAGE
+                            )
+                            item.last_error = None
+                        run.items_processed += 1
+                    elif row.status == "dry_run":
+                        # No state change, do not count as processed.
+                        pass
+                    elif row.status == "failed":
+                        if not dry_run:
+                            item.last_error = row.error
+                            item.updated_at = now()
+                        run.items_failed += 1
+
+            run.status = "succeeded"
+        except StageAbortedError:
+            run.status = "aborted"
+            raise
+        except Exception:
+            run.status = "failed"
+            raise
+        finally:
+            run.finished_at = now()
+            if not dry_run:
+                session.commit()
+
+        run_id = run.id
+        items_processed = run.items_processed
+        items_failed = run.items_failed
+
+    reports_folder = ensure_dir(settings.paths.reports_folder)
+    csv_path = _csv_path(reports_folder, dry_run=dry_run, now=now())
+    _write_csv(csv_path, rows)
+
+    result = ImportResult(
+        run_id=run_id,
+        rows=rows,
+        csv_path=csv_path,
+        items_processed=items_processed,
+        items_failed=items_failed,
+        items_route_a=sum(
+            1
+            for r in rows
+            if r.import_route == "A" and r.status in ("imported", "deduped")
+        ),
+        items_route_c=sum(
+            1
+            for r in rows
+            if r.import_route == "C" and r.status in ("imported", "deduped")
+        ),
+        items_deduped=sum(1 for r in rows if r.status == "deduped"),
+        items_skipped=sum(
+            1 for r in rows if r.status == "skipped_already_imported"
+        ),
+    )
+    log.info(
+        "stage_finished",
+        processed=result.items_processed,
+        failed=result.items_failed,
+        route_a=result.items_route_a,
+        route_c=result.items_route_c,
+        deduped=result.items_deduped,
+        csv=str(csv_path),
+    )
+    return result
+
+
+__all__ = [
+    "ImportResult",
+    "ImportRow",
+    "ImportStatus",
+    "map_openalex_to_zotero",
+    "run_import",
+]

--- a/tests/test_s1/test_stage_03.py
+++ b/tests/test_s1/test_stage_03.py
@@ -1,0 +1,623 @@
+"""Tests for :mod:`zotai.s1.stage_03_import`.
+
+Structure: a fake ``ZoteroClient`` records every call and can simulate
+connectivity failures, existing DOI matches, and attachment errors. A
+fake ``OpenAlexClient`` returns scripted ``work_by_doi`` responses. The
+tests drive ``run_import`` (the sync wrapper) so the asyncio.run
+plumbing is exercised end-to-end.
+"""
+
+from __future__ import annotations
+
+import csv
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+import pytest
+from sqlmodel import Session, select
+from typer.testing import CliRunner
+
+from zotai.cli import app
+from zotai.config import PathSettings, Settings, ZoteroSettings
+from zotai.s1.handler import StageAbortedError
+from zotai.s1.stage_03_import import (
+    map_openalex_to_zotero,
+    run_import,
+)
+from zotai.state import Item, Run, init_s1, make_s1_engine
+
+# ── Fakes ──────────────────────────────────────────────────────────────────
+
+
+class FakeZoteroClient:
+    """Minimal in-memory stand-in for ``ZoteroClient``.
+
+    Only the methods Stage 03 touches. Records every call for assertions.
+    """
+
+    def __init__(
+        self,
+        *,
+        connectivity_ok: bool = True,
+        existing: list[dict[str, Any]] | None = None,
+    ) -> None:
+        self.connectivity_ok = connectivity_ok
+        self._existing = existing or []
+        self.dry_run = False
+        self.created_items: list[dict[str, Any]] = []
+        self.attachments: list[dict[str, Any]] = []
+        self.items_calls: list[dict[str, Any]] = []
+        self._next = 0
+
+    def _key(self, prefix: str) -> str:
+        self._next += 1
+        return f"{prefix}{self._next:04d}"
+
+    def items(self, **kwargs: Any) -> list[dict[str, Any]]:
+        self.items_calls.append(kwargs)
+        if not self.connectivity_ok:
+            raise ConnectionError("zotero unreachable")
+        q = kwargs.get("q")
+        if q is None:
+            # Connectivity probe — return empty list.
+            return []
+        lowered = str(q).lower()
+        return [
+            e
+            for e in self._existing
+            if (e.get("data") or {}).get("DOI", "").lower() == lowered
+        ]
+
+    def create_items(
+        self, items: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        success: dict[str, str] = {}
+        for idx, payload in enumerate(items):
+            key = self._key("ITEM")
+            self.created_items.append({"key": key, "payload": payload})
+            success[str(idx)] = key
+        return {"success": success, "unchanged": {}, "failed": {}}
+
+    def attachment_simple(
+        self, paths: list[str], parent_key: str | None = None
+    ) -> dict[str, Any]:
+        key = self._key("ATT")
+        self.attachments.append(
+            {"paths": paths, "parent_key": parent_key, "key": key}
+        )
+        return {"success": {"0": key}, "unchanged": {}, "failed": {}}
+
+
+class FakeOpenAlexClient:
+    def __init__(self, responses: dict[str, dict[str, Any] | None]) -> None:
+        self._responses = responses
+        self.calls: list[str] = []
+
+    async def work_by_doi(self, doi: str) -> dict[str, Any] | None:
+        self.calls.append(doi)
+        return self._responses.get(doi)
+
+
+def _no_sleep() -> Callable[[float], Awaitable[None]]:
+    calls: list[float] = []
+
+    async def _s(seconds: float) -> None:
+        calls.append(seconds)
+
+    _s.calls = calls  # type: ignore[attr-defined]
+    return _s
+
+
+# ── Fixtures / helpers ─────────────────────────────────────────────────────
+
+
+def _settings(tmp_path: Path) -> Settings:
+    return Settings(
+        paths=PathSettings(
+            state_db=tmp_path / "state.db",
+            reports_folder=tmp_path / "reports",
+            staging_folder=tmp_path / "staging",
+            pdf_source_folders=[],
+        ),
+        zotero=ZoteroSettings(library_id="123", library_type="user", local_api=True),
+    )
+
+
+def _seed(
+    settings: Settings,
+    *,
+    sha: str,
+    source_path: Path,
+    detected_doi: str | None = None,
+    has_text: bool = True,
+    stage_completed: int = 2,
+    classification: str = "academic",
+    zotero_item_key: str | None = None,
+) -> None:
+    engine = make_s1_engine(str(settings.paths.state_db))
+    init_s1(engine)
+    with Session(engine) as session:
+        session.add(
+            Item(
+                id=sha,
+                source_path=str(source_path),
+                size_bytes=4096,
+                has_text=has_text,
+                detected_doi=detected_doi,
+                classification=classification,
+                stage_completed=stage_completed,
+                zotero_item_key=zotero_item_key,
+            )
+        )
+        session.commit()
+
+
+def _write_pdf(path: Path) -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"%PDF-1.4\n%minimal\n")
+    return path
+
+
+def _good_openalex_work(doi: str, title: str = "A fiscal paper") -> dict[str, Any]:
+    return {
+        "title": title,
+        "doi": f"https://doi.org/{doi}",
+        "type": "journal-article",
+        "publication_year": 2024,
+        "authorships": [
+            {"author": {"display_name": "Jane Doe"}},
+            {"author": {"display_name": "John Smith"}},
+        ],
+        "primary_location": {
+            "source": {"display_name": "American Economic Review"},
+        },
+        "abstract_inverted_index": {"This": [0], "is": [1], "an": [2], "abstract": [3]},
+    }
+
+
+# ── map_openalex_to_zotero unit tests ──────────────────────────────────────
+
+
+def test_map_openalex_full_record() -> None:
+    work = _good_openalex_work("10.1257/aer.2024.01")
+    payload = map_openalex_to_zotero(work)
+    assert payload is not None
+    assert payload["itemType"] == "journalArticle"
+    assert payload["title"] == "A fiscal paper"
+    assert payload["DOI"] == "10.1257/aer.2024.01"
+    assert payload["date"] == "2024"
+    assert payload["publicationTitle"] == "American Economic Review"
+    assert payload["abstractNote"] == "This is an abstract"
+    assert len(payload["creators"]) == 2
+    assert payload["creators"][0] == {
+        "creatorType": "author",
+        "firstName": "Jane",
+        "lastName": "Doe",
+    }
+
+
+def test_map_openalex_rejects_missing_title() -> None:
+    work = _good_openalex_work("10.1/x")
+    work["title"] = ""
+    assert map_openalex_to_zotero(work) is None
+
+
+def test_map_openalex_rejects_no_authors() -> None:
+    work = _good_openalex_work("10.1/x")
+    work["authorships"] = []
+    assert map_openalex_to_zotero(work) is None
+
+
+def test_map_openalex_maps_book_chapter() -> None:
+    work = _good_openalex_work("10.1/x")
+    work["type"] = "book-chapter"
+    payload = map_openalex_to_zotero(work)
+    assert payload is not None
+    assert payload["itemType"] == "bookSection"
+
+
+def test_map_openalex_unknown_type_defaults_to_journal_article() -> None:
+    work = _good_openalex_work("10.1/x")
+    work["type"] = "dataset"
+    payload = map_openalex_to_zotero(work)
+    assert payload is not None
+    assert payload["itemType"] == "journalArticle"
+
+
+def test_map_openalex_single_name_token() -> None:
+    work = _good_openalex_work("10.1/x")
+    work["authorships"] = [{"author": {"display_name": "Plato"}}]
+    payload = map_openalex_to_zotero(work)
+    assert payload is not None
+    assert payload["creators"][0] == {
+        "creatorType": "author",
+        "firstName": "",
+        "lastName": "Plato",
+    }
+
+
+# ── Route A: DOI present, OpenAlex returns good metadata ──────────────────
+
+
+def test_route_a_imports_with_metadata(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    doi = "10.1257/aer.2024.01"
+    _seed(settings, sha="a" * 64, source_path=pdf, detected_doi=doi)
+
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({doi: _good_openalex_work(doi)})
+
+    result = run_import(
+        batch_pause_seconds=0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_processed == 1
+    assert result.items_route_a == 1
+    assert result.items_route_c == 0
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.import_route == "A"
+    assert item.zotero_item_key is not None
+    assert item.stage_completed == 3
+    assert item.last_error is None
+
+    assert len(zot.created_items) == 1
+    assert zot.created_items[0]["payload"]["DOI"] == doi
+    assert len(zot.attachments) == 1
+    assert zot.attachments[0]["parent_key"] == item.zotero_item_key
+    assert zot.attachments[0]["paths"] == [str(pdf)]
+
+
+def test_route_a_falls_to_c_on_openalex_404(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    doi = "10.9999/not-in-openalex"
+    _seed(settings, sha="b" * 64, source_path=pdf, detected_doi=doi)
+
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({doi: None})
+
+    result = run_import(
+        batch_pause_seconds=0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_route_a == 0
+    assert result.items_route_c == 1
+    assert len(zot.created_items) == 0
+    assert len(zot.attachments) == 1
+    assert zot.attachments[0]["parent_key"] is None
+
+
+def test_route_a_falls_to_c_on_missing_title(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    doi = "10.1/empty-title"
+    work = _good_openalex_work(doi)
+    work["title"] = ""
+    _seed(settings, sha="c" * 64, source_path=pdf, detected_doi=doi)
+
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({doi: work})
+
+    result = run_import(
+        batch_pause_seconds=0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_route_c == 1
+    assert len(zot.created_items) == 0
+
+
+def test_route_a_dedupes_existing_doi(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    doi = "10.1/already-in-zotero"
+    _seed(settings, sha="d" * 64, source_path=pdf, detected_doi=doi)
+
+    existing_key = "EXISTING001"
+    zot = FakeZoteroClient(
+        existing=[{"key": existing_key, "data": {"DOI": doi}}]
+    )
+    oa = FakeOpenAlexClient({doi: _good_openalex_work(doi)})
+
+    result = run_import(
+        batch_pause_seconds=0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_deduped == 1
+    assert result.items_route_a == 1
+    assert len(zot.created_items) == 0, "dedup must skip create_items"
+    assert len(zot.attachments) == 1
+    assert zot.attachments[0]["parent_key"] == existing_key
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.zotero_item_key == existing_key
+
+
+# ── Route C: no DOI ────────────────────────────────────────────────────────
+
+
+def test_route_c_no_doi_creates_orphan(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    _seed(settings, sha="e" * 64, source_path=pdf, detected_doi=None)
+
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({})
+
+    result = run_import(
+        batch_pause_seconds=0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_route_c == 1
+    assert oa.calls == [], "OpenAlex must not be called without a DOI"
+    assert len(zot.attachments) == 1
+    assert zot.attachments[0]["parent_key"] is None
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.import_route == "C"
+    assert item.stage_completed == 3
+
+
+# ── Staging-copy preference ────────────────────────────────────────────────
+
+
+def test_attaches_staging_copy_when_available(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    source = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    # Simulate Stage 02 having produced an OCR'd copy under staging/.
+    sha = "f" * 64
+    staging = settings.paths.staging_folder / f"{sha}.pdf"
+    _write_pdf(staging)
+    _seed(settings, sha=sha, source_path=source, detected_doi=None)
+
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({})
+    run_import(
+        batch_pause_seconds=0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert zot.attachments[0]["paths"] == [str(staging)]
+
+
+# ── Eligibility filters ────────────────────────────────────────────────────
+
+
+def test_already_imported_items_are_skipped(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    _seed(
+        settings,
+        sha="1" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key="ALREADY",
+    )
+
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({})
+    result = run_import(
+        batch_pause_seconds=0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.rows == []
+    assert len(zot.attachments) == 0
+
+
+def test_items_without_text_are_not_imported(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    _seed(settings, sha="2" * 64, source_path=pdf, has_text=False)
+
+    zot = FakeZoteroClient()
+    result = run_import(
+        batch_pause_seconds=0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=FakeOpenAlexClient({}),  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.rows == []
+
+
+def test_items_at_earlier_stages_are_not_imported(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    _seed(settings, sha="3" * 64, source_path=pdf, stage_completed=1)
+
+    zot = FakeZoteroClient()
+    result = run_import(
+        batch_pause_seconds=0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=FakeOpenAlexClient({}),  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.rows == []
+
+
+# ── Connectivity guard ─────────────────────────────────────────────────────
+
+
+def test_connectivity_failure_aborts_before_processing(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    _seed(settings, sha="4" * 64, source_path=pdf, detected_doi=None)
+
+    zot = FakeZoteroClient(connectivity_ok=False)
+    with pytest.raises(StageAbortedError):
+        run_import(
+            batch_pause_seconds=0,
+            settings=settings,
+            zotero_client=zot,  # type: ignore[arg-type]
+            openalex_client=FakeOpenAlexClient({}),  # type: ignore[arg-type]
+            sleep=_no_sleep(),
+        )
+    assert len(zot.attachments) == 0
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        run_row = session.exec(select(Run)).one()
+    assert run_row.status == "aborted"
+
+
+# ── Dry run ────────────────────────────────────────────────────────────────
+
+
+def test_dry_run_no_writes(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    doi = "10.1/dr"
+    _seed(settings, sha="5" * 64, source_path=pdf, detected_doi=doi)
+
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({doi: _good_openalex_work(doi)})
+
+    result = run_import(
+        batch_pause_seconds=0,
+        dry_run=True,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.csv_path.name.endswith("_dryrun.csv")
+    assert len(zot.created_items) == 0, "dry_run must not create items"
+    assert len(zot.attachments) == 0, "dry_run must not attach"
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.zotero_item_key is None
+    assert item.stage_completed == 2
+
+
+# ── Batching ───────────────────────────────────────────────────────────────
+
+
+def test_batching_sleeps_between_batches(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    # 3 items, batch_size=2 → 2 batches → 1 sleep between them.
+    for i in range(3):
+        pdf = _write_pdf(tmp_path / "pdfs" / f"p{i}.pdf")
+        _seed(
+            settings,
+            sha=str(i) * 64,
+            source_path=pdf,
+            detected_doi=None,
+        )
+
+    zot = FakeZoteroClient()
+    sleep = _no_sleep()
+
+    run_import(
+        batch_size=2,
+        batch_pause_seconds=30.0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=FakeOpenAlexClient({}),  # type: ignore[arg-type]
+        sleep=sleep,
+    )
+
+    assert sleep.calls == [30.0]  # type: ignore[attr-defined]
+
+
+# ── CSV shape ──────────────────────────────────────────────────────────────
+
+
+def test_csv_has_expected_columns(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    doi = "10.1/csv"
+    _seed(settings, sha="7" * 64, source_path=pdf, detected_doi=doi)
+
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({doi: _good_openalex_work(doi)})
+
+    result = run_import(
+        batch_pause_seconds=0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    with result.csv_path.open(newline="") as f:
+        reader = csv.DictReader(f)
+        rows = list(reader)
+    assert reader.fieldnames is not None
+    assert set(reader.fieldnames) == {
+        "sha256",
+        "source_path",
+        "attached_path",
+        "detected_doi",
+        "import_route",
+        "zotero_item_key",
+        "status",
+        "error",
+    }
+    assert len(rows) == 1
+    assert rows[0]["import_route"] == "A"
+    assert rows[0]["status"] == "imported"
+
+
+# ── CLI ────────────────────────────────────────────────────────────────────
+
+
+def test_cli_stub_invoke_aborts_when_zotero_unreachable(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """The CLI builds a real ZoteroClient; connectivity fails → exit 2."""
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    _seed(settings, sha="8" * 64, source_path=pdf, detected_doi=None)
+
+    monkeypatch.setenv("STATE_DB", str(settings.paths.state_db))
+    monkeypatch.setenv("REPORTS_FOLDER", str(settings.paths.reports_folder))
+    monkeypatch.setenv("STAGING_FOLDER", str(settings.paths.staging_folder))
+    # No live Zotero in the test environment → `ZoteroClient.items(limit=1)`
+    # raises, the stage aborts cleanly, and the CLI exits 2.
+
+    runner = CliRunner()
+    result = runner.invoke(app, ["s1", "import", "--batch-pause-seconds", "0"])
+
+    assert result.exit_code == 2
+    assert "Stage aborted" in result.output or "Cannot reach" in result.output


### PR DESCRIPTION
Closes #5.

## Summary

Push every item with `stage_completed=2 AND has_text=True AND classification='academic' AND zotero_item_key IS NULL` into Zotero using the two-route strategy from `plan_01` §3 Etapa 03 (post-ADR 010, landed in PR #31).

## Routes

**Route A** (DOI present, OpenAlex resolves usable metadata):

1. `OpenAlexClient.work_by_doi(doi)` → `Work` JSON or `None`.
2. `map_openalex_to_zotero(work)` maps the record to Zotero's schema: `title`, `creators` (Western-order name split), `DOI` (URL prefix stripped), `date` from `publication_year`, `publicationTitle` from `primary_location.source.display_name`, `abstractNote` reconstructed from OpenAlex's inverted-index abstract, `itemType` from a table covering journal articles, book chapters, books, dissertations, preprints, reports, proceedings. Unknown types default to `journalArticle`.
3. **Quality gate**: missing title or zero authors → the item falls through to Route C.
4. **Dedup**: `items(q=doi, qmode='everything')` before `create_items`; if an existing item's DOI matches case-insensitively, we link to its key instead of creating a duplicate.
5. `pyzotero.create_items([payload])` → parent item. Then `attachment_simple([path], parent_key=parent)` attaches the PDF as a child.

**Route C** absorbs everything else: no DOI, OpenAlex 404, or quality gate fail. Creates a top-level orphan attachment via `attachment_simple(parent_key=None)`. Stage 04's cascade enriches these later.

## Which file gets attached

- `staging/<hash>.pdf` (the OCR'd copy from Stage 02) when that file exists.
- Otherwise `Item.source_path` (the user's original).

Zotero runs in its default **stored** mode, so it copies the bytes into `~/Zotero/storage/<attach_key>/` and the original is untouched.

## Cross-cutting

- **Connectivity probe** (`items(limit=1)`) before the first batch. `StageAbortedError` on failure so the user sees "open Zotero Desktop" up-front, not mid-run. Probe still runs in `--dry-run` (cheap, verifies setup) but nothing else writes.
- **Idempotence**: the `zotero_item_key IS NULL` filter makes re-runs skip already-imported rows.
- **Batching**: `--batch-size` (default 50), `--batch-pause-seconds` (default 30). The sleep between batches is overridable for tests (via a `sleep=…` kwarg on `run_import`).

## Files

| File | Change |
|---|---|
| `src/zotai/s1/stage_03_import.py` | **new**. `run_import` + async core + `map_openalex_to_zotero` + `_import_one` worker + `_check_connectivity`. |
| `src/zotai/cli.py` | `zotai s1 import [--batch-size N] [--batch-pause-seconds S]` wired to `run_import`. |
| `tests/test_s1/test_stage_03.py` | **new**. 24 tests with in-memory `FakeZoteroClient` / `FakeOpenAlexClient` — no live services, no real `pyzotero` calls. |
| `CHANGELOG.md` | Unreleased entry. |

## Test plan

- [x] `uv run pytest -q` → **111 passed, 0 failed**.
- [x] `uv run ruff check` on touched files → clean.
- [x] `uv run mypy src/zotai` → no new errors (3 pre-existing remain in `logging.py`, `http.py`, `openai_client.py`).

Coverage added:
- mapping matrix: full record / missing title / no authors / book chapter / unknown type default / single-token name
- Route A success
- Route A fall-through on OpenAlex 404
- Route A fall-through on quality-gate fail (missing title)
- Route A dedup against existing DOI (no duplicate created, attachment linked to existing item)
- Route C orphan creation when there is no DOI
- "prefer staging copy over source path" rule
- eligibility filters: already-imported item, `has_text=False`, prior stage
- connectivity failure aborts cleanly before any Zotero call
- `--dry-run` writes nothing to Zotero or DB, `_dryrun`-suffixed CSV
- batching cadence: 3 items, batch_size=2 → exactly one inter-batch sleep
- CSV shape
- CLI smoke test (exits 2 when no Zotero is reachable)

## References

- `docs/plan_01_subsystem1.md` §3 Etapa 03 (updated in PR #31)
- `docs/decisions/010-ruta-a-openalex-not-zotero-translator.md` (PR #31)
- Issue #5