### PR TITLE
chore: realign README + CLI stubs with current S1 state

### DIFF
--- a/README.md
+++ b/README.md
@@ -67,9 +67,9 @@ Ver `docs/plan_01_subsystem1.md` §3.1 para el detalle del clasificador.
 
 | Subsistema | Estado | Plan |
 |---|---|---|
-| S1 – Retroactive | 🟢 En implementación (Stage 01 inventory mergeado; classifier pendiente [#24](https://github.com/igalkej/auto_zotero/issues/24)) | `docs/plan_01_subsystem1.md` |
-| S3 – MCP access | 🟡 Spec, pendiente implementación | `docs/plan_03_subsystem3.md` |
-| S2 – Prospective | 🟡 Spec, pendiente implementación | `docs/plan_02_subsystem2.md` |
+| S1 – Retroactive | 🟢 En implementación (Stages 01 inventory+classifier, 02 OCR, 03 import mergeados; próximo Stage 04 enrich [#6](https://github.com/igalkej/auto_zotero/issues/6)) | `docs/plan_01_subsystem1.md` |
+| S3 – MCP access | 🟡 Spec, pendiente implementación ([#11](https://github.com/igalkej/auto_zotero/issues/11)) | `docs/plan_03_subsystem3.md` |
+| S2 – Prospective | 🟡 Spec, pendiente implementación ([#12](https://github.com/igalkej/auto_zotero/issues/12)–[#15](https://github.com/igalkej/auto_zotero/issues/15)) | `docs/plan_02_subsystem2.md` |
 
 ---
 
@@ -116,12 +116,14 @@ docker compose up dashboard
 
 ## Presupuestos estimados
 
-| Concepto | One-time | Mensual |
-|---|---|---|
-| S1 (APIs durante carga) | ~$2 | — |
-| S2 (APIs scoring) | — | ~$2 |
-| S3 (embeddings iniciales) | ~$2 | — |
-| Claude Pro (para usar MCP) | — | $20 |
+| Concepto | Estimado one-time | Estimado mensual | Hard cap |
+|---|---|---|---|
+| S1 (APIs durante carga) | ~$2 | — | $5 (alarma $10) |
+| S2 (APIs scoring) | — | ~$2 | $5/mes |
+| S3 (embeddings iniciales) | ~$2 | — | (compartido con S1) |
+| Claude Pro (para usar MCP) | — | $20 | — |
+
+**Estimado** = gasto típico observado en uso real. **Hard cap** = tope duro configurable en `.env` (`MAX_COST_USD_TOTAL`, `MAX_COST_USD_STAGE_*`, `S2_MAX_COST_USD_MONTHLY`); el pipeline aborta al superarlo.
 
 Tiempo humano: ~3h carga inicial + ~20 min/semana de triage.
 

--- a/src/zotai/cli.py
+++ b/src/zotai/cli.py
@@ -66,11 +66,12 @@ def _root(
 
 def _not_implemented(stage: str, phase: int, issue: int) -> None:
     typer.secho(
-        f"`{stage}` is not yet implemented — scheduled for Phase {phase} (#{issue}).",
+        f"`{stage}` is not yet implemented — scheduled for Phase {phase} "
+        f"(#{issue}). Any flags passed are parsed but ignored until then.",
         err=True,
         fg=typer.colors.YELLOW,
     )
-    raise typer.Exit(code=1)
+    raise typer.Exit(code=2)
 
 
 # ─── S1 commands ──────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Alignment fixes found in the Apr-22 review, grouped so a second PR can handle the heavier spec/ADR work on its own branch.

- **README status table**: Stage 01 classifier merged (#28), OCR (#30), and import (#32) have all landed since the row was last updated. Next is Stage 04 enrich (#6). Also linked the open S2/S3 issues.
- **README budgets table**: added a "Hard cap" column and a note at the bottom so the estimate (~\$2 typical) is no longer mistaken for the configured abort threshold (\$5 / alarm \$10, per \`MAX_COST_USD_TOTAL\` etc.).
- **\`cli._not_implemented\`**: exit 1 → 2 (consistent with the other usage-error paths in this file, e.g. "No source folders" or \`StageAbortedError\`). The message now explicitly calls out that flags are parsed but ignored until the owning Phase lands — so someone running \`zotai s1 enrich --substage 04b\` does not assume it executed.

No functional change to any already-implemented stage. No test currently asserts the stubs' exit code.

## Test plan

- [ ] \`zotai s1 enrich\` prints the new yellow warning and exits with code 2
- [ ] \`zotai s1 inventory\` / \`ocr\` / \`import\` unaffected
- [ ] Rendered README tables look correct on GitHub