### PR TITLE
docs(specs): align S2/S3 ambiguities via ADRs 011 and 012

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -52,9 +52,20 @@ USER_EMAIL=
 # ────────────── S2 Worker ──────────────
 S2_FETCH_INTERVAL_HOURS=6
 S2_CANDIDATES_DB=/workspace/candidates.db
-# Path to the ChromaDB maintained by zotero-mcp (shared with S3, read-only for S2)
+# Container-side path where S2 reads ChromaDB. Always /workspace/chroma_db.
+# The real store lives on the host (see ZOTERO_MCP_CHROMA_HOST_PATH below)
+# and is bind-mounted by the `dashboard` service in docker-compose.yml.
+# Read-only for S2. See ADR 011 (docs/decisions/011-chromadb-bind-mount.md).
 S2_CHROMA_PATH=/workspace/chroma_db
-# Zotero collection name where accepted candidates land
+# Host-side source for the ChromaDB bind mount. Default matches the path
+# that `zotero-mcp setup` plants. Override only if you moved it.
+ZOTERO_MCP_CHROMA_HOST_PATH=${HOME}/.config/zotero-mcp/chroma_db
+# Set to true to disable the in-process APScheduler. Use with cron / Task
+# Scheduler invoking `docker compose run --rm onboarding zotai s2 fetch-once`.
+# See ADR 012 (docs/decisions/012-apscheduler-default-cron-alternative.md).
+S2_WORKER_DISABLED=false
+# Zotero collection name where accepted candidates land. S2 creates it
+# on-demand and idempotently — you do not need to create it by hand.
 S2_ZOTERO_INBOX_COLLECTION=Inbox S2
 
 # ────────────── S2 PDF fetch cascade ──────────────
@@ -62,6 +73,15 @@ S2_ZOTERO_INBOX_COLLECTION=Inbox S2
 # candidate with a missing PDF. Stops at first success. Remove an entry to
 # disable that source. See docs/plan_02_subsystem2.md §10.
 S2_PDF_SOURCES=openaccess,doi,annas,libgen,scihub,rss
+# Max sources to try per candidate before tagging needs-pdf.
+S2_PDF_FETCH_MAX_ATTEMPTS_PER_CANDIDATE=6
+# Per-source timeout in seconds — one slow source does not block the worker.
+S2_PDF_FETCH_TIMEOUT_SECONDS=30
+# Weekly wall-clock budget (minutes) for PDF fetching across all candidates.
+# Resets Monday 00:00 local. Guards against a Sci-Hub / LibGen outage
+# burning the worker's time. On exceed, remaining candidates are tagged
+# needs-pdf and surfaced in the dashboard for manual retry.
+S2_PDF_FETCH_MAX_MINUTES_WEEKLY=20
 
 # ────────────── S2 Dashboard ──────────────
 S2_DASHBOARD_HOST=127.0.0.1

--- a/config/taxonomy.yaml
+++ b/config/taxonomy.yaml
@@ -2,14 +2,34 @@
 # config/taxonomy.yaml — TEMA + METODO tag taxonomy.
 #
 # ⚠️  TEMPLATE — MUST BE CUSTOMIZED BEFORE Phase 6 (`zotai s1 tag`).
+#
 # The values below are the suggested defaults from `docs/plan_taxonomy.md`
-# for an economics / LATAM social-sciences corpus. Adapt them to match your
-# actual research profile, then change `status` below from `template` to
-# `customized`. `zotai s1 tag` refuses to run while `status: template`.
-# See docs/plan_taxonomy.md §7 for the user TODO checklist.
+# for an economics / LATAM social-sciences corpus. If your field is
+# different (biomedicine, law, CS, humanities, physics, ...) you should
+# REPLACE these entries — not extend them. Covering many fields at once
+# makes every tag too broad.
+#
+# HOW TO ADAPT:
+#   1. Read `docs/plan_taxonomy.md` §8 for the design principles, a
+#      biomedicine walkthrough, and a smoke-test checklist.
+#   2. Keep two dimensions: TEMA (what the paper is about) and METODO
+#      (how it approaches the problem). 25-40 tags total, kebab-case,
+#      no accents.
+#   3. Each entry needs an `id`, a one-line `description`, and a list of
+#      `synonyms` (LLM hints; not applied as tags).
+#   4. When done, change `status: template` → `status: customized` below.
+#      `zotai s1 tag` refuses to run while `status: template` so the
+#      default taxonomy never silently ends up in your Zotero library.
+#   5. Smoke-test with `zotai s1 tag --preview` on a subset before
+#      `--apply`.
+#
+# See also:
+#   - docs/plan_taxonomy.md §4 (application rules the tagger enforces)
+#   - docs/plan_taxonomy.md §5 (re-tagging workflow after edits)
+#   - docs/plan_taxonomy.md §8 (adapt-to-domain guide + smoke-test)
 # ─────────────────────────────────────────────────────────────
 version: 1
-status: template
+status: template  # change to `customized` once you have edited the lists below
 
 tema:
   # Macro

--- a/docs/decisions/011-chromadb-bind-mount.md
+++ b/docs/decisions/011-chromadb-bind-mount.md
@@ -1,0 +1,171 @@
+# ADR 011 — ChromaDB is shared via a Docker bind mount, not duplicated
+
+**Status**: Accepted
+**Date**: 2026-04-22
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+ChromaDB is written by `zotero-mcp` (Subsystem 3) on the host and read
+by Subsystem 2 from inside the Docker container. Before this ADR, the
+two specs named it with two different paths:
+
+- `plan_02_subsystem2.md` §12 used `S2_CHROMA_PATH=/workspace/chroma_db`
+  — a container-side path, consistent with the `/workspace/*`
+  convention already used for `state.db`, `candidates.db`,
+  `staging/`, and `reports/`.
+- `plan_03_subsystem3.md` §4.3 and §8 used
+  `~/.config/zotero-mcp/chroma_db/` — the host path where
+  `zotero-mcp setup` plants its index by default, and where the
+  `zotero-mcp update-db` cron job keeps writing.
+
+Both statements were true — each subsystem saw the store from its own
+vantage point — but read together they implied two different file
+paths, and did not say how they become the same ChromaDB. A careful
+reader of the specs could not answer "what mounts where" without
+guessing.
+
+The two requirements this ADR has to reconcile:
+
+1. S1/S2 containers should name paths as `/workspace/*` (ADR 002 /
+   CLAUDE.md Docker rules). Breaking that convention for one special
+   case would make the Compose file harder to read and encourage more
+   exceptions.
+2. `zotero-mcp` runs on the host (see plan_03 §5 — requires host
+   Python 3.11 and a Claude Desktop installation), so whatever location
+   it writes to has to be the *real* location on the host filesystem.
+   We cannot ask `zotero-mcp` to write into `/workspace/chroma_db`; it
+   has no such directory.
+
+## Decision
+
+**The canonical path is `/workspace/chroma_db` inside the container.
+The dashboard Compose service bind-mounts the host's zotero-mcp
+ChromaDB directory to that container path, read-only for S2.**
+
+Concretely, the dashboard service in `docker-compose.yml` gains a
+volume entry (alongside the existing `./workspace:/workspace` and
+`./config:/app/config`) of the form:
+
+```yaml
+- ${ZOTERO_MCP_CHROMA_HOST_PATH:-${HOME}/.config/zotero-mcp/chroma_db}:/workspace/chroma_db:ro
+```
+
+Rules:
+
+- **Specs and code name the path as `/workspace/chroma_db`.** This is
+  what `S2_CHROMA_PATH` defaults to in `.env.example` and what the S2
+  code opens.
+- **The host-side source is configurable** via
+  `ZOTERO_MCP_CHROMA_HOST_PATH` in `.env`, defaulting to
+  `${HOME}/.config/zotero-mcp/chroma_db` — the same default path that
+  `zotero-mcp setup` uses.
+- **The mount is read-only (`:ro`).** S2 is a consumer of the index,
+  not a writer. `zotero-mcp` owns writes. If S2 ever tries to write,
+  Docker fails loudly instead of silently producing an S2-only copy
+  that drifts from the S3 index.
+- **The `onboarding` service does not mount it.** S1 has no reason to
+  touch ChromaDB; keeping the mount off that service avoids surprising
+  the user during the first run (when ChromaDB may not yet exist on
+  the host).
+- **Empty / missing ChromaDB degrades gracefully.** If the host path
+  does not exist yet (user has not run S1 → S3 setup in order), S2's
+  `score_semantic` returns `0.5` (neutral) per plan_02 §7.3, and the
+  dashboard keeps working. The user sees a one-time warning pointing
+  at `docs/s3-setup.md`.
+
+The Compose wiring itself lands in Phase 9 (#10) as part of Docker
+finalization; Phase 11 (#12) adds the degradation warning in the
+dashboard. This ADR fixes the pattern so those phases do not relitigate
+it.
+
+## Consequences
+
+### Positive
+
+- **One canonical name.** Every place in the repo that names this
+  index — specs, `.env.example`, code, dashboard error messages — says
+  `/workspace/chroma_db`. There is no second path to keep in sync.
+- **No copy, no sync job.** The S3 writer and the S2 reader look at the
+  same bytes. When `zotero-mcp update-db --fulltext` runs nightly, the
+  dashboard sees the fresh index on its next query with no additional
+  plumbing.
+- **S2 cannot corrupt the S3 index.** The read-only mount is enforced
+  at the kernel level. A bug in S2 that tries to `chroma_client.add()`
+  fails immediately instead of producing a subtle divergence.
+- **Host path is overridable.** Users who already have ChromaDB in a
+  non-default location (custom `ZOTERO_MCP_HOME`, Windows user with
+  OneDrive-redirected `$HOME`, etc.) set
+  `ZOTERO_MCP_CHROMA_HOST_PATH` in `.env` without touching Compose.
+
+### Negative
+
+- **Order of execution matters more than before.** If S2 starts before
+  S3 has ever run, the bind mount source is missing. Docker Compose
+  handles this by creating an empty directory at the source path; the
+  S2 code must then treat an empty ChromaDB as "degrade to neutral
+  score", not "crash on open". This is already required by plan_02
+  §7.3, so the ADR does not add new code — just calls out the tie.
+- **Windows/WSL path translation.** Docker Desktop on Windows translates
+  `${HOME}/.config/zotero-mcp/chroma_db` correctly when WSL is the
+  Docker backend, but users who run Docker Desktop without WSL (rare
+  on Windows 11) may need to set `ZOTERO_MCP_CHROMA_HOST_PATH` to a
+  Windows-style path. Documented in `docs/setup-windows.md` (Phase 9).
+- **`chroma_db` name is now a Compose-managed path name, not a freely
+  chosen one.** Renaming it later requires coordinated updates across
+  ADR 011, Compose, `.env.example`, and both plans. A rename should go
+  through an ADR update.
+
+### Neutral
+
+- **S2 could eventually run on the host too.** If the Compose setup is
+  dropped in a future revision, the host-side S2 reads ChromaDB
+  directly at its native path and this ADR stops applying. That
+  scenario is not in scope for v1; noting it here so a future migration
+  can cite ADR 011 as "formerly load-bearing, now obsolete".
+
+## Alternatives considered
+
+**A. Name the path `~/.config/zotero-mcp/chroma_db/` everywhere,
+bind-mount into the container at the same path.**
+Rejected. Breaks the `/workspace/*` convention inside the container
+and creates awkward Compose syntax (`${HOME}/.config/...:${HOME}/.config/...`).
+Also couples the container's filesystem layout to the host user's
+`$HOME`, which is leaky.
+
+**B. S2 maintains its own ChromaDB and runs a sync job against S3's.**
+Rejected. Doubles disk usage, adds a sync job that can drift, and
+introduces a third consistency model (S3 index vs S2 copy vs Zotero
+library state). The gracefully-degrading "empty means neutral" model
+already covers the case S3 had not indexed yet.
+
+**C. S2 does not use ChromaDB at all; compute embeddings on demand per
+candidate.**
+Rejected. Defeats the purpose of `score_semantic` being cheap (the
+index exists precisely to avoid re-embedding the library on every
+scoring call). On a 1500-paper library, per-query embedding would cost
+~$0.005 per scored candidate vs ~$0 against the cached index — the
+nightly full index cost is already paid by S3.
+
+**D. Bind-mount a named volume (`docker volume create zotero-mcp-chroma`)
+and document a separate sync step from the host into that volume.**
+Rejected. Named volumes are opaque to the host user — `zotero-mcp`
+would have to write into a Docker-managed path instead of its default.
+That leaks Docker into S3's surface, which ADR 001 explicitly avoids
+for anything the user interacts with outside the container.
+
+## References
+
+- `docs/plan_02_subsystem2.md` §7.3, §12, §15
+- `docs/plan_03_subsystem3.md` §4.3, §8, §11
+- `docs/decisions/001-use-docker.md` — Docker as the distribution
+  boundary
+- `docs/decisions/002-sqlite-for-state.md` — the parallel case for
+  state.db: one canonical path, one writer, consumers read from the
+  same file
+- `CLAUDE.md` — "Reglas sobre Docker": `/workspace/*` is the canonical
+  container path naming

--- a/docs/decisions/012-apscheduler-default-cron-alternative.md
+++ b/docs/decisions/012-apscheduler-default-cron-alternative.md
@@ -1,0 +1,175 @@
+# ADR 012 — APScheduler in-process is the default; cron/Task Scheduler is the documented alternative
+
+**Status**: Accepted
+**Date**: 2026-04-22
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+S2's worker (plan_02 §9) runs one fetch cycle every N hours: pull
+configured RSS feeds, deduplicate, enrich, score, persist. There are
+two plausible ways to get the cycle to run on a schedule:
+
+- **In-process**: APScheduler living inside the dashboard's FastAPI
+  app, firing the `run_fetch_cycle()` coroutine on an interval. The
+  dashboard and worker share one Python process, one set of DB
+  connections, and one Compose service.
+- **Out-of-process**: an OS-level scheduler (cron on Linux/macOS,
+  Task Scheduler on Windows) invoking `docker compose run --rm
+  onboarding zotai s2 fetch-once` at the desired cadence, independent
+  of whether the dashboard is up.
+
+plan_02 §9 named APScheduler as "decisión preliminar" without fully
+committing, leaving the choice floating. The review that produced this
+ADR found that scenario α (single researcher, heterogeneous usage
+patterns) does not have one right answer: some users keep the
+dashboard open continuously and want everything bundled; others open
+the dashboard once a week for the triage session and want fetches to
+happen regardless.
+
+## Decision
+
+**APScheduler in-process is the default. cron / Task Scheduler is
+documented as an alternative for users whose dashboard is not up 24/7.
+Both paths call the same `zotai s2 fetch-once` code path.**
+
+Concretely:
+
+1. **Default behaviour (APScheduler).** When the `dashboard` Compose
+   service starts, `src/zotai/s2/worker.py` registers a job with
+   APScheduler that invokes `run_fetch_cycle()` every
+   `S2_FETCH_INTERVAL_HOURS` (default 6). This is the single-command
+   experience advertised in the README quickstart (`docker compose up
+   dashboard`). Both the worker and the FastAPI routes share one
+   process, one `candidates.db` connection pool, one set of env vars.
+
+2. **Opt-out switch.** Setting `S2_WORKER_DISABLED=true` in `.env`
+   prevents APScheduler from registering the job. The dashboard still
+   serves `/inbox`, but the job never fires from inside the container.
+   This is the switch a user flips when they prefer to drive fetches
+   externally.
+
+3. **Alternative path (cron / Task Scheduler).** With
+   `S2_WORKER_DISABLED=true`, users install an OS-level scheduler job
+   that runs:
+
+   ```bash
+   docker compose run --rm onboarding zotai s2 fetch-once
+   ```
+
+   `docs/setup-linux.md` ships a `crontab -e` example; `docs/setup-
+   windows.md` ships a Task Scheduler XML snippet. Both Phase 9 (#10)
+   deliverables.
+
+4. **Single implementation.** `zotai s2 fetch-once` (exposed via the
+   CLI in `cli.py` stub form since Phase 1, wired in Phase 11 #12) and
+   APScheduler's in-process callback both call the same
+   `run_fetch_cycle()` function. There is no duplicated scheduling
+   logic. Anything that changes in the fetch cycle (rate limits, error
+   handling, budget enforcement) applies to both paths uniformly.
+
+5. **Dashboard exposes `/worker/run-now`.** Per plan_02 §8.1, the
+   dashboard surfaces a button that triggers an immediate fetch cycle.
+   This works regardless of whether APScheduler is enabled — it calls
+   `run_fetch_cycle()` directly in a background task — so a user who
+   has disabled APScheduler can still force a fetch from the UI when
+   they want one.
+
+## Consequences
+
+### Positive
+
+- **Defaults match the 80% case.** Most researchers leave the
+  dashboard running; for them, "it just works" is the APScheduler
+  path and there is nothing to configure.
+- **Power users are not blocked.** A user on a laptop that they close
+  nightly can get reliable fetches by flipping one env var and
+  setting up cron once. No custom S2 support code required.
+- **One code path for fetch logic.** Tests cover
+  `run_fetch_cycle()` directly; both schedulers are thin wrappers
+  around it. A bug fixed in the logic is fixed everywhere.
+- **Scheduler choice is observable.** A
+  `/metrics` panel (plan_02 §8.1) surfaces which path is active (
+  "APScheduler (next run in 2h 15m)" vs "External scheduler
+  (last fetch: 4h ago)"), so the user always knows which knob to
+  twist.
+- **Matches Compose lifecycle.** APScheduler stops cleanly when the
+  dashboard container stops (FastAPI's lifespan callback kills the
+  scheduler), so there is no orphaned worker process.
+
+### Negative
+
+- **APScheduler default has a failure mode.** If the dashboard crashes
+  overnight and Docker's `restart: unless-stopped` does not bring it
+  back (e.g. the user `docker compose down`'d it), fetches silently
+  stop. The `/metrics` panel catches this on the user's next visit,
+  but there is no active notification. For v1, that is acceptable —
+  S2 is a weekly-touch workflow, not a SRE-monitored service. Adding
+  alerting is out of scope (plan_02 §14).
+- **Two code paths to document.** `docs/s2-user-guide.md` (Phase
+  14 #15) must cover both. Users have one more knob to think about
+  than a single-scheduler design would have required.
+- **Cross-container invocation from cron.** On Windows, Task Scheduler
+  launching `docker compose run ...` has to inherit the right
+  environment (Docker Desktop running, WSL available). We document
+  the gotcha in `docs/setup-windows.md` and accept it as part of the
+  Windows installation complexity that ADR 001 already absorbs.
+
+### Neutral
+
+- **Scheduler choice is reversible.** Flipping between the two paths
+  requires no data migration — both produce the same rows in
+  `candidates.db`. A user can start with APScheduler and switch to
+  cron later (or vice versa) with a single env var change.
+
+## Alternatives considered
+
+**A. APScheduler only, no cron path.**
+Rejected. Breaks the use case of users who run the dashboard on
+demand. They would have to keep it running 24/7 just to get the
+background fetches, which doesn't match how the triage workflow is
+meant to be used (15-20 min/week, not continuously).
+
+**B. cron/Task Scheduler only, no in-process scheduler.**
+Rejected. Requires every user to write an OS-level scheduled task
+during setup. For a user on Windows who does not know Task Scheduler,
+this is a meaningful onboarding hurdle — and more importantly, the
+"default experience" in the README quickstart becomes 5+ lines of
+setup instructions per OS. ADR 001 explicitly trades off in favour of
+"fewer manual steps" for the default path.
+
+**C. A separate worker service in Compose with its own container.**
+Rejected. Two containers sharing `candidates.db` is a write
+contention risk (SQLite concurrent writes), adds a second service to
+the Compose file, and duplicates the env-var surface. The in-process
+approach avoids all three.
+
+**D. systemd timer units (Linux-only).**
+Rejected as the primary path. systemd timers are more robust than
+cron but do not help Windows users, and the target audience includes
+both OSes. Documented as a footnote in `docs/setup-linux.md` for
+users who prefer systemd over cron.
+
+**E. `S2_WORKER_MODE={apscheduler|cron|disabled}` enum instead of a
+boolean.**
+Rejected. The enum adds a third state ("cron") that behaves
+identically to `disabled` from the container's perspective — the
+scheduler code does nothing either way. The difference (cron is
+running on the host) is external to the container. A single boolean
+keeps the container's behaviour simple and pushes the host-side
+detail where it belongs, in the setup docs.
+
+## References
+
+- `docs/plan_02_subsystem2.md` §9 (worker), §8.1 (`/worker/run-now`),
+  §15 (dependencies)
+- `docs/decisions/001-use-docker.md` — the distribution boundary ADR
+  that this one builds on
+- Issue #15 — Phase 14 S2 Sprint 4 will wire APScheduler; the cron
+  recipe is a Phase 9 (#10) deliverable
+- `src/zotai/cli.py` — `zotai s2 fetch-once` command wiring (stub as
+  of Phase 1; implementation in Phase 11 #12)

--- a/docs/plan_02_subsystem2.md
+++ b/docs/plan_02_subsystem2.md
@@ -315,11 +315,13 @@ def composite_score(c: Candidate, weights: Weights) -> float:
 
 **Archivo**: `src/zotai/s2/worker.py`
 
-**Tecnología**: APScheduler (in-process) o cron externo invocando `zotai s2 fetch`.
+**Tecnología**: APScheduler in-process es el default; cron / Task Scheduler es la alternativa para usuarios que no mantienen el dashboard corriendo 24/7. Ambos caminos invocan la misma función `run_fetch_cycle()`. Ver **ADR 012** (`docs/decisions/012-apscheduler-default-cron-alternative.md`) para el detalle de la decisión y la receta de cron.
 
-**Decisión preliminar**: APScheduler, porque corre en el mismo container que el dashboard, simplifica deploy. Alternativa cron si el dashboard no está 24/7.
+- **APScheduler default**: `docker compose up dashboard` arranca el scheduler en el mismo proceso que FastAPI. No hay pasos adicionales.
+- **Cron alternativo**: setear `S2_WORKER_DISABLED=true` en `.env` y configurar un job del SO que ejecute `docker compose run --rm onboarding zotai s2 fetch-once`. Recetas por OS en `docs/setup-linux.md` y `docs/setup-windows.md` (Phase 9 / #10).
+- **Dashboard `/worker/run-now`** dispara un fetch inmediato por background task, independiente del scheduler (plan §8.1).
 
-**Frecuencia default**: cada 6 horas. Configurable.
+**Frecuencia default**: cada 6 horas. Configurable via `S2_FETCH_INTERVAL_HOURS`.
 
 **Lógica del job**:
 ```python
@@ -362,16 +364,20 @@ Se dispara cuando un candidate se marca `accepted`.
    5. Sci-Hub (búsqueda por DOI)
    6. URL del RSS (si sirve PDF directo)
 
-   Cada fuente es configurable via `.env` (`S2_PDF_SOURCES`). Un fetch por
-   candidato aceptado, rate-limited por servicio. Si ninguna fuente entrega
-   PDF, el item mantiene el tag `needs-pdf`.
+   Cada fuente es configurable via `.env` (`S2_PDF_SOURCES`). **Knobs de control**:
+   - `S2_PDF_FETCH_MAX_ATTEMPTS_PER_CANDIDATE` (default 6) — tope de fuentes que se prueban antes de declarar el candidate como `needs-pdf`.
+   - `S2_PDF_FETCH_TIMEOUT_SECONDS` (default 30) — timeout por fuente; una fuente lenta no bloquea al worker.
+   - `S2_PDF_FETCH_MAX_MINUTES_WEEKLY` (default 20) — budget global wall-clock por semana para fetch de PDFs. Al excederlo, el worker salta el fetch y etiqueta `needs-pdf`; evita que un outage prolongado de Sci-Hub/LibGen queme tiempo del usuario. Se resetea el lunes 00:00 local.
+
+   Si ninguna fuente entrega PDF dentro del budget, el item mantiene el tag `needs-pdf` y queda visible en el dashboard para retry manual.
 3. Aplicar tags derivados del scoring (los que mejor matchearon).
-4. Mover a colección "Inbox S2" en Zotero (configurable).
+4. Mover a colección "Inbox S2" en Zotero. **El push la crea on-demand e idempotentemente** — si no existe, S2 la crea; si ya existe, la usa. El nombre viene de `S2_ZOTERO_INBOX_COLLECTION` (default `Inbox S2`). No se le pide al usuario que la cree a mano.
 5. Update del candidate: `zotero_item_key`, `pushed_at`.
 
 **Edge cases**:
 - Item ya existe en Zotero (mismo DOI): no duplicar, solo marcar `zotero_item_key` al existente.
 - Push falla (API error, red): retry con backoff, eventualmente marcar `push_failed`, mostrar en dashboard.
+- Colección `Inbox S2` renombrada por el usuario entre runs: la próxima corrida crea una nueva con el nombre canónico — no buscamos por nombre viejo. Si el usuario quiere renombrar persistentemente, también cambia `S2_ZOTERO_INBOX_COLLECTION` en `.env`.
 
 ---
 
@@ -437,8 +443,22 @@ Se dispara cuando un candidate se marca `accepted`.
 # ──────────── S2 Worker ────────────
 S2_FETCH_INTERVAL_HOURS=6
 S2_CANDIDATES_DB=/workspace/candidates.db
-S2_CHROMA_PATH=/workspace/chroma_db   # compartido con S3
-S2_ZOTERO_INBOX_COLLECTION=Inbox S2   # nombre de la colección destino
+# Container-side path. Montado desde la ChromaDB del host por el servicio
+# `dashboard` en docker-compose.yml. Ver ADR 011 y plan_03 §4.3 / §8.
+S2_CHROMA_PATH=/workspace/chroma_db
+# Host-side source para el bind mount. Default coincide con el path que planta
+# `zotero-mcp setup`. Override si tenés ChromaDB en otra ubicación.
+ZOTERO_MCP_CHROMA_HOST_PATH=${HOME}/.config/zotero-mcp/chroma_db
+# Cambiar a `true` para deshabilitar APScheduler in-process y usar cron/Task
+# Scheduler externo. Ver ADR 012.
+S2_WORKER_DISABLED=false
+S2_ZOTERO_INBOX_COLLECTION=Inbox S2   # S2 crea la colección on-demand
+
+# ──────────── S2 PDF fetch cascade ────────────
+S2_PDF_SOURCES=openaccess,doi,annas,libgen,scihub,rss
+S2_PDF_FETCH_MAX_ATTEMPTS_PER_CANDIDATE=6
+S2_PDF_FETCH_TIMEOUT_SECONDS=30
+S2_PDF_FETCH_MAX_MINUTES_WEEKLY=20
 
 # ──────────── S2 Dashboard ────────────
 S2_DASHBOARD_HOST=127.0.0.1
@@ -483,6 +503,6 @@ Cada una es un ticket para v1.1+.
 ## 15. Dependencias del S2
 
 - **S1** debe haber corrido: necesitamos biblioteca poblada para que el scoring funcione.
-- **S3** debe estar operativo: necesitamos ChromaDB para el score semántico.
-- **Zotero abierto** con API local (igual que S1).
-- **Worker y dashboard corriendo**: típicamente en el mismo Docker container (misma imagen), separado por service en docker-compose.
+- **S3** debe estar operativo: necesitamos ChromaDB para el score semántico. El acceso concreto se hace via bind mount read-only (`/workspace/chroma_db` dentro del container ← path del host). Ver ADR 011. Si ChromaDB está vacía o no existe todavía, `score_semantic=0.5` (neutral) y el dashboard sigue funcionando.
+- **Zotero abierto** con API local (igual que S1). S2 crea la colección `Inbox S2` (o el nombre en `S2_ZOTERO_INBOX_COLLECTION`) on-demand e idempotentemente en el primer push.
+- **Worker y dashboard corriendo**: por default APScheduler in-process en el mismo container del dashboard (ADR 012). Usuarios que no mantienen el dashboard 24/7 pueden setear `S2_WORKER_DISABLED=true` y usar cron / Task Scheduler externos (receta en `docs/setup-{linux,windows}.md`).

--- a/docs/plan_03_subsystem3.md
+++ b/docs/plan_03_subsystem3.md
@@ -83,8 +83,10 @@ Permitir al investigador consultar su biblioteca Zotero desde Claude Desktop med
 
 ### 4.3 ChromaDB local
 
-- Path: `~/.config/zotero-mcp/chroma_db/` (default) o configurable.
-- **Shared con S2**: `S2_CHROMA_PATH` en `.env` apunta a este mismo path. S2 lee-only.
+- **Path en el host** (donde `zotero-mcp` escribe): `~/.config/zotero-mcp/chroma_db/` por default. Configurable en `.env` via `ZOTERO_MCP_CHROMA_HOST_PATH` — típicamente coincide con lo que `zotero-mcp setup` elige.
+- **Path en el container S2** (donde S2 lee): `/workspace/chroma_db`. Es siempre este valor, consistente con la convención `/workspace/*` del resto del container. `S2_CHROMA_PATH=/workspace/chroma_db` por default.
+- **El puente**: el servicio `dashboard` de `docker-compose.yml` monta el path del host en `/workspace/chroma_db:ro` (read-only para S2). Ver **ADR 011** (`docs/decisions/011-chromadb-bind-mount.md`) para el rationale completo.
+- **S2 lee, nunca escribe.** El mount es `:ro`, así que un bug que intente `chroma.add()` falla fuerte en vez de divergir silenciosamente del índice que mantiene `zotero-mcp`.
 
 ---
 
@@ -209,11 +211,11 @@ Problemas comunes:
 
 ## 8. Integración con S2 (shared ChromaDB)
 
-S2 usa el mismo ChromaDB para su criterio `score_semantic`. Implicancias:
+S2 usa el mismo ChromaDB que `zotero-mcp` para su criterio `score_semantic`. Detalles en ADR 011; resumen:
 
-- **Path compartido**: configurar `S2_CHROMA_PATH` en `.env` al mismo path que `zotero-mcp` (default `~/.config/zotero-mcp/chroma_db/`).
-- **S2 solo lee**: nunca escribe a ChromaDB, solo queries.
-- **Si ChromaDB vacía o desincronizada**: S2 degrada gracefully, `score_semantic=0.5` (neutral).
+- **Un solo store físico en disco**: el que `zotero-mcp` mantiene en `${ZOTERO_MCP_CHROMA_HOST_PATH:-$HOME/.config/zotero-mcp/chroma_db}`. No hay copia ni sync job.
+- **S2 lo ve via bind mount** en `/workspace/chroma_db` (read-only). El container nombra `S2_CHROMA_PATH=/workspace/chroma_db`; el host decide qué directorio "real" se monta ahí.
+- **Si ChromaDB vacía o desincronizada** (p.ej. el usuario nunca terminó el setup de S3): S2 degrada gracefully, `score_semantic=0.5` (neutral). El dashboard muestra un warning apuntando a `docs/s3-setup.md`.
 
 ---
 
@@ -225,7 +227,7 @@ S2 usa el mismo ChromaDB para su criterio `score_semantic`. Implicancias:
 - [ ] `docs/s3-troubleshooting.md` con problemas comunes.
 - [ ] `docs/decisions/006-zotero-mcp.md` ADR justificando no desarrollar custom.
 - [ ] Script helper `scripts/reindex-s3.sh` (y `.ps1`) para re-indexación fácil.
-- [ ] Verificación de que `S2_CHROMA_PATH` está documentado coherentemente entre S2 y S3.
+- [ ] Verificación de que `S2_CHROMA_PATH` está documentado coherentemente entre S2 y S3 (cumplido por ADR 011 y los edits de §4.3 / §8).
 
 ---
 

--- a/docs/plan_taxonomy.md
+++ b/docs/plan_taxonomy.md
@@ -149,5 +149,78 @@ metodo:
 
 - [ ] Revisar esta lista sugerida y ajustarla al perfil real del corpus.
 - [ ] Completar descripciones y synonyms de cada tag.
-- [ ] Guardar en `config/taxonomy.yaml`.
+- [ ] Guardar en `config/taxonomy.yaml` y cambiar `status: template` por `status: customized`.
 - [ ] Commit a repo antes de correr `zotai s1 tag`.
+
+---
+
+## 8. Adaptar la taxonomía a tu dominio
+
+La lista de `config/taxonomy.yaml` viene sesgada a economía / ciencias sociales con foco LATAM. Si tu corpus es de otro dominio (biomedicina, física de altas energías, derecho, humanidades digitales, etc.), tenés que reemplazarla — no sumarle. El objetivo es que las etiquetas reflejen *tu* campo, no una sobre-cobertura de múltiples campos.
+
+### 8.1 Qué hace una buena tag
+
+Una tag útil cumple cuatro condiciones:
+
+1. **Granularidad adecuada**: ni tan amplia que taggée al 60% del corpus (`economia`, `biologia` — inútil para búsqueda), ni tan angosta que solo matchée 1-2 papers (`efectos-del-covid-sobre-la-tasa-de-actividad-femenina-en-CABA`). Apuntar a 3-10% del corpus por tag como zona saludable.
+2. **Ortogonalidad**: dos tags del mismo nivel no deberían ser casi-sinónimos. Si existieran `macro-monetaria` y `banca-central`, habría que elegir uno y mandar el otro a `synonyms`. En caso de duda, aplicar el **test del LLM**: ¿un tagger razonable podría dudar entre estas dos tags para el mismo paper? Si sí, son redundantes.
+3. **Estabilidad semántica**: la tag significa hoy lo mismo que va a significar dentro de 2 años. Evitar tags acopladas a eventos o modas (`post-pandemia`, `era-IA`) — esas son mejor en el `Date` nativo de Zotero.
+4. **Referible en una frase**: si no podés escribir una `description` de 1 línea para la tag, la tag no está clara todavía. Los `synonyms` son para variaciones de vocabulario (inglés/castellano, acrónimos), no para pegar varios conceptos.
+
+### 8.2 Cómo pensar TEMA vs METODO
+
+**TEMA responde "¿de qué es?"**. **METODO responde "¿cómo lo aborda?"**.
+
+Si te encontrás con una tag candidata en la que no está claro cuál de los dos es, probablemente estás mezclando: `tema-teorico` es malo (teórico es método), `empirico-macro` es malo (macro es tema). Las dos dimensiones se componen: un paper puede ser `macro-fiscal` × `empirico-quasi-exp`.
+
+Si tu dominio no tiene una división natural tema/método (p.ej. muchas humanidades), podés dejar METODO con 2-3 tags muy amplios (`narrativo-historico`, `caso-estudio`, `revision-literatura`) y poner el grueso del poder discriminativo en TEMA.
+
+### 8.3 Walkthrough: adaptar a biomedicina
+
+Para orientar, un ejemplo mínimo de cómo se vería la plantilla aplicada a un corpus de biomedicina traslacional:
+
+```yaml
+tema:
+  - id: oncologia-solida
+    description: "Tumores sólidos: mama, pulmón, colorrectal, próstata, etc."
+    synonyms: ["solid tumors", "breast cancer", "lung cancer"]
+  - id: hematologia
+    description: "Leucemias, linfomas, mieloma"
+    synonyms: ["leukemia", "lymphoma"]
+  - id: inmunoterapia
+    description: "Checkpoint inhibitors, CAR-T, vacunas terapéuticas"
+    synonyms: ["immunotherapy", "CAR-T", "checkpoint inhibitors"]
+  - id: farmacogenomica
+    description: "Variación genética y respuesta a drogas"
+    synonyms: ["pharmacogenomics"]
+  # ... (continuar 20-30 más)
+
+metodo:
+  - id: ensayo-clinico-fase-iii
+    description: "Ensayos clínicos de fase III, randomizados"
+    synonyms: ["phase III", "randomized clinical trial"]
+  - id: ensayo-clinico-temprano
+    description: "Fase I / II, pilotos, seguridad"
+    synonyms: ["phase I", "phase II"]
+  - id: estudio-preclinico
+    description: "Modelos animales, in vitro"
+    synonyms: ["preclinical", "in vivo", "in vitro"]
+  - id: observacional-cohorte
+    description: "Estudios de cohorte, case-control"
+    synonyms: ["cohort study", "case-control"]
+  # ... (continuar hasta ~10-12)
+```
+
+Este ejemplo ilustra el patrón: **TEMA se ancla a subespecialidades del dominio; METODO a niveles de evidencia / tipos de estudio del dominio**. La división es paralela a la de economía (TEMA = áreas, METODO = estrategia empírica), solo que el contenido cambia.
+
+### 8.4 Smoke-test antes de correr `zotai s1 tag`
+
+Antes del primer `--apply`, usar `--preview` sobre una muestra del corpus (20-30 items variados) y revisar el CSV resultante:
+
+- [ ] **Cobertura**: al menos 1 TEMA y 1 METODO por item.
+- [ ] **Reparto**: ningún tag aparece en >80% de los items (si pasa: tag demasiado amplio, split).
+- [ ] **Reparto**: ningún tag aparece en 0% (si pasa: tag nunca matchea, considerar borrar o ajustar `description`/`synonyms`).
+- [ ] **Consistencia manual**: elegir 5 items al azar y chequear que los tags que el LLM aplicó son los que vos hubieras elegido. Si hay desacuerdo sistemático en un tag, revisar su `description`.
+- [ ] **Tags inventados**: verificar que el CSV no tiene valores fuera de la taxonomía (el stage valida esto, pero conviene chequear a ojo).
+
+Si el smoke-test es OK, correr `--apply`. Si no, editar `config/taxonomy.yaml` y repetir el preview — la iteración es barata ($0.001 por 25 items).


### PR DESCRIPTION
Follow-up to #33, tackling the five structural ambiguities the alignment review flagged.

## Summary

- **ADR 011 — ChromaDB bind mount.** Pins the canonical path to \`/workspace/chroma_db\` inside the container; the dashboard service bind-mounts the host's zotero-mcp directory read-only into that path. Host source is configurable via \`ZOTERO_MCP_CHROMA_HOST_PATH\`. Reconciles the conflicting paths that plan_02 §12 and plan_03 §4.3/§8 used to give.
- **ADR 012 — APScheduler default, cron alternative.** Commits to APScheduler in-process as the default; documents \`S2_WORKER_DISABLED=true\` + cron/Task Scheduler for users whose dashboard is not up 24/7. Both paths call the same \`run_fetch_cycle()\`.
- **Inbox S2 collection**: plan_02 §10 / §15 now state S2 creates it on-demand and idempotently — no manual bootstrap.
- **S2 PDF fetch budgets**: added \`S2_PDF_FETCH_MAX_ATTEMPTS_PER_CANDIDATE\`, \`S2_PDF_FETCH_TIMEOUT_SECONDS\`, and \`S2_PDF_FETCH_MAX_MINUTES_WEEKLY\` to plan_02 §10 and \`.env.example\`. The weekly wall-clock guard protects against outage-driven burn.
- **Taxonomy customization guide**: \`plan_taxonomy.md §8\` adds design principles, TEMA-vs-METODO framing, a biomedicine walkthrough, and a smoke-test checklist for \`zotai s1 tag --preview\`. \`config/taxonomy.yaml\`'s header comment rewritten to point there.

Docker Compose wiring for the ChromaDB bind mount is scoped to Phase 9 (#10); APScheduler wiring to Phase 14 (#15). This PR is spec/ADR/env only.

## Related issues

Aceptance criteria touched in the planned phases:
- **#10 (Phase 9, Docker finalization)**: add the \`:ro\` bind mount for ChromaDB per ADR 011.
- **#12 (Phase 11, S2 Sprint 1)**: degrade-to-neutral warning when ChromaDB source path is missing or empty.
- **#13 (Phase 12, S2 Sprint 2)**: enforce the three PDF-fetch knobs; S2 creates the \`Inbox S2\` collection on-demand in the push code path.
- **#15 (Phase 14, S2 Sprint 4)**: APScheduler wired per ADR 012; cron receta documented in \`docs/setup-{linux,windows}.md\`.

## Test plan

- [x] \`pytest -q\` green (111 passed) — this PR does not touch runtime code.
- [ ] Render the two ADRs on GitHub to confirm headings / links render.
- [ ] Confirm \`.env.example\` loads without warnings under pydantic-settings after Phase 9 finalizes the new vars in \`config.py\`.

## Out of scope

- Updating \`docker-compose.yml\` with the ChromaDB bind mount → Phase 9 (#10).
- Wiring the \`S2_WORKER_DISABLED\` / \`S2_PDF_FETCH_*\` vars into \`config.py\` → Phase 11-14 as each sub-module lands.
- Populating the biomedicine (or any other) taxonomy actually used by the user — the template stays as \`status: template\` in \`config/taxonomy.yaml\`.