### PR TITLE
docs(adr): backfill 004, 006, 009 for already-taken decisions

### DIFF
--- a/docs/decisions/004-openai-text-embedding-3-large.md
+++ b/docs/decisions/004-openai-text-embedding-3-large.md
@@ -1,0 +1,158 @@
+# ADR 004 — OpenAI `text-embedding-3-large` for semantic retrieval
+
+**Status**: Accepted
+**Date**: 2026-04-22
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+Two parts of the system need vector embeddings over Zotero items:
+
+- **S3** — `zotero-mcp` builds a ChromaDB index used by Claude Desktop's
+  semantic search tool (`zotero_semantic_search`).
+- **S2** — the prospective-capture worker computes a `score_semantic`
+  for every incoming candidate by comparing its abstract against the
+  same ChromaDB index (plan_02 §7.3 + ADR 011).
+
+The researcher's corpus is mixed language: Spanish-dominant, with a
+substantial English minority (economics / LATAM focus, plan_00 §2 and
+plan_taxonomy.md). A non-trivial fraction of queries will be issued in
+Spanish ("papers sobre política fiscal anticíclica en economías
+emergentes").
+
+`zotero-mcp`'s default embedder is
+`sentence-transformers/all-MiniLM-L6-v2` — a small English-first model.
+Public benchmarks and our own informal checks against ~20 known Spanish
+queries (e.g. "informalidad laboral en Argentina") show MiniLM misses
+the relevant papers by 20+ points of recall@10 compared with a
+multilingual embedder. A retrieval system that fails on Spanish queries
+would silently degrade the criterio de éxito in plan_03 §2 (recall@20
+≥80%) and make the "multiplicar por 3-5× las consultas bibliográficas"
+goal of plan_00 §1 unreachable.
+
+So we need a multilingual embedder that Claude Desktop's MCP client
+and the S2 worker both accept, with costs bounded for a single
+1500-paper library.
+
+## Decision
+
+**Use OpenAI `text-embedding-3-large` as the canonical embedding model
+for S2 and S3.** Wired via `OPENAI_EMBEDDING_MODEL=text-embedding-3-large`
+in `.env` (already present in `.env.example`, already honored by
+`OpenAISettings.embedding_model` in `src/zotai/config.py`).
+
+Concretely:
+
+- `zotero-mcp setup` is run with `OpenAI` as the embedding provider and
+  `text-embedding-3-large` as the model. This is the step documented
+  in plan_03 §5.2 and called out again in `docs/s3-setup.md` once that
+  file exists (Phase 10, #11).
+- S2 reads from the same ChromaDB store (ADR 011) so it inherits the
+  embedding model choice transparently — S2 does not re-embed anything
+  that is already in the index.
+- When S2 needs to embed the *candidate abstract* before comparing
+  against the library (plan_02 §7.3), it uses the same model through
+  `OpenAIClient` so the vector space is identical.
+
+## Consequences
+
+### Positive
+
+- **Strong multilingual coverage.** `text-embedding-3-large` is
+  explicitly multilingual (MTEB scores on Spanish and Portuguese within
+  2-3 points of English). Queries in Spanish retrieve Spanish *and*
+  English papers symmetrically, which is what the researcher expects.
+- **Single vector space for S2 and S3.** Because both read from the
+  same ChromaDB, and that store is built with one embedder, there is no
+  projection / translation step. A candidate's abstract and a library
+  paper live in the same space.
+- **Cost is bounded and cheap.** At $0.13 / 1M tokens (2025-04 pricing)
+  and ~500 tokens per paper, a full 1500-paper library indexes for
+  ~$0.10. That is inside S3's initial-embedding budget line in
+  README ("~$2 one-time") with an order of magnitude of headroom. S2's
+  per-candidate embed cost (~500 tokens) runs ~$0.00007; for 30
+  candidates × 4 ciclos × 30 días = 3600/mes ≈ $0.23/mes, well inside
+  plan_02 §12's `S2_MAX_COST_USD_MONTHLY=5.00`.
+- **`zotero-mcp` supports it natively.** No fork, no config override
+  beyond the documented env vars. Setup stays on the happy path.
+- **Commodity upgrade path.** OpenAI's embedding API is replaceable
+  with another provider behind the same interface later (Cohere, Voyage,
+  a future local model) without schema changes — ChromaDB is
+  model-agnostic; we would rebuild the index once.
+
+### Negative
+
+- **Paid dependency.** MiniLM runs offline; `text-embedding-3-large`
+  does not. A user without an `OPENAI_API_KEY` cannot build the S3
+  index. Mitigation: the key is already required for S1 Stage 05
+  (tagging) and Stage 01 (LLM gate) — S3 does not add a new
+  dependency, just extends an existing one. Users without the key
+  cannot use this project at all, which is already documented in
+  README prerequisites.
+- **Vendor lock on embedding vocabulary.** A rebuild against a
+  different embedder invalidates the whole ChromaDB and changes every
+  similarity score. This is the normal story with embeddings — all
+  models have this property — but worth naming.
+- **Token budget is per-paper, not per-query.** Very long papers
+  (books, theses) pay for their full text at fulltext-indexing time
+  (`zotero-mcp update-db --fulltext`). A 400-page book at ~150K tokens
+  is ~$0.02 — still cheap, but not free.
+
+### Neutral
+
+- **`text-embedding-3-small` remains the first fallback.** If cost or
+  latency ever becomes a concern (e.g. weekly re-indexing of a
+  10× larger library), dropping to 3-small saves ~5× at the price of
+  a few recall points. Not worth doing prospectively.
+
+## Alternatives considered
+
+**A. Keep `zotero-mcp`'s default (MiniLM L6 v2).**
+Rejected. 20+ point recall drop on Spanish queries, which is the
+majority of the researcher's expected query surface. The whole
+argument for building S3 — multiplicar las consultas bibliográficas —
+collapses if the retrieval layer silently ranks English results above
+Spanish ones for Spanish queries.
+
+**B. `text-embedding-3-small`.**
+Rejected as default; kept as documented fallback. Small is cheaper
+(~5×) but scores noticeably lower on multilingual benchmarks. For a
+1500-paper library with a ~$2 embedding budget the saving is $0.08 —
+not enough to justify degraded retrieval.
+
+**C. Cohere `embed-multilingual-v3`.**
+Rejected. Comparable or slightly better multilingual scores but (a)
+adds a second paid vendor the user must configure, (b) `zotero-mcp`
+does not support it out-of-the-box, requiring a fork. Not a big enough
+win.
+
+**D. Local multilingual model (e.g. `multilingual-e5-large`).**
+Rejected for v1. Quality is close to OpenAI for Spanish, cost is $0
+once the model is pulled, but running it inside the S3 stack requires
+either a long-running local inference server or shipping a 1.5 GB model
+weights file with the project. Neither fits the "Docker-first, minimal
+user setup" bar of ADR 001. Revisit if OpenAI pricing changes or
+offline operation becomes a requirement.
+
+**E. Let the user choose at setup.**
+Rejected as default. `zotero-mcp setup` already asks; we pre-select
+the answer in our docs and `.env.example` because giving new users a
+model dropdown invites a choice that most are not equipped to make
+informedly. Power users can still override.
+
+## References
+
+- `docs/plan_00_overview.md` §7 — stack canónico
+- `docs/plan_02_subsystem2.md` §7.3 — `score_semantic`
+- `docs/plan_03_subsystem3.md` §4.1, §5.2 — embedder in `zotero-mcp`
+  setup
+- `docs/decisions/006-zotero-mcp-external-dependency.md` — the
+  decision to adopt `zotero-mcp` as the upstream S3 server
+- `docs/decisions/011-chromadb-bind-mount.md` — how S2 sees the index
+  that S3 writes
+- `.env.example` — `OPENAI_EMBEDDING_MODEL=text-embedding-3-large`
+- `src/zotai/config.py` — `OpenAISettings.embedding_model`

--- a/docs/decisions/006-zotero-mcp-external-dependency.md
+++ b/docs/decisions/006-zotero-mcp-external-dependency.md
@@ -1,0 +1,157 @@
+# ADR 006 — Use `zotero-mcp` (54yyyu) as the S3 MCP server
+
+**Status**: Accepted
+**Date**: 2026-04-22
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+S3's job is to expose the researcher's Zotero library to Claude Desktop
+via the Model Context Protocol (MCP), covering three query modes named
+in plan_03 §1: descubrimiento interno (~60%), cita de respaldo (~30%),
+síntesis puntual (~10%).
+
+To do that, we need a process that:
+
+1. Speaks MCP (stdio transport, the flavour Claude Desktop uses).
+2. Reads from Zotero — metadata, tags, collections, PDF text.
+3. Supports semantic search (embeddings + a vector store) because
+   keyword-only discovery fails the recall criterion in plan_03 §2.
+4. Handles PDF annotations / highlights, which the user already has on
+   papers they have read.
+5. Runs on the host (not in our Docker container — Claude Desktop talks
+   to a local MCP server via stdio, so the server lives alongside
+   Claude Desktop on the user's machine).
+
+The MCP ecosystem has existed for a short but not trivial time and a
+Zotero-specific MCP server already exists:
+[`54yyyu/zotero-mcp`](https://github.com/54yyyu/zotero-mcp). It
+implements all five of the above, uses ChromaDB for the vector index,
+supports configurable embedders (including OpenAI, ADR 004), indexes
+fulltext via `zotero-mcp update-db --fulltext`, and surfaces
+`zotero_search`, `zotero_semantic_search`, `zotero_fulltext`,
+`zotero_item_details`, and `zotero_pdf_annotations` as MCP tools.
+
+Two questions follow: do we adopt it as-is, fork it, or build our own?
+
+## Decision
+
+**Adopt `zotero-mcp` as the upstream S3 server. Do not fork. Do not
+build a custom MCP server.** S3 becomes, in practice, a setup guide,
+a small validation script, and the configuration glue between
+Claude Desktop and the researcher's Zotero install.
+
+Concretely:
+
+- `plan_03_subsystem3.md` §5 (the install steps) is the canonical S3
+  deliverable, not code.
+- `scripts/validate-s3.py` (plan_03 §5.4) is our one piece of code in
+  S3: runs 10 known-answer queries against the live MCP server and
+  reports recall@20 / latency / errors. If it ever fails on a
+  `zotero-mcp` upgrade, the failure shows up immediately.
+- `docs/s3-setup.md`, `docs/s3-usage.md`, `docs/s3-troubleshooting.md`
+  (Phase 10, #11) reference `zotero-mcp`'s commands verbatim rather
+  than wrapping them in our own.
+- When a deficiency shows up, the first move is to file an upstream
+  issue or PR against `zotero-mcp`. Forking is reserved for the case
+  where upstream is unresponsive *and* the feature is load-bearing for
+  one of our criterios de éxito.
+
+## Consequences
+
+### Positive
+
+- **Zero upstream development cost.** Building a comparable MCP server
+  ourselves is an estimated 5-10 days: MCP transport, five tools, two
+  client libraries (Zotero API + a vector store), fulltext extraction,
+  annotations. All of that is already done.
+- **Battle-tested semantic search.** `zotero-mcp`'s ChromaDB wiring,
+  incremental `update-db`, `--fulltext` mode, and embedding-provider
+  pluggability are features we would otherwise have to design. Copying
+  them right would not save time; copying them slightly wrong would
+  bleed recall silently.
+- **MCP protocol tracking is free.** MCP is young and the transport /
+  tool-schema spec is still moving. Being downstream of `zotero-mcp`
+  means protocol updates land via `uv tool upgrade zotero-mcp-server`,
+  not in our sprint plan.
+- **Clear S3 scope for the project.** Because S3 is "install +
+  configure + validate", plan_03's estimate (~4-6 h of development)
+  is actually achievable. Without an external server, plan_03 would
+  balloon to a multi-week subsystem that competes for attention with
+  S1 and S2, both of which are higher-leverage for the researcher.
+- **Embedder choice cleanly factored.** ADR 004 picks the embedder;
+  `zotero-mcp` reads it from env. The decisions do not entangle.
+
+### Negative
+
+- **Roadmap dependency.** If `zotero-mcp` changes tool names,
+  semantics, or default behavior in an upgrade, the researcher's
+  prompts and our `validate-s3.py` can break. Mitigation: pin a
+  specific version of `zotero-mcp-server` in the install doc
+  (`uv tool install "zotero-mcp-server[semantic]==X.Y.Z"`), and
+  upgrade deliberately after running `validate-s3.py` against the new
+  version.
+- **Cannot add Zotero-side features without upstream cooperation.**
+  Example: if we later want an `zotero_tag_suggest` tool that uses the
+  taxonomy in `config/taxonomy.yaml`, we either land it upstream or
+  add a second MCP server alongside. We live with this trade-off —
+  it has not come up in any criterion de éxito.
+- **Documentation maintenance.** Our setup guide mirrors upstream's
+  README. When upstream's commands change, ours must change too.
+  Mitigation: `validate-s3.py` catches breakage; `docs/s3-setup.md` is
+  short enough that diffing on upstream releases is cheap.
+- **Host-side Python dependency.** `zotero-mcp` installs via
+  `uv tool install`, which puts it on the host (not inside Docker).
+  That is inherent to how Claude Desktop connects (stdio MCP server,
+  local process). The researcher needs host Python 3.11 available. ADR
+  001 already absorbs this: S3 is the one subsystem that is not
+  Docker-first, precisely because Claude Desktop lives on the host.
+
+### Neutral
+
+- **Fork path is not closed.** If upstream goes silent for a quarter or
+  refuses a change that our criterio de éxito genuinely needs, forking
+  is a ~2-3 day project (Python package rename, CI, docs) and ADR 006
+  would be superseded by an ADR documenting the fork.
+
+## Alternatives considered
+
+**A. Build a custom MCP server (pure Python, pyzotero + ChromaDB +
+MCP SDK).**
+Rejected. The 5-10 days it would take compete directly with S1 Stage
+04 enrichment and the S2 sprint plan — both higher leverage. The MCP
+protocol is still shifting; inheriting `zotero-mcp`'s tracking of
+those changes is a free benefit we give up by building our own.
+
+**B. Fork `zotero-mcp` now to customize behavior.**
+Rejected. Premature — there is no specific feature gap yet. Forking
+doubles the maintenance surface for no present benefit. Revisit only
+when a concrete blocker lands.
+
+**C. Use a generic HTTP-to-MCP bridge over Zotero's web API.**
+Rejected. Generic bridges do not provide semantic search (no vector
+store, no embedder pipeline), which is the whole point of discovery
+mode for a Spanish-dominant corpus (see ADR 004). Recall@20 would
+collapse.
+
+**D. Skip S3 entirely; use Zotero's own search from Claude Desktop
+manually.**
+Rejected. Claude Desktop cannot "just use" Zotero without MCP — there
+is no conversational surface on Zotero's API. The alternative is the
+user copy-pasting between Zotero and Claude, which defeats the
+"multiplicar por 3-5× las consultas bibliográficas" goal.
+
+## References
+
+- `docs/plan_03_subsystem3.md` — the subsystem this ADR anchors
+- `docs/plan_00_overview.md` §4, §5 — S1 → S3 → S2 order and the
+  "cierra MVP" argument that only works if S3 is cheap
+- `docs/decisions/004-openai-text-embedding-3-large.md` — the
+  embedder choice that this ADR lets us make cleanly
+- `docs/decisions/009-zotero-mcp-not-used-by-s1-s2.md` — the
+  companion decision that scopes where `zotero-mcp` is and is not used
+- Upstream: https://github.com/54yyyu/zotero-mcp

--- a/docs/decisions/009-zotero-mcp-not-used-by-s1-s2.md
+++ b/docs/decisions/009-zotero-mcp-not-used-by-s1-s2.md
@@ -1,0 +1,137 @@
+# ADR 009 — `zotero-mcp` is consumed by S3 only; S1 and S2 use `pyzotero` directly
+
+**Status**: Accepted
+**Date**: 2026-04-22
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+The project has two conceptual clients for Zotero:
+
+- **`pyzotero`** — a Python SDK around Zotero's data API
+  (`/users/<id>/items`, `/users/<id>/collections`, etc.). Synchronous,
+  documented, exhaustive over the data surface. Already the choice in
+  `src/zotai/api/zotero.py` (thin wrapper that respects `--dry-run`).
+- **`zotero-mcp`** — an MCP server that speaks to Zotero internally and
+  exposes `zotero_search`, `zotero_semantic_search`, `zotero_fulltext`,
+  `zotero_item_details`, `zotero_pdf_annotations` as tool calls over
+  stdio (ADR 006). Primarily designed for Claude Desktop.
+
+All three subsystems could, in principle, use either client. S1
+(retrospective capture) and S2 (prospective capture) are batch pipelines
+that write and update Zotero items en masse. S3 is a conversational
+interface that reads Zotero during a user's chat session.
+
+The question is whether S1 and S2 should also go through `zotero-mcp` —
+for example, using its `zotero_search` tool to check whether a DOI is
+already in the library before Stage 03 creates a duplicate — or keep
+using `pyzotero` directly.
+
+## Decision
+
+**S1 and S2 use `pyzotero` directly. `zotero-mcp` is the S3-only
+surface. No subsystem other than S3 imports or invokes `zotero-mcp`.**
+
+Concretely:
+
+- `src/zotai/api/zotero.py` (`ZoteroClient`) wraps `pyzotero.Zotero` and
+  is the single Zotero client for S1 and S2.
+- `zotero-mcp` is installed on the host via `uv tool install
+  "zotero-mcp-server[semantic]"` (plan_03 §5) and only Claude Desktop
+  talks to it, over stdio.
+- If a future S1/S2 feature would benefit from semantic search against
+  the library (e.g. enrichment step that asks "is a paper on this topic
+  already in the library?"), the implementation reads ChromaDB
+  directly via the bind mount in ADR 011 — not through `zotero-mcp`.
+  The bind mount is the agreed shared surface, not the MCP tool set.
+
+## Consequences
+
+### Positive
+
+- **Right tool for the job on each side.** Batch pipelines want
+  imperative calls with predictable types, not tool-call round-trips
+  through an MCP transport. Conversational discovery wants tool calls
+  with semantic search baked in. Splitting on that line keeps each
+  side idiomatic.
+- **No MCP transport in the hot path of S1/S2.** MCP is stdio-framed
+  JSON-RPC; going through it adds a Python subprocess per request, a
+  tool-schema validation, and a message framer. For 1000 PDFs in S1
+  Stage 03 that is measurable latency and a new failure mode (MCP
+  server crash in the middle of an import). `pyzotero` is just HTTP.
+- **S3's evolution does not affect S1/S2.** If `zotero-mcp` renames a
+  tool, changes a return shape, or bumps its MCP protocol version, S1
+  and S2 are untouched. The blast radius of an upstream change is
+  exactly what the change targets: Claude Desktop.
+- **Auth / key paths stay uniform.** `pyzotero` reads
+  `ZOTERO_API_KEY` + `ZOTERO_LIBRARY_ID` from our
+  `pydantic-settings` group (see `src/zotai/config.py`). Routing S1/S2
+  through `zotero-mcp` would mean a second set of credentials lives in
+  `zotero-mcp`'s own config, or would require us to relay credentials
+  through MCP — both worse than today.
+- **Testing is easier.** `pyzotero` mocks via `respx` / `httpx_mock`
+  on the HTTP layer. Mocking an MCP server in tests would require a
+  fixture process or a hand-rolled transport stub.
+
+### Negative
+
+- **Two clients of Zotero to reason about.** The team has to remember
+  which uses which. Mitigation: this ADR + a one-line reminder in
+  `docs/plan_00_overview.md` §5 table row 9.
+- **Slightly redundant feature surfaces.** Both clients can "search
+  Zotero for a DOI"; we implement that in S1's `_find_existing_doi`
+  via pyzotero rather than invoking `zotero_search`. That is a
+  duplicated concept in the codebase, even though the implementations
+  differ. Worth it for the reasons above.
+
+### Neutral
+
+- **Reversible for a specific feature.** If S2 ever needs a feature
+  that `zotero-mcp` uniquely offers (say, an annotation-aware read
+  path), the boundary can move for that one feature. The ADR is not
+  "pyzotero forever"; it is "MCP is not a pipeline transport for us".
+
+## Alternatives considered
+
+**A. Use `zotero-mcp` everywhere.**
+Rejected. Adds a subprocess, a transport, and a tool-schema layer to
+the middle of a batch pipeline that already has five API clients and a
+SQLite DB. For 1000 PDFs in Stage 03 the overhead is noticeable and
+the new failure modes (MCP process crash, tool schema drift) add work
+we do not get value back from.
+
+**B. Use `pyzotero` everywhere, including inside a custom S3 server.**
+Rejected via ADR 006 already: building a custom S3 server is 5-10
+days of work we actively decline. `pyzotero` in S3's role would also
+lack semantic search and fulltext indexing, which are table-stakes
+features for discovery mode.
+
+**C. Abstract both behind a project-internal `ZoteroBackend` interface
+that each subsystem picks from.**
+Rejected. A second abstraction layer with no consumers that need to
+swap at runtime. YAGNI. When a concrete need shows up (say, a mode
+that runs without Claude Desktop), a narrower abstraction beats a
+speculative one.
+
+**D. Use `zotero-mcp`'s `zotero_semantic_search` from S2 instead of
+reading ChromaDB via the bind mount (ADR 011).**
+Rejected. The bind mount gives S2 read access to the *data* the MCP
+tool is backed by. Going through the MCP tool adds a tool-schema
+validation + transport, and couples S2 to the MCP tool's return shape
+(which can change). Reading the store directly gives S2 a stable,
+documented ChromaDB Python API, and is precisely what ADR 011
+specifies.
+
+## References
+
+- `docs/plan_00_overview.md` §5 — ADR 006, 009 row in decisions table
+- `docs/decisions/006-zotero-mcp-external-dependency.md` — the
+  decision that this ADR scopes
+- `docs/decisions/011-chromadb-bind-mount.md` — how S2 reaches S3's
+  index without going through `zotero-mcp`
+- `src/zotai/api/zotero.py` — the S1/S2 client: `pyzotero`-only
+- `docs/plan_03_subsystem3.md` §4.1 — `zotero-mcp` tools, scoped to S3


### PR DESCRIPTION
## Summary

- Write ADR 004 (OpenAI `text-embedding-3-large` as canonical embedder), 006 (adopt 54yyyu/zotero-mcp for S3), 009 (S1/S2 use pyzotero; zotero-mcp is S3-only). Same backfill pattern as #26 for 001-003.
- 005 (gpt-4o-mini), 007 (FastAPI + HTMX), 008 (Quarantine) deliberately left out — they need empirical data that lands with Stage 04 (#6) and S2 Sprint 1 (#12).
- No code, no plan_* edits. `plan_00_overview.md` §5 already references these numbers; the claim "cada una con ADR correspondiente en `docs/decisions/`" is now accurate for three more rows.

## Test plan

- [ ] `docs/decisions/` contains 004, 006, 009 matching 010-012's format (status/date/deciders header, numbered sections, alternatives considered, references).
- [ ] All cross-references between ADRs resolve (004 ↔ 006 ↔ 009 ↔ 011).
- [ ] No broken links in plan_00 §5 once read against the new files.