### PR TITLE
fix(docker): bridge networking + host.docker.internal for cross-platform (ADR 013)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -12,6 +12,14 @@ ZOTERO_LIBRARY_ID=
 ZOTERO_LIBRARY_TYPE=user
 # Use local API (requires Zotero Desktop running). Fallback to web API if false.
 ZOTERO_LOCAL_API=true
+# Host for the local Zotero API. Empty means "use pyzotero's default of
+# http://localhost:23119" (correct when running outside Docker on the
+# same host as Zotero Desktop). Inside the Docker-compose setup the
+# dashboard/onboarding services default to
+# http://host.docker.internal:23119 via docker-compose.yml so the
+# container can reach the host. Override only if Zotero Desktop runs on a
+# different machine or port. See ADR 013.
+ZOTERO_LOCAL_API_HOST=
 
 # ────────────── OpenAI ──────────────
 OPENAI_API_KEY=

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,27 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Changed
+
+- **Networking**: the `onboarding` and `dashboard` Compose services
+  switch from `network_mode: host` to default bridge networking with
+  `extra_hosts: - "host.docker.internal:host-gateway"` so the same
+  setup works on Linux, macOS, and Windows uniformly (the previous
+  `network_mode: host` silently no-ops on Docker Desktop). `pyzotero`'s
+  hardcoded `http://localhost:23119/api` endpoint is now overridable
+  via `ZOTERO_LOCAL_API_HOST` (new `.env` key, default
+  `http://host.docker.internal:23119` inside the Compose containers;
+  empty outside Docker → pyzotero's default stands). New
+  `ZoteroSettings.local_api_host` setting + `ZoteroClient(..,
+  local_api_host=...)` constructor kwarg; Stage 03 wires it through
+  from settings. The `dashboard` container's uvicorn bind moves from
+  `127.0.0.1` to `0.0.0.0` *inside* the container so the
+  `127.0.0.1:8000:8000` port mapping (now truthful under bridge mode)
+  actually reaches it — the host-side binding remains localhost-only.
+  Covered by new `tests/test_api/test_zotero.py` (endpoint respects
+  default, override, trailing-slash strip, and is ignored when
+  `local=False`). See ADR 013.
+
 ### Added
 
 - **S1 Stage 03 — import to Zotero** (#5): `zotai.s1.stage_03_import.run_import`

--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -8,6 +8,11 @@
 #   - ./workspace : state.db, candidates.db, staging/, reports/, chroma_db/
 #   - ./config    : feeds.yaml, taxonomy.yaml, scoring.yaml
 #   - ./data      : source PDFs (read-only for the container)
+#
+# Networking: bridge (default). Zotero Desktop's local API lives on the
+# host at localhost:23119 and is reached from inside the container as
+# `host.docker.internal:23119` via Compose's `extra_hosts` alias — works
+# uniformly on Linux (Docker 20.10+), macOS, and Windows. See ADR 013.
 
 services:
   onboarding:
@@ -15,15 +20,16 @@ services:
     image: zotai:latest
     profiles: ["onboarding"]
     env_file: .env
+    environment:
+      # Route pyzotero's local API client to the host's Zotero Desktop.
+      # Overridable in .env if the user runs Zotero on a different host.
+      ZOTERO_LOCAL_API_HOST: ${ZOTERO_LOCAL_API_HOST:-http://host.docker.internal:23119}
     volumes:
       - ./workspace:/workspace
       - ./config:/app/config
       - ./data:/data:ro
-    # Note: host networking keeps Zotero local-API reachable at
-    # http://localhost:23119 from inside the container on Linux. On macOS/Windows
-    # the container talks to `host.docker.internal` — override in .env:
-    #   ZOTERO_LOCAL_API_HOST=http://host.docker.internal:23119
-    network_mode: host
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     command: ["zotai", "s1", "--help"]
     # Onboarding is interactive and short-lived: no healthcheck needed.
     healthcheck:
@@ -33,13 +39,16 @@ services:
     build: .
     image: zotai:latest
     env_file: .env
+    environment:
+      ZOTERO_LOCAL_API_HOST: ${ZOTERO_LOCAL_API_HOST:-http://host.docker.internal:23119}
     volumes:
       - ./workspace:/workspace
       - ./config:/app/config
+    extra_hosts:
+      - "host.docker.internal:host-gateway"
     ports:
       - "127.0.0.1:8000:8000"
-    network_mode: host
-    command: ["uvicorn", "zotai.s2.dashboard.main:app", "--host", "127.0.0.1", "--port", "8000"]
+    command: ["uvicorn", "zotai.s2.dashboard.main:app", "--host", "0.0.0.0", "--port", "8000"]
     restart: unless-stopped
     healthcheck:
       test: ["CMD", "python", "/app/scripts/healthcheck.py"]

--- a/docs/decisions/013-bridge-networking-host-docker-internal.md
+++ b/docs/decisions/013-bridge-networking-host-docker-internal.md
@@ -1,0 +1,194 @@
+# ADR 013 — Bridge networking + `host.docker.internal` instead of `network_mode: host`
+
+**Status**: Accepted
+**Date**: 2026-04-22
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+Both Compose services (`onboarding` for S1, `dashboard` for S2) need
+to reach **Zotero Desktop's local API** at `localhost:23119` on the
+user's host — that is the transport that `pyzotero` with `local=True`
+uses (verified by reading `pyzotero.zotero.Zotero.__init__`: it
+hardcodes `self.endpoint = "http://localhost:23119/api"`).
+
+The initial `docker-compose.yml` solved "reach the host's
+`localhost:23119`" by setting `network_mode: host` on both services.
+That works on Linux. It does **not** work on Docker Desktop for Mac or
+Windows: Docker's documentation is explicit that `network_mode: host`
+is a no-op there (the container still runs inside Docker Desktop's
+Linux VM and does not get the macOS/Windows host's loopback). CLAUDE.md
+declares Windows/WSL2 and Linux as primary targets plus macOS as
+"nice-to-have", and the project's README promises cross-platform
+distribution as the motivation for Docker (ADR 001) in the first
+place. `network_mode: host` silently defeats that promise for two of
+the three target OSs.
+
+A secondary issue: under `network_mode: host`, the `ports:
+- "127.0.0.1:8000:8000"` entry on the `dashboard` service is a no-op
+(the container is already on the host network). Readers of the Compose
+file could not tell which of the two mechanisms was actually binding
+the port, and the compose was self-contradictory on Mac/Windows where
+neither path worked.
+
+We need one configuration that reaches the host's Zotero API
+identically on Linux, macOS, and Windows, without adding per-OS
+overrides.
+
+## Decision
+
+**Drop `network_mode: host`. Use default bridge networking with
+Docker's cross-platform `host.docker.internal:host-gateway` alias, and
+route `pyzotero` to it via a new `ZOTERO_LOCAL_API_HOST` env var that
+`ZoteroClient` honours.**
+
+Concretely:
+
+1. **Compose** (`docker-compose.yml`):
+   - Remove `network_mode: host` from both services.
+   - Add `extra_hosts: - "host.docker.internal:host-gateway"` to both.
+     Docker 20.10+ (released 2020-12) implements the `host-gateway`
+     magic on Linux; Docker Desktop for Mac and Windows define
+     `host.docker.internal` natively. The alias resolves to the host's
+     reachable IP on all three OSs.
+   - Set `environment.ZOTERO_LOCAL_API_HOST:
+     ${ZOTERO_LOCAL_API_HOST:-http://host.docker.internal:23119}`. The
+     `${VAR:-default}` syntax lets a user override in `.env` or their
+     shell without editing Compose.
+   - Change the `dashboard` container's uvicorn bind from
+     `--host 127.0.0.1` to `--host 0.0.0.0`. Under bridge networking
+     the container's loopback is not the host's loopback, so binding
+     uvicorn to `127.0.0.1` inside the container would leave the
+     `ports: - "127.0.0.1:8000:8000"` mapping unreachable. The host
+     side of the mapping remains `127.0.0.1`, so the dashboard is
+     still localhost-only from the user's perspective.
+
+2. **Settings** (`src/zotai/config.py`):
+   - Add `ZoteroSettings.local_api_host: str = ""`. Empty default
+     means "use pyzotero's hardcoded `localhost:23119`" — which is
+     correct when running outside Docker (tests, direct host
+     execution).
+
+3. **Client** (`src/zotai/api/zotero.py`):
+   - `ZoteroClient.__init__` takes a `local_api_host: str | None`
+     parameter. When `local=True` and a host is given, override
+     pyzotero's `self._client.endpoint` to `"{host}/api"`. The
+     override is one assignment after pyzotero's normal init — no
+     fork, no subclass, no monkey-patching of pyzotero's classes.
+
+4. **Example env** (`.env.example`):
+   - Add `ZOTERO_LOCAL_API_HOST=` with a comment explaining that the
+     Compose layer sets the default inside the container and the user
+     overrides it here only if Zotero lives elsewhere.
+
+## Consequences
+
+### Positive
+
+- **One Compose file, three OSs.** The default `docker compose up
+  dashboard` works on Linux, macOS, and Windows with Docker Desktop.
+  No per-OS overrides, no conditional docs, no "Linux-only" asterisk.
+- **`ports:` mapping is now truthful.** Under bridge networking the
+  mapping is what binds the dashboard to `127.0.0.1:8000` on the host.
+  A reader of the Compose file can follow the wiring in one place.
+- **Host-side reach is explicit.** `ZOTERO_LOCAL_API_HOST` is the one
+  knob users turn if they put Zotero on a different host (rare, but
+  trivially supported).
+- **Non-Docker execution keeps working.** With `local_api_host=""`,
+  `ZoteroClient` leaves pyzotero's default untouched. Tests that
+  instantiate `ZoteroClient` directly, or users running the CLI on
+  the host, reach `localhost:23119` as before.
+- **S3 unaffected.** `zotero-mcp` runs on the host (ADR 006, plan_03
+  §5), not inside Docker — it does not need this wiring and this ADR
+  does not touch it.
+
+### Negative
+
+- **Requires Docker ≥ 20.10.** Released 2020-12; safe on any
+  reasonably-current install (Docker Desktop has not shipped a
+  version without `host-gateway` in years). Documented as the minimum
+  in `docs/setup-{linux,windows}.md` (Phase 9 deliverable).
+- **Reaches the host via its default gateway, not via loopback.**
+  With `network_mode: host` the container literally was the host from
+  a network point of view. Under bridge mode it is one hop away, on
+  the docker bridge's gateway IP. The user's firewall must allow the
+  container → host traffic on port 23119; on all three target OSs the
+  default Zotero install binds on `0.0.0.0:23119` and the Docker
+  bridge traffic is permitted by default. Worth calling out in the
+  troubleshooting doc so a user with a locked-down host firewall
+  knows where to look.
+- **Zotero Desktop must listen on an address the bridge can reach.**
+  Zotero's default is `0.0.0.0:23119`, so this is met without user
+  action. If a future Zotero release starts binding only to
+  `127.0.0.1`, we would need a socat sidecar. Not a concern today but
+  worth naming.
+- **The `pyzotero` endpoint override is a post-init assignment to an
+  attribute that pyzotero treats as public-ish but never documented
+  as a public API.** If pyzotero refactors to make `endpoint` a
+  property or moves the URL composition, our override breaks. Tests
+  pin the current behaviour (the override test fails loudly if
+  pyzotero ever changes). A future fork of pyzotero, or contributing
+  an upstream `local_host` parameter, would be cleaner.
+
+### Neutral
+
+- **Reversible.** If a future decision puts S2 back on host
+  networking (e.g. to colocate with a host-bound service), dropping
+  `extra_hosts` and adding `network_mode: host` back is a one-line
+  change. The `ZoteroClient.local_api_host` override stays correct
+  either way.
+
+## Alternatives considered
+
+**A. Keep `network_mode: host`; narrow CLAUDE.md to Linux-only.**
+Rejected. ADR 001's whole argument for adopting Docker is
+cross-platform distribution; abandoning Mac/Win contradicts that
+decision and shrinks the audience the project promised to serve.
+
+**B. Per-OS Compose overrides (`docker-compose.linux.yml` +
+`docker-compose.desktop.yml`) via `COMPOSE_FILE`.**
+Rejected. Doubles the Compose surface for a problem that one
+`extra_hosts` entry solves. Documentation would have to explain which
+file to use when, and the overrides drift over time. Not worth it.
+
+**C. `socat` sidecar forwarding `localhost:23119` inside the
+container to `host.docker.internal:23119`.**
+Rejected. Adds a second process per service and a new failure mode
+(sidecar crash), for no benefit over `extra_hosts` + endpoint
+override. Pointless when pyzotero already exposes `self.endpoint` for
+post-init adjustment.
+
+**D. Run Zotero Desktop in a container next to ours.**
+Rejected. Zotero Desktop is a user-facing GUI application; it is not
+distributed as a container image and is explicitly meant to run on
+the user's desktop with their personal library. Containerising it
+would also break S3 (Claude Desktop talks to `zotero-mcp`, which
+talks to Zotero Desktop on the host).
+
+**E. Subclass `pyzotero.Zotero` with a configurable endpoint.**
+Rejected as premature. A post-init assignment achieves the same result
+with one line and no subclassing. If this becomes load-bearing (many
+call sites, many overrides), a proper subclass or a pyzotero upstream
+PR is the right move then. Today it is not.
+
+## References
+
+- `docs/decisions/001-use-docker.md` — the ADR this one preserves
+  the intent of: cross-platform distribution as the motivation for
+  Docker in the first place
+- `docs/plan_01_subsystem1.md` §3 Etapa 03 — Stage 03's reliance on
+  Zotero local API
+- `docker-compose.yml` — the compose change that lands with this ADR
+- `src/zotai/api/zotero.py` — `ZoteroClient.__init__` `local_api_host`
+  parameter
+- `src/zotai/config.py` — `ZoteroSettings.local_api_host`
+- `.env.example` — `ZOTERO_LOCAL_API_HOST` user-facing override
+- Docker networking reference:
+  https://docs.docker.com/reference/compose-file/services/#extra_hosts
+  (host-gateway special alias)
+- `pyzotero.zotero.Zotero.__init__` — the hardcoded
+  `http://localhost:23119/api` endpoint we override

--- a/src/zotai/api/zotero.py
+++ b/src/zotai/api/zotero.py
@@ -30,6 +30,7 @@ class ZoteroClient:
         library_type: str = "user",
         api_key: str,
         local: bool = True,
+        local_api_host: str | None = None,
         dry_run: bool = False,
     ) -> None:
         self._client = zotero.Zotero(
@@ -38,6 +39,15 @@ class ZoteroClient:
             api_key=api_key,
             local=local,
         )
+        if local and local_api_host:
+            # pyzotero hardcodes ``self.endpoint = "http://localhost:23119/api"``
+            # when ``local=True`` (see ``pyzotero.zotero.Zotero.__init__``).
+            # Inside a bridge-mode Docker container, ``localhost`` resolves to
+            # the container itself — Zotero Desktop's local API lives on the
+            # host and must be reached via ``host.docker.internal`` (wired via
+            # Compose's ``extra_hosts: host-gateway``). Override the endpoint
+            # so the same pyzotero calls work transparently. See ADR 013.
+            self._client.endpoint = f"{local_api_host.rstrip('/')}/api"
         self.dry_run = dry_run
 
     # ─── Reads ────────────────────────────────────────────────────────────

--- a/src/zotai/config.py
+++ b/src/zotai/config.py
@@ -58,6 +58,12 @@ class ZoteroSettings(_GroupBase):
     library_id: str = ""
     library_type: Literal["user", "group"] = "user"
     local_api: bool = True
+    # Override for pyzotero's hardcoded ``http://localhost:23119/api``. Used
+    # inside Docker bridge-mode containers where ``localhost`` is the
+    # container itself; Docker Compose's ``extra_hosts`` exposes the host
+    # as ``host.docker.internal`` on Linux/macOS/Windows uniformly. Empty
+    # string means "use pyzotero's default". See ADR 013.
+    local_api_host: str = ""
 
 
 class OpenAISettings(_GroupBase):

--- a/src/zotai/s1/stage_03_import.py
+++ b/src/zotai/s1/stage_03_import.py
@@ -558,6 +558,7 @@ async def _run_import_async(
             library_type=settings.zotero.library_type,
             api_key=settings.zotero.api_key.get_secret_value(),
             local=settings.zotero.local_api,
+            local_api_host=settings.zotero.local_api_host or None,
             dry_run=dry_run,
         )
     if openalex_client is None:

--- a/tests/test_api/test_zotero.py
+++ b/tests/test_api/test_zotero.py
@@ -1,0 +1,58 @@
+"""Tests for :class:`zotai.api.zotero.ZoteroClient`.
+
+The wrapper is thin; what matters here is the ``local_api_host``
+override introduced with ADR 013 — pyzotero hardcodes
+``http://localhost:23119/api`` when ``local=True``, and we need it to
+point at ``host.docker.internal`` when running in a bridge-mode Docker
+container.
+"""
+
+from __future__ import annotations
+
+from zotai.api.zotero import ZoteroClient
+
+_FAKE_KEY = "deadbeef"
+_FAKE_LIB = "999"
+
+
+def test_local_client_uses_pyzotero_default_when_host_empty() -> None:
+    client = ZoteroClient(
+        library_id=_FAKE_LIB,
+        api_key=_FAKE_KEY,
+        local=True,
+        local_api_host=None,
+    )
+    # pyzotero's own hardcoded endpoint when local=True.
+    assert client._client.endpoint == "http://localhost:23119/api"
+
+
+def test_local_client_honours_host_override() -> None:
+    client = ZoteroClient(
+        library_id=_FAKE_LIB,
+        api_key=_FAKE_KEY,
+        local=True,
+        local_api_host="http://host.docker.internal:23119",
+    )
+    assert client._client.endpoint == "http://host.docker.internal:23119/api"
+
+
+def test_host_override_strips_trailing_slash() -> None:
+    client = ZoteroClient(
+        library_id=_FAKE_LIB,
+        api_key=_FAKE_KEY,
+        local=True,
+        local_api_host="http://host.docker.internal:23119/",
+    )
+    assert client._client.endpoint == "http://host.docker.internal:23119/api"
+
+
+def test_host_override_ignored_when_local_false() -> None:
+    # When ``local=False`` pyzotero points at the web API; the override
+    # must not fire (we'd be aiming at the wrong endpoint entirely).
+    client = ZoteroClient(
+        library_id=_FAKE_LIB,
+        api_key=_FAKE_KEY,
+        local=False,
+        local_api_host="http://host.docker.internal:23119",
+    )
+    assert client._client.endpoint == "https://api.zotero.org"

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -30,6 +30,7 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
             "LIBRARY_ID",
             "LIBRARY_TYPE",
             "LOCAL_API",
+            "LOCAL_API_HOST",
             "MODEL_TAG",
             "MODEL_EXTRACT",
             "EMBEDDING_MODEL",
@@ -66,6 +67,10 @@ def test_settings_load_with_defaults() -> None:
     s = Settings()
     assert s.zotero.library_type == "user"
     assert s.zotero.local_api is True
+    # Empty default means "use pyzotero's hardcoded localhost:23119"; the
+    # docker-compose layer sets host.docker.internal at the container env,
+    # so the settings layer stays OS-agnostic. See ADR 013.
+    assert s.zotero.local_api_host == ""
     assert s.openai.model_tag == "gpt-4o-mini"
     assert s.ocr.languages == "spa+eng"
     assert s.ocr.parallel_processes == 4


### PR DESCRIPTION
## Summary

- Drop `network_mode: host` from both Compose services (silently no-ops on Docker Desktop Mac/Win) in favour of default bridge networking + `extra_hosts: "host.docker.internal:host-gateway"` — works uniformly on Linux, macOS, Windows.
- New `ZOTERO_LOCAL_API_HOST` (env + `ZoteroSettings.local_api_host` + `ZoteroClient(.., local_api_host=..)`) overrides pyzotero's hardcoded `http://localhost:23119/api`. Empty default → pyzotero's default stands (correct for non-Docker execution).
- Compose sets `ZOTERO_LOCAL_API_HOST` to `http://host.docker.internal:23119` inside both containers; user can override in `.env` if Zotero lives elsewhere.
- `dashboard` container's uvicorn bind moves `127.0.0.1 → 0.0.0.0` *inside* the container so the host-side `127.0.0.1:8000:8000` mapping is reachable under bridge mode. Host-facing behaviour unchanged (still localhost-only).
- ADR 013 documents the decision, trade-offs, and five alternatives considered.

Preserves the intent of ADR 001 (cross-platform distribution as the motivation for Docker) instead of silently abandoning Mac/Windows.

## Test plan

- [ ] New `tests/test_api/test_zotero.py` passes: pins pyzotero's `endpoint` under default / override / trailing-slash / `local=False` ignored.
- [ ] Full suite: `pytest -q` → 115 passed.
- [ ] `docker compose config` parses the new YAML on Linux + Docker Desktop.
- [ ] Manual smoke: `docker compose run --rm --profile onboarding onboarding zotai s1 --help` starts cleanly under bridge networking.
- [ ] `docker compose up dashboard` + `curl http://127.0.0.1:8000/healthz` reaches uvicorn.

## References

- ADR 013 (this PR)
- ADR 001 (cross-platform distribution as the Docker motivation — this PR preserves that intent)