### PR TITLE
fix(s1): stage 03 dedup skips attach when existing item has a PDF (ADR 014)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **S1 Stage 03 dedup** (ADR 014): when Ruta A finds that a DOI is
+  already in the user's Zotero library, the stage now checks the
+  existing item for PDF attachments before adding ours.
+  - If the existing item already has a PDF child → skip attach,
+    `ImportRow.status = "deduped"`. Preserves the user's curated
+    state; avoids duplicated PDF children under one item.
+  - If the existing item has no PDF (metadata-only prior import) →
+    attach as before, `ImportRow.status = "deduped_pdf_added"`.
+  Both statuses count toward `items_deduped` and `items_route_a`; the
+  CSV surfaces which branch ran via the `status` column. HTML
+  snapshots and non-PDF attachments do not count as "has PDF". New
+  `ZoteroClient.children(item_key)` helper; three new tests
+  (`_attaches_when_existing_has_no_pdf`,
+  `_skips_attach_when_existing_has_pdf`,
+  `_skips_non_pdf_attachment`); `plan_01` §3 Etapa 03 Edge cases line
+  updated to reference the policy.
 - **Networking**: the `onboarding` and `dashboard` Compose services
   switch from `network_mode: host` to default bridge networking with
   `extra_hosts: - "host.docker.internal:host-gateway"` so the same

--- a/docs/decisions/014-stage-03-dedup-skip-attach-if-pdf-exists.md
+++ b/docs/decisions/014-stage-03-dedup-skip-attach-if-pdf-exists.md
@@ -1,0 +1,161 @@
+# ADR 014 — Stage 03 dedup: skip attach when existing Zotero item already has a PDF
+
+**Status**: Accepted
+**Date**: 2026-04-22
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+S1 Stage 03 imports PDFs into Zotero. Ruta A (plan_01 §3 Etapa 03,
+ADR 010) resolves a DOI → OpenAlex metadata → `create_items` in
+Zotero. Before creating, it checks whether the DOI already exists in
+the user's library via `_find_existing_doi` (a `pyzotero.items(q=doi,
+qmode="everything")` quicksearch). If it does, the plan's edge-case
+rule says: *"Item ya existe en Zotero (detectable por DOI duplicado):
+no crear de nuevo, asociar nuestro `state.db` con el `item_key`
+existente."*
+
+The current implementation honours the "do not create" half of that
+rule, but it still calls `zotero_client.attachment_simple([our_pdf],
+parent_key=existing_key)`. Result: the existing item collects a second
+PDF child. If the user had already imported that paper with its own
+PDF (via Zotero's browser connector, or a prior S1 run that got
+interrupted), they end up with two PDFs hanging off one bibliographic
+record — visibly duplicated in Zotero's item tree, with no flag as to
+which was "the user's" copy.
+
+The plan did not specify the attach behaviour here, only the
+"associate" behaviour on the parent key side. We need to pick a
+policy and write it down.
+
+## Decision
+
+**On dedup, skip the attach if the existing Zotero item already has at
+least one PDF attachment. Attach our PDF only if the existing item has
+none (metadata-only prior import).**
+
+Concretely:
+
+1. `ZoteroClient.children(item_key)` is added to the thin wrapper over
+   pyzotero (no dry-run guard — reads are always real, same as
+   `items()`).
+2. `stage_03_import._existing_has_pdf_attachment(client, item_key)`
+   walks the children once and returns True iff any child is an
+   attachment with `contentType` starting with `application/pdf`. HTML
+   snapshots, notes, and non-PDF attachments do not count.
+3. The Ruta A dedup branch in `_import_one`:
+   - If `_existing_has_pdf_attachment` → do not call
+     `attachment_simple`. Record `ImportRow.status = "deduped"`.
+   - Else → call `attachment_simple(parent_key=existing_key)`. Record
+     `ImportRow.status = "deduped_pdf_added"`.
+4. Both statuses count toward `ImportResult.items_deduped` and toward
+   `items_route_a`. The CSV surfaces the distinction in the `status`
+   column so Stage 06 validation can break out "dedup no-op" vs
+   "dedup filled-in".
+5. Dry-run never calls `children()`; status stays `dry_run` as before.
+
+## Consequences
+
+### Positive
+
+- **Respects pre-existing user state.** If the user already curated
+  this paper in Zotero with a PDF, they see no visible change beyond a
+  `state.db` row pointing at their item. The library does not grow
+  silently-duplicated PDF children.
+- **Still adds value when it can.** The common case of "the user
+  imported a DOI via a BibTeX dump and never had the PDF" is precisely
+  where our pipeline *should* add value. Those items get our
+  (potentially OCR'd) PDF.
+- **One extra read per dedup hit.** `pyzotero.children(item_key)` is a
+  cheap local-API call. Dedups are a minority of the corpus (plan_01
+  §3 Etapa 03 §126: A is 50-60%, dedup is a subset of A). Overhead is
+  measured in hundreds of local HTTP calls for a 1000-paper run — not
+  noticeable next to OpenAlex's rate limit floor.
+- **Explicit in the CSV.** `status=deduped` vs `status=deduped_pdf_added`
+  lets Stage 06's validation report break the number apart without a
+  second log scan.
+- **Easy to override later if needed.** The policy lives in one
+  function (`_existing_has_pdf_attachment`) and one branch. Replacing
+  it with a per-user flag or a "always attach" mode is a small diff.
+
+### Negative
+
+- **Does not detect duplicate PDFs by content.** Two different PDFs
+  (say, a preprint and the published version) of the same DOI would
+  be conflated: if the user had the preprint attached, we would not
+  add the published PDF. In practice, Zotero's dedup semantics are
+  DOI-based too, so this aligns with how the user already thinks of
+  "the same paper"; Stage 04 enrichment has a chance to flag
+  preprint-vs-published if the scenario comes up. Not load-bearing
+  enough to chase.
+- **Silently loses our (potentially OCR'd) PDF when user's copy is
+  worse.** If the user's pre-existing PDF is a scanned image with no
+  text layer and ours is post-Stage-02 OCR, we throw away the
+  improvement. The cost here is real but uncommon (user usually
+  imports PDFs with text); a `--force-attach-on-dedup` flag would
+  cover the corner case if it ever matters.
+- **Relies on Zotero's `contentType` metadata.** Zotero typically
+  stamps PDF attachments with `application/pdf`; if a user's
+  attachment has a missing or odd content type, we would attach
+  redundantly. Unlikely in practice, and the safer failure direction
+  (extra PDF > none).
+
+### Neutral
+
+- **Semantics converge with Zotero's own "Retrieve Metadata for PDFs"
+  flow.** When Zotero's desktop recognizer finds a DOI match against
+  an already-imported item, it links rather than creates a parallel
+  attachment. This ADR brings our pipeline's behaviour in line with
+  that UX expectation.
+
+## Alternatives considered
+
+**A. Always attach on dedup (status quo before this ADR).**
+Rejected. Produces visibly duplicated PDF children for the realistic
+case of a user who had the paper already. The "no creamos de nuevo"
+half of the plan rule addressed the bibliographic item; this ADR
+extends the same respect to the attachment.
+
+**B. Never attach on dedup.**
+Rejected. Loses the legitimate case of a DOI-only prior import (BibTeX
+dump, manual drag of metadata). Our PDF is the value-add in exactly
+that scenario; skipping it defeats the point of running Stage 03.
+
+**C. Prompt the user interactively.**
+Rejected. Stage 03 processes 1000 PDFs in a session; per-item prompts
+would turn a batch pipeline into a manual task that violates the
+"2-3h total of human time" budget (CLAUDE.md). The user may not even
+be watching when the dedup hits.
+
+**D. Detect PDF identity by SHA-256 and attach only if different.**
+Rejected for v1. Zotero's API does not expose a child attachment's
+hash without downloading the bytes, so the detection would add a
+round trip *plus* a file download per dedup hit. Worse, "different
+bytes for the same DOI" (preprint vs published) is not a reliable
+signal of "the user wants both" — see the preprint/published note in
+Consequences. Revisit if a real scenario makes this matter.
+
+**E. Configurable policy: env var `STAGE_03_DEDUP_ATTACH_POLICY=
+{skip_if_has_pdf,always,never}` defaulting to `skip_if_has_pdf`.**
+Rejected as premature. The default from this ADR matches what a
+reasonable single-investigator workflow expects. Adding knobs for
+hypothetical users invites the "make everything configurable"
+antipattern CLAUDE.md warns against. Revisit if two real users need
+two different behaviours.
+
+## References
+
+- `docs/plan_01_subsystem1.md` §3 Etapa 03 "Edge cases" — the partial
+  rule this ADR extends
+- `docs/decisions/010-ruta-a-openalex-not-zotero-translator.md` — the
+  Ruta A pipeline this lives inside
+- `src/zotai/s1/stage_03_import.py` — `_existing_has_pdf_attachment`,
+  the `deduped_pdf_added` literal, and the branched `_import_one`
+  dedup path
+- `src/zotai/api/zotero.py` — `ZoteroClient.children`
+- `tests/test_s1/test_stage_03.py` — three new tests covering the
+  two branches plus the HTML-snapshot-doesn't-count edge case

--- a/docs/plan_01_subsystem1.md
+++ b/docs/plan_01_subsystem1.md
@@ -171,7 +171,7 @@ zotai s1 ocr [--force-ocr] [--parallel N]
 
 **Edge cases**:
 - Zotero desktop no abierto: error claro al usuario antes de arrancar, no a mitad.
-- Item ya existe en Zotero (detectable por DOI duplicado): no crear de nuevo, asociar nuestro `state.db` con el `item_key` existente.
+- Item ya existe en Zotero (detectable por DOI duplicado): no crear de nuevo, asociar nuestro `state.db` con el `item_key` existente. Política de adjunto (ADR 014): si el item existente ya tiene ≥1 attachment con `contentType=application/pdf`, saltar el adjunto (status `deduped`); si no, adjuntar nuestro PDF (status `deduped_pdf_added`). Evita duplicar PDFs cuando el usuario ya curó el paper, y agrega valor cuando solo había metadata.
 - PDF >20MB: Zotero API tiene límites. Subirlo via WebDAV / file storage directo.
 
 **Tasa esperada**:

--- a/src/zotai/api/zotero.py
+++ b/src/zotai/api/zotero.py
@@ -62,6 +62,19 @@ class ZoteroClient:
     def item(self, item_key: str) -> dict[str, Any]:
         return cast(dict[str, Any], self._client.item(item_key))
 
+    def children(
+        self, item_key: str, **kwargs: Any
+    ) -> list[dict[str, Any]]:
+        """Proxy to ``pyzotero.Zotero.children(item_key, **kwargs)``.
+
+        Used by Stage 03's dedup path to decide whether an existing
+        Zotero item already has a PDF attachment before we add ours
+        (ADR 014).
+        """
+        return cast(
+            list[dict[str, Any]], self._client.children(item_key, **kwargs)
+        )
+
     # ─── Writes — all respect dry_run ─────────────────────────────────────
 
     def create_items(self, items: list[dict[str, Any]]) -> dict[str, Any]:

--- a/src/zotai/s1/stage_03_import.py
+++ b/src/zotai/s1/stage_03_import.py
@@ -91,6 +91,7 @@ _CSV_COLUMNS: Final[tuple[str, ...]] = (
 ImportStatus = Literal[
     "imported",
     "deduped",
+    "deduped_pdf_added",
     "skipped_already_imported",
     "failed",
     "dry_run",
@@ -300,6 +301,27 @@ def _find_existing_doi(
     return None
 
 
+def _existing_has_pdf_attachment(
+    zotero_client: ZoteroClient, item_key: str
+) -> bool:
+    """Return True iff the item already has at least one PDF attachment.
+
+    Used on the dedup path (ADR 014): when Stage 03 finds that the DOI
+    is already in the user's Zotero library, we skip attaching our PDF
+    if an existing PDF child is there — the user already had the paper
+    and its own copy. If the parent has *no* PDF (metadata-only import
+    from a prior session), we still attach.
+    """
+    for child in zotero_client.children(item_key):
+        data = child.get("data") or {}
+        if data.get("itemType") != "attachment":
+            continue
+        content_type = (data.get("contentType") or "").lower()
+        if content_type.startswith("application/pdf"):
+            return True
+    return False
+
+
 def _pick_attach_path(item: Item, staging_folder: Path) -> Path:
     """Return the PDF path to attach: staging copy if Stage 02 ran, else original."""
     staging_path = staging_folder / f"{item.id}.pdf"
@@ -363,14 +385,47 @@ async def _import_one(
                 else _find_existing_doi(zotero_client, doi_value)
             )
             if existing_key:
-                attach_response = (
-                    {"success": {"0": "DRYRUN"}}
-                    if dry_run
-                    else zotero_client.attachment_simple(
-                        [str(attached_path)], parent_key=existing_key
+                # ADR 014: if the existing Zotero item already carries a
+                # PDF attachment, the user already had this paper with
+                # its own copy. Do not add a second PDF child; just link
+                # our state row to the existing key.
+                if dry_run:
+                    dedup_status: ImportStatus = "dry_run"
+                else:
+                    already_has_pdf = _existing_has_pdf_attachment(
+                        zotero_client, existing_key
                     )
-                )
-                _ = attach_response  # attachment key not persisted in state
+                    if already_has_pdf:
+                        log.info(
+                            "stage_03.dedup.attach_skipped",
+                            existing_key=existing_key,
+                            reason="pdf_present",
+                        )
+                        dedup_status = "deduped"
+                    else:
+                        try:
+                            zotero_client.attachment_simple(
+                                [str(attached_path)],
+                                parent_key=existing_key,
+                            )
+                        except Exception as exc:
+                            return ImportRow(
+                                sha256=item.id,
+                                source_path=item.source_path,
+                                attached_path=str(attached_path),
+                                detected_doi=item.detected_doi,
+                                import_route="A",
+                                zotero_item_key=existing_key,
+                                status="failed",
+                                error=(
+                                    f"attachment_simple:{type(exc).__name__}:{exc}"
+                                ),
+                            )
+                        log.info(
+                            "stage_03.dedup.attach_added",
+                            existing_key=existing_key,
+                        )
+                        dedup_status = "deduped_pdf_added"
                 return ImportRow(
                     sha256=item.id,
                     source_path=item.source_path,
@@ -378,7 +433,7 @@ async def _import_one(
                     detected_doi=item.detected_doi,
                     import_route="A",
                     zotero_item_key=existing_key,
-                    status="deduped" if not dry_run else "dry_run",
+                    status=dedup_status,
                     error=None,
                 )
 
@@ -604,7 +659,11 @@ async def _run_import_async(
                     )
                     rows.append(row)
 
-                    if row.status in ("imported", "deduped"):
+                    if row.status in (
+                        "imported",
+                        "deduped",
+                        "deduped_pdf_added",
+                    ):
                         item.updated_at = now()
                         if not dry_run:
                             item.zotero_item_key = row.zotero_item_key
@@ -643,6 +702,7 @@ async def _run_import_async(
     csv_path = _csv_path(reports_folder, dry_run=dry_run, now=now())
     _write_csv(csv_path, rows)
 
+    _success_statuses = ("imported", "deduped", "deduped_pdf_added")
     result = ImportResult(
         run_id=run_id,
         rows=rows,
@@ -652,14 +712,16 @@ async def _run_import_async(
         items_route_a=sum(
             1
             for r in rows
-            if r.import_route == "A" and r.status in ("imported", "deduped")
+            if r.import_route == "A" and r.status in _success_statuses
         ),
         items_route_c=sum(
             1
             for r in rows
-            if r.import_route == "C" and r.status in ("imported", "deduped")
+            if r.import_route == "C" and r.status in _success_statuses
         ),
-        items_deduped=sum(1 for r in rows if r.status == "deduped"),
+        items_deduped=sum(
+            1 for r in rows if r.status in ("deduped", "deduped_pdf_added")
+        ),
         items_skipped=sum(
             1 for r in rows if r.status == "skipped_already_imported"
         ),

--- a/tests/test_s1/test_stage_03.py
+++ b/tests/test_s1/test_stage_03.py
@@ -41,13 +41,16 @@ class FakeZoteroClient:
         *,
         connectivity_ok: bool = True,
         existing: list[dict[str, Any]] | None = None,
+        existing_children: dict[str, list[dict[str, Any]]] | None = None,
     ) -> None:
         self.connectivity_ok = connectivity_ok
         self._existing = existing or []
+        self._existing_children = existing_children or {}
         self.dry_run = False
         self.created_items: list[dict[str, Any]] = []
         self.attachments: list[dict[str, Any]] = []
         self.items_calls: list[dict[str, Any]] = []
+        self.children_calls: list[str] = []
         self._next = 0
 
     def _key(self, prefix: str) -> str:
@@ -87,6 +90,10 @@ class FakeZoteroClient:
             {"paths": paths, "parent_key": parent_key, "key": key}
         )
         return {"success": {"0": key}, "unchanged": {}, "failed": {}}
+
+    def children(self, item_key: str, **kwargs: Any) -> list[dict[str, Any]]:
+        self.children_calls.append(item_key)
+        return self._existing_children.get(item_key, [])
 
 
 class FakeOpenAlexClient:
@@ -323,7 +330,8 @@ def test_route_a_falls_to_c_on_missing_title(tmp_path: Path) -> None:
     assert len(zot.created_items) == 0
 
 
-def test_route_a_dedupes_existing_doi(tmp_path: Path) -> None:
+def test_route_a_dedup_attaches_when_existing_has_no_pdf(tmp_path: Path) -> None:
+    """ADR 014: existing Zotero item with no PDF child → we attach ours."""
     settings = _settings(tmp_path)
     pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
     doi = "10.1/already-in-zotero"
@@ -331,7 +339,9 @@ def test_route_a_dedupes_existing_doi(tmp_path: Path) -> None:
 
     existing_key = "EXISTING001"
     zot = FakeZoteroClient(
-        existing=[{"key": existing_key, "data": {"DOI": doi}}]
+        existing=[{"key": existing_key, "data": {"DOI": doi}}],
+        # No children at all → metadata-only prior import, we add the PDF.
+        existing_children={existing_key: []},
     )
     oa = FakeOpenAlexClient({doi: _good_openalex_work(doi)})
 
@@ -348,11 +358,104 @@ def test_route_a_dedupes_existing_doi(tmp_path: Path) -> None:
     assert len(zot.created_items) == 0, "dedup must skip create_items"
     assert len(zot.attachments) == 1
     assert zot.attachments[0]["parent_key"] == existing_key
+    assert zot.children_calls == [existing_key]
+    assert [r.status for r in result.rows] == ["deduped_pdf_added"]
 
     engine = make_s1_engine(str(settings.paths.state_db))
     with Session(engine) as session:
         item = session.exec(select(Item)).one()
     assert item.zotero_item_key == existing_key
+    assert item.stage_completed == 3
+
+
+def test_route_a_dedup_skips_attach_when_existing_has_pdf(tmp_path: Path) -> None:
+    """ADR 014: existing Zotero item with a PDF child → do not duplicate."""
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    doi = "10.1/already-in-zotero-with-pdf"
+    _seed(settings, sha="g" * 64, source_path=pdf, detected_doi=doi)
+
+    existing_key = "EXISTING002"
+    zot = FakeZoteroClient(
+        existing=[{"key": existing_key, "data": {"DOI": doi}}],
+        existing_children={
+            existing_key: [
+                {
+                    "key": "PRE_PDF_001",
+                    "data": {
+                        "itemType": "attachment",
+                        "contentType": "application/pdf",
+                    },
+                }
+            ]
+        },
+    )
+    oa = FakeOpenAlexClient({doi: _good_openalex_work(doi)})
+
+    result = run_import(
+        batch_pause_seconds=0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_deduped == 1
+    assert result.items_route_a == 1
+    assert len(zot.attachments) == 0, (
+        "existing PDF child must prevent a duplicate attach"
+    )
+    assert zot.children_calls == [existing_key]
+    assert [r.status for r in result.rows] == ["deduped"]
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.zotero_item_key == existing_key
+    assert item.stage_completed == 3
+
+
+def test_route_a_dedup_skips_non_pdf_attachment(tmp_path: Path) -> None:
+    """An HTML snapshot on the existing item does not count as a PDF."""
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    doi = "10.1/has-snapshot-but-no-pdf"
+    _seed(settings, sha="h" * 64, source_path=pdf, detected_doi=doi)
+
+    existing_key = "EXISTING003"
+    zot = FakeZoteroClient(
+        existing=[{"key": existing_key, "data": {"DOI": doi}}],
+        existing_children={
+            existing_key: [
+                {
+                    "key": "SNAPSHOT_001",
+                    "data": {
+                        "itemType": "attachment",
+                        "contentType": "text/html",
+                    },
+                },
+                {
+                    "key": "NOTE_001",
+                    "data": {
+                        "itemType": "note",
+                    },
+                },
+            ]
+        },
+    )
+    oa = FakeOpenAlexClient({doi: _good_openalex_work(doi)})
+
+    result = run_import(
+        batch_pause_seconds=0,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    # HTML snapshot ≠ PDF — we still attach our PDF.
+    assert len(zot.attachments) == 1
+    assert [r.status for r in result.rows] == ["deduped_pdf_added"]
 
 
 # ── Route C: no DOI ────────────────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Stage 03's Ruta A dedup branch (`_find_existing_doi` → link instead of `create_items`) previously always attached our PDF as a new child of the existing Zotero item. If the user already had the paper with its own PDF, the library ended up with two PDFs hanging off one bibliographic record.

Policy (ADR 014): on dedup, inspect the existing item's children; if any has `contentType=application/pdf`, skip attach (`status=deduped`); otherwise attach (`status=deduped_pdf_added`). Preserves curated state, still adds value on metadata-only prior imports.

**Changes:**
- `ZoteroClient.children(item_key, **kwargs)` proxy (reads, no dry-run guard).
- `_existing_has_pdf_attachment` helper in `stage_03_import`.
- `ImportStatus` adds `deduped_pdf_added`; aggregation counts both dedup statuses for `items_deduped` / `items_route_a`; CSV surfaces the branch.
- Attach errors on the attach-on-dedup branch are captured as `status=failed` with the same error-string shape.
- `plan_01` §3 Etapa 03 "Edge cases" line for DOI dedup references ADR 014 explicitly.

## Test plan

- [ ] Three new tests cover (attach when no PDF / skip when PDF / skip ignores non-PDF attachments like HTML snapshots).
- [ ] `pytest -q` → 113 passed.
- [ ] `mypy --strict` on `src/zotai/s1/stage_03_import.py` and `src/zotai/api/zotero.py` → clean.
- [ ] `FakeZoteroClient` extended with `children()` + `existing_children` constructor hook.

## References

- ADR 014 (this PR)
- plan_01 §3 Etapa 03 "Edge cases"