### PR TITLE
docs: align plans 00/01/02/03, glossary, CLAUDE, env + cli stubs with ADR 015 (Fase 1)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -60,21 +60,44 @@ USER_EMAIL=
 # ────────────── S2 Worker ──────────────
 S2_FETCH_INTERVAL_HOURS=6
 S2_CANDIDATES_DB=/workspace/candidates.db
-# Container-side path where S2 reads ChromaDB. Always /workspace/chroma_db.
-# The real store lives on the host (see ZOTERO_MCP_CHROMA_HOST_PATH below)
-# and is bind-mounted by the `dashboard` service in docker-compose.yml.
-# Read-only for S2. See ADR 011 (docs/decisions/011-chromadb-bind-mount.md).
+# Container-side path where S2 owns and writes ChromaDB. Always
+# /workspace/chroma_db. The real store lives on the host (see
+# ZOTERO_MCP_CHROMA_HOST_PATH below) and is bind-mounted by the
+# `dashboard` service in docker-compose.yml with :rw flag. zotero-mcp
+# serve on the host reads the same store (read-only consumer). See ADR
+# 015 (docs/decisions/015-s2-owns-embeddings-index.md) for ownership
+# model and ADR 011 for the bind-mount mechanism (amended for :rw).
 S2_CHROMA_PATH=/workspace/chroma_db
 # Host-side source for the ChromaDB bind mount. Default matches the path
-# that `zotero-mcp setup` plants. Override only if you moved it.
+# that `zotero-mcp setup` reads from. Override only if you moved it; you
+# must also override in `zotero-mcp` setup so both processes agree on
+# the same path.
 ZOTERO_MCP_CHROMA_HOST_PATH=${HOME}/.config/zotero-mcp/chroma_db
 # Set to true to disable the in-process APScheduler. Use with cron / Task
 # Scheduler invoking `docker compose run --rm onboarding zotai s2 fetch-once`.
-# See ADR 012 (docs/decisions/012-apscheduler-default-cron-alternative.md).
+# `fetch-once` runs the embedding-index reconcile as step 0 just like the
+# in-process worker, so the ChromaDB invariant holds in both modes. See
+# ADR 012 (docs/decisions/012-apscheduler-default-cron-alternative.md).
 S2_WORKER_DISABLED=false
 # Zotero collection name where accepted candidates land. S2 creates it
 # on-demand and idempotently — you do not need to create it by hand.
 S2_ZOTERO_INBOX_COLLECTION=Inbox S2
+
+# ────────────── S2 Index reconciliation (ADR 015) ──────────────
+# Max embeddings computed per worker cycle. Limits cost and latency
+# spikes; residual converges over multiple cycles. Tune up if you have
+# thousands of papers added at once and want fewer cycles to converge.
+S2_MAX_EMBED_PER_CYCLE=50
+# Safety threshold: if orphans/total > this ratio, do NOT delete and
+# require manual intervention. Protects against a buggy Zotero read
+# (e.g. API returning empty list erroneously) from vacating ChromaDB
+# via diff. Range: 0.0 (never auto-delete) to 1.0 (always auto-delete).
+S2_SAFE_DELETE_RATIO=0.10
+# Budget cap for the one-shot `zotai s2 backfill-index` command, used to
+# populate ChromaDB from an existing Zotero library. Independent of the
+# daily/monthly worker caps. Typical first-run spend on a 1500-paper
+# library is ~$1-2.
+S2_MAX_COST_USD_BACKFILL=3.00
 
 # ────────────── S2 PDF fetch cascade ──────────────
 # Ordered, comma-separated list of sources to try when pushing an accepted

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Architecture (Fase 1 of ADR 015 — docs alignment)**: rippled the
+  S2-owns-embeddings inversion across all the documents that used to
+  describe the pre-ADR-015 ownership model.
+  - `plan_00_overview.md` §4 + §5: clarified that "S3" in the
+    S1 → S3 → S2 order means setup of `zotero-mcp serve` only — no
+    `update-db` is part of any operational flow under ADR 015. Decisions
+    table extended with rows 010-015 (was missing 010+).
+  - `plan_01_subsystem1.md` §10: line about ChromaDB in "Fuera de
+    alcance" inverted ("responsabilidad de S2 (ver ADR 015). S1 no
+    escribe a ChromaDB bajo ninguna circunstancia").
+  - `plan_02_subsystem2.md` §4 (architecture diagram), §5 (data model),
+    §7.2 (semantic score fallback now `min_corpus_size`-based, not
+    "empty"-based), §9 (worker pseudocode now opens with reconcile
+    step), §10 (push does not write ChromaDB directly), §11 (Sprint 1
+    grows the indexing module + `backfill-index` / `reconcile` CLI
+    deliverables; Sprint 3 simplified), §12 (new env vars
+    `S2_MAX_EMBED_PER_CYCLE`, `S2_SAFE_DELETE_RATIO`,
+    `S2_MAX_COST_USD_BACKFILL`), §15 (dependencies inverted: S2 is the
+    owner; S3 setup is no longer a prerequisite).
+  - `plan_03_subsystem3.md` §4.3 (ownership flipped, mount becomes
+    `:rw`), §5.2 (removed "Build del índice inicial" step), §7.1 (the
+    re-indexing section is now obsolete; the user is redirected to
+    `zotai s2 reconcile` / the worker's automatic cycle), §8
+    (S2/S3 integration direction inverted), §9 (deliverables: removed
+    `scripts/reindex-s3.{sh,ps1}`).
+  - `plan_glossary.md`: "Chroma DB" entry inverted; new entries for
+    "Reconciliación de embeddings" and "Backfill de índice".
+  - `CLAUDE.md` §"Contratos entre subsistemas": the diagram now shows
+    ChromaDB explicitly with arrows from S2 (write) and to S3 (read);
+    the "solo a través de Zotero" claim softened to "ChromaDB is the
+    one exception — S2-owned derived state".
+  - `.env.example`: `S2_CHROMA_PATH` comment inverted to mark `:rw`
+    ownership; added `S2_MAX_EMBED_PER_CYCLE`, `S2_SAFE_DELETE_RATIO`,
+    `S2_MAX_COST_USD_BACKFILL` block with cross-references to ADR 015.
+  - `config/scoring.yaml`: added `semantic_scoring.min_corpus_size: 50`.
+  - `src/zotai/cli.py`: stubbed `zotai s2 backfill-index` and
+    `zotai s2 reconcile` (point to Phase 11 / #12 like the rest of S2
+    stubs); enriched the `s2 fetch-once` docstring to call out the
+    reconcile step.
+  - No Python runtime code modified — purely editorial + CLI stubs +
+    one YAML key. Tests still pass (115). Code module + empirical
+    validation come in subsequent PRs per the orden de trabajo.
+
 - **Architecture — ADR 015**: S2 becomes the owner of the ChromaDB
   embeddings index; S3 (`zotero-mcp serve`) is reduced to a pure
   reader. The project no longer invokes `zotero-mcp update-db` in

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -189,17 +189,23 @@ zotero-ai-toolkit/
 
 ## Contratos entre subsistemas
 
-Los tres subsistemas se comunican **solo a través de Zotero**. Zotero es la fuente de verdad única.
+Zotero es la fuente de verdad bibliográfica. ChromaDB es estado derivado vivo: S2 lo mantiene, S3 lo lee.
 
 ```
-S1 → Zotero ← S3 (read)
-            ↑
-S2 (write accepted items)
+S1 → Zotero ← S3 (read MCP)
+            ↑              ↑
+S2 (write accepted items)  │
+            │              │
+            └→ ChromaDB ←──┘
+               (S2 escribe; S3 lee)
 ```
 
-No hay DB compartida entre S1 y S2. No hay API interna entre subsistemas. Si necesitás que S2 "sepa algo" de S1, ese algo tiene que estar en Zotero (como tag, colección, o campo).
+**Reglas:**
+- No hay DB compartida entre S1 y S2 — `state.db` y `candidates.db` son disjuntas.
+- No hay API interna entre subsistemas. Si S2 necesita "saber algo" de S1, ese algo tiene que estar en Zotero (como tag, colección, o campo).
+- ChromaDB es la única excepción al "solo via Zotero": es estado derivado que S2 mantiene como índice secundario sobre Zotero. ADR 015 explica por qué S2 (no S3) es el owner. S3 lee ChromaDB para responder queries MCP; nunca escribe (`zotero-mcp update-db` no se usa en ningún flujo del proyecto).
 
-**Consecuencia**: S2 y S3 deben poder correr aunque S1 no haya corrido nunca. Degradan gracefully.
+**Consecuencia**: S2 y S3 deben poder correr aunque S1 no haya corrido nunca. Degradan gracefully (S2: `score_semantic=neutral_fallback`; S3: queries devuelven vacío hasta que `zotai s2 backfill-index` corra).
 
 ---
 

--- a/config/scoring.yaml
+++ b/config/scoring.yaml
@@ -19,6 +19,12 @@ tag_scoring:
 
 semantic_scoring:
   top_k_corpus: 20
-  # Returned when ChromaDB is missing or empty, so the composite is still
-  # defined instead of silently dropping to 0 (see plan_02 §7.2).
+  # Returned when ChromaDB has fewer than min_corpus_size documents, so
+  # the composite stays defined instead of silently dropping to 0 (see
+  # plan_02 §7.2).
   neutral_fallback: 0.5
+  # Minimum docs in ChromaDB below which we fall back to neutral_fallback
+  # without attempting the k-NN query. Threshold-by-count (rather than
+  # "empty / not empty") covers small libraries where k-NN over a handful
+  # of papers would be uninformative noise. See ADR 015 §2.
+  min_corpus_size: 50

--- a/docs/decisions/004-openai-text-embedding-3-large.md
+++ b/docs/decisions/004-openai-text-embedding-3-large.md
@@ -98,9 +98,10 @@ Concretely:
   similarity score. This is the normal story with embeddings — all
   models have this property — but worth naming.
 - **Token budget is per-paper, not per-query.** Very long papers
-  (books, theses) pay for their full text at fulltext-indexing time
-  (`zotero-mcp update-db --fulltext`). A 400-page book at ~150K tokens
-  is ~$0.02 — still cheap, but not free.
+  (books, theses) pay for their full text at indexing time (initial
+  `zotai s2 backfill-index` and any subsequent reconcile cycle that
+  picks them up under ADR 015). A 400-page book at ~150K tokens is
+  ~$0.02 — still cheap, but not free.
 
 ### Neutral
 
@@ -147,12 +148,14 @@ informedly. Power users can still override.
 ## References
 
 - `docs/plan_00_overview.md` §7 — stack canónico
-- `docs/plan_02_subsystem2.md` §7.3 — `score_semantic`
+- `docs/plan_02_subsystem2.md` §7.2 — `score_semantic`
 - `docs/plan_03_subsystem3.md` §4.1, §5.2 — embedder in `zotero-mcp`
-  setup
+  setup (S3 reads the index that S2 writes; ADR 015)
 - `docs/decisions/006-zotero-mcp-external-dependency.md` — the
   decision to adopt `zotero-mcp` as the upstream S3 server
-- `docs/decisions/011-chromadb-bind-mount.md` — how S2 sees the index
-  that S3 writes
+- `docs/decisions/011-chromadb-bind-mount.md` — bind-mount mechanism
+  (amended `:ro` → `:rw` by ADR 015)
+- `docs/decisions/015-s2-owns-embeddings-index.md` — who invokes the
+  embedder (S2, not `zotero-mcp update-db`)
 - `.env.example` — `OPENAI_EMBEDDING_MODEL=text-embedding-3-large`
 - `src/zotai/config.py` — `OpenAISettings.embedding_model`

--- a/docs/plan_00_overview.md
+++ b/docs/plan_00_overview.md
@@ -62,9 +62,9 @@ Objetivo de más alto nivel: **multiplicar por 3-5x la cantidad de consultas bib
 Razones:
 
 - S1 produce la biblioteca sobre la que opera todo lo demás. Bloqueante.
-- S3 es barato de implementar (~4h) y **cierra un ciclo de valor mínimo**: apenas terminado S1+S3, el usuario ya tiene producto funcional para descubrimiento y cita. Posponerlo al final deja al usuario con 3-4 semanas de biblioteca sin forma de consultar.
-- S3 funciona como **banco de validación para S2**: los mismos embeddings que expone S3 son los que usa S2 en su criterio de "similitud con corpus". Testear el scoring del S2 sin S3 operativo es a ciegas.
-- S2 es el más complejo (~2-3 semanas de desarrollo incremental). Construirlo sobre base ya validada reduce riesgo.
+- S3 en esta fase significa **setup del servidor MCP** para Claude Desktop: instalar `zotero-mcp`, configurar `claude_desktop_config.json`, y dejarlo corriendo. **No** se ejecuta `zotero-mcp update-db` — bajo ADR 015, S2 es el owner del índice de embeddings y `update-db` no se usa nunca en el flujo operativo. El backfill inicial de ChromaDB se dispara con `zotai s2 backfill-index` cuando S2 esté implementado.
+- S3 setup es barato (~4h) y **cierra un ciclo de valor mínimo**: con S1 + S3 + el primer `backfill-index` de S2, el usuario ya tiene producto funcional para descubrimiento y cita. Posponer S3 al final dejaría al usuario con semanas de biblioteca sin forma de consultar.
+- S2 es el más complejo (~2-3 semanas de desarrollo incremental). Bajo ADR 015 también absorbe la responsabilidad del indexador de embeddings (`src/zotai/s2/indexing.py`) que mantiene el invariante "todo item no-cuarentenado en Zotero está en ChromaDB" via reconciliación por diff en cada ciclo del worker.
 
 ---
 
@@ -82,7 +82,13 @@ Cada una con ADR correspondiente en `docs/decisions/`.
 | 006 | zotero-mcp (54yyyu) para S3 | Existe, estable, cubre los 3 modos out-of-the-box. Build propio no justificado. |
 | 007 | FastAPI + HTMX para dashboard S2 | HTMX evita SPA, renderizado server-side, más simple de mantener. Un único investigador hace cambios. |
 | 008 | Cuarentena en S1 en vez de "todo o nada" | Resuelve tensión completitud vs calidad. Lo dudoso queda accesible pero marcado. |
-| 009 | zotero-mcp usado por S3 **pero no por S1/S2** | S1/S2 usan la API de Zotero directa (pyzotero). MCP es para consumo conversacional. |
+| 009 | zotero-mcp usado por S3 **pero no por S1/S2** | S1/S2 usan la API de Zotero directa (pyzotero). MCP es para consumo conversacional. **Parcialmente superseded por ADR 015** en lo que hace al ChromaDB: S2 ahora también escribe directo al índice (sin pasar por `zotero-mcp update-db`), aunque sigue usando pyzotero para Zotero. |
+| 010 | Ruta A usa OpenAlex para DOI → metadata (no el translator de Zotero) | Translator de Zotero es API no pública / frágil entre versiones. OpenAlex cubre >98% DOIs académicos con API estable. |
+| 011 | ChromaDB compartida via bind mount Docker (no copia, no sync job) | Una sola path canónica `/workspace/chroma_db`, host-side configurable, mount `:rw` para que S2 escriba (amended por ADR 015 — originalmente `:ro`). |
+| 012 | APScheduler in-process default; cron / Task Scheduler como alternativa | Default que matchea el caso 80% (dashboard up); cron sirve a usuarios que cierran el dashboard a diario. Misma función `run_fetch_cycle()` desde ambos paths. |
+| 013 | Bridge networking + `host.docker.internal` en lugar de `network_mode: host` | `network_mode: host` no funciona en Docker Desktop Mac/Win; bridge + `extra_hosts: host-gateway` es uniforme cross-platform. |
+| 014 | Stage 03 dedup: skip attach si el item existente ya tiene PDF | Respeta estado curado del usuario; agrega valor cuando solo había metadata sin PDF. |
+| 015 | **S2 es owner del índice de embeddings; S3 es lector puro** | Invierte ADR 006/009 parcialmente. Elimina trigger externo (cron / on-use) y la ventana de staleness. S2 mantiene el invariante via reconciliación por diff en cada ciclo del worker. Ver ADR 015. |
 
 ---
 

--- a/docs/plan_01_subsystem1.md
+++ b/docs/plan_01_subsystem1.md
@@ -511,7 +511,7 @@ Modo `--yes` skippea confirmaciones (para CI o usuarios experimentados).
 ## 10. Fuera de alcance del S1
 
 Explícitamente pospuesto:
-- Indexación semántica con ChromaDB → parte del S3.
+- Indexación semántica con ChromaDB → responsabilidad de S2 (ver ADR 015). S1 no escribe a ChromaDB bajo ninguna circunstancia.
 - Dashboard web → parte del S2.
 - Integración con Better BibTeX export → post-v1.0.
 - Detección de duplicados entre preprint/published → v1.1 si hace falta.

--- a/docs/plan_02_subsystem2.md
+++ b/docs/plan_02_subsystem2.md
@@ -44,6 +44,9 @@ Mantener la biblioteca Zotero sincronizada con el estado del arte de los temas d
 ┌───────────────────────────────────────────────────────────────┐
 │ Worker (scheduled, corre c/ N horas)                          │
 │  ┌──────────────────────────────────────────────────────┐     │
+│  │ 0. Reconcile ChromaDB (add missing, remove orphans)  │     │
+│  │    Mantiene el invariante: todo item no-cuarentenado │     │
+│  │    en Zotero tiene entrada en ChromaDB. Ver ADR 015. │     │
 │  │ 1. Fetch RSS de journals configurados                │     │
 │  │ 2. Parsear, deduplicar vs candidatos ya vistos       │     │
 │  │ 3. Para cada nuevo candidato:                        │     │
@@ -152,6 +155,16 @@ class TriageMetric(SQLModel, table=True):
     precision_observed: float  # accepted / (accepted + rejected)
 ```
 
+**Nota — ChromaDB no está en `candidates.db`**. Bajo ADR 015, S2 también
+es el owner del índice de embeddings persistido en ChromaDB
+(`/workspace/chroma_db`). Los embeddings de los items de la biblioteca
+viven ahí, no en `candidates.db`. El campo `score_semantic` de
+`Candidate` es solo el float derivado de la query del candidate contra
+ese índice. La lógica de escritura (embedding + upsert) y de
+mantenimiento del invariante vive en
+`src/zotai/s2/indexing.py` (módulo dedicado, ver §11 Sprint 1) y se
+documenta como contrato de schema en ADR 015 §6.
+
 ---
 
 ## 6. Sub-módulo: Feed ingestion
@@ -213,20 +226,21 @@ Cada criterio produce un score `[0, 1]`. El score compuesto es combinación pond
 
 **Alternativa más barata (sin LLM)**: keyword matching sobre abstract contra un vocabulary derivado de tags existentes. Más rápido, menos preciso. Implementar ambas, dejar la elección configurable.
 
-### 7.2 Score semántico (sprint 3, requiere S3 operativo)
+### 7.2 Score semántico (sprint 3)
 
 **Input**: candidate con `abstract`.
 **Output**: `score_semantic ∈ [0, 1]`.
 
 **Lógica**:
 1. Calcular embedding del `abstract` del candidate (OpenAI `text-embedding-3-large`, ~$0.00013/candidate).
-2. Query contra ChromaDB del S3 con `top_k=20`.
+2. Query contra ChromaDB con `top_k = semantic_scoring.top_k_corpus` (default 20).
 3. `score = mean(similarity_scores de los top-k)`.
 4. Normalizar: si la biblioteca tiene N papers y el candidate matchea fuerte con ≥10% de los papers temáticamente cercanos, score alto.
 
 **Implementación**:
-- Reutilizar la instancia de ChromaDB que construye `zotero-mcp` (path configurable).
-- Si ChromaDB no está poblada (S3 nunca corrió), score=0.5 (neutral).
+- Bajo ADR 015, ChromaDB es **mantenida por el propio S2** via reconciliación en cada ciclo del worker (paso 0 del diagrama §4). El path es `S2_CHROMA_PATH=/workspace/chroma_db`, montado read-write desde el host.
+- Si ChromaDB tiene **menos de `semantic_scoring.min_corpus_size` documentos** (default 50, configurable en `config/scoring.yaml`), `score_semantic = semantic_scoring.neutral_fallback` (default 0.5) sin intentar la query k-NN. Este caso solo se da si S1 nunca corrió, o si el primer `zotai s2 backfill-index` todavía no se ejecutó. En régimen normal el invariante de reconciliación mantiene el índice poblado y este fallback no se activa.
+- El threshold por count (en lugar de "está vacía") cubre el caso de bibliotecas chiquitas — un k-NN sobre 5 papers no es ruido informativo, mejor degradar.
 
 ### 7.3 Score por queries persistentes
 
@@ -326,6 +340,15 @@ def composite_score(c: Candidate, weights: Weights) -> float:
 **Lógica del job**:
 ```python
 async def run_fetch_cycle():
+    # Step 0 — reconcile ChromaDB so scoring queries hit a fresh index.
+    # The reconcile is bounded (S2_MAX_EMBED_PER_CYCLE) and safe-guarded
+    # for deletes (S2_SAFE_DELETE_RATIO). Errors are logged but do not
+    # abort the cycle — score_semantic degrades to neutral_fallback if
+    # the corpus_size threshold isn't met after reconcile. See ADR 015.
+    reconcile_embeddings(zot_client, chroma_collection, openai_client,
+                         max_per_cycle=settings.s2.max_embed_per_cycle,
+                         safe_delete_ratio=settings.s2.safe_delete_ratio)
+
     for feed in get_active_feeds():
         try:
             entries = fetch_and_parse(feed)
@@ -343,7 +366,9 @@ async def run_fetch_cycle():
             feed.save()
 ```
 
-**Budget**: cada candidato cuesta ~$0.0005 en embeddings + scoring. Para 30 candidates/ciclo × 4 ciclos/día × 30 días = 3600/mes → ~$2/mes.
+**Budget**: cada candidato cuesta ~$0.0005 en embeddings + scoring. Para 30 candidates/ciclo × 4 ciclos/día × 30 días = 3600/mes → ~$2/mes. Sumar ~$0.01-0.05/ciclo de reconciliación incremental sobre la biblioteca (típicamente 0-3 items nuevos por ciclo en régimen). El backfill inicial (`zotai s2 backfill-index`) tiene su propio cap `S2_MAX_COST_USD_BACKFILL=3.00`. Ver ADR 015 §8.
+
+**Comando manual `zotai s2 reconcile`**: dispara un solo ciclo de reconciliación sin fetch de RSS — útil para debug, para forzar la propagación de un push reciente, o para usuarios que prefieren disparar el reconcile desde un cron externo independiente del worker. Usa los mismos defaults de `.env` que el ciclo del worker.
 
 ---
 
@@ -379,22 +404,25 @@ Se dispara cuando un candidate se marca `accepted`.
 - Push falla (API error, red): retry con backoff, eventualmente marcar `push_failed`, mostrar en dashboard.
 - Colección `Inbox S2` renombrada por el usuario entre runs: la próxima corrida crea una nueva con el nombre canónico — no buscamos por nombre viejo. Si el usuario quiere renombrar persistentemente, también cambia `S2_ZOTERO_INBOX_COLLECTION` en `.env`.
 
+**Nota — el push no escribe a ChromaDB directamente**. La escritura a ChromaDB ocurre en el siguiente ciclo de reconciliación del worker (paso 0 del diagrama §4 / pseudocódigo §9), que detecta el nuevo item en Zotero y lo embebe. Esto mantiene un único path de escritura a ChromaDB, simple de testear y auditar (ver ADR 015). El precio: hay una ventana de hasta `S2_FETCH_INTERVAL_HOURS` entre el push y la disponibilidad del item en queries semánticas — aceptable para el flujo de S3 (Claude Desktop), donde el usuario raramente consulta sobre papers que aceptó hace minutos.
+
 ---
 
 ## 11. Roadmap por sprints
 
-### Sprint 1 (3-5 días): Captura bruta
+### Sprint 1 (3-5 días): Captura bruta + indexación
 
-**Objetivo**: el worker captura de feeds, persiste en DB, el dashboard los muestra sin scoring.
+**Objetivo**: el worker captura de feeds, persiste en DB, el dashboard los muestra sin scoring. **El módulo de indexación (ADR 015) aterriza en este sprint** porque Sprint 2 lo necesita para `score_semantic` ya en su cuna.
 
 - [ ] `config/feeds.yaml` inicial con 5-10 journals.
 - [ ] `src/zotai/s2/feeds.py` con RSS parsing.
 - [ ] `candidates.db` con schema.
-- [ ] `src/zotai/s2/worker.py` con fetch cycle básico.
-- [ ] Dashboard minimal: `/inbox` muestra lista sin scoring ni triage.
-- [ ] CLI: `zotai s2 fetch-once` para testing manual.
+- [ ] `src/zotai/s2/indexing.py` con `reconcile_embeddings()`. Schema de ChromaDB según ADR 015 §6. Tests con ChromaDB temporal.
+- [ ] `src/zotai/s2/worker.py` con fetch cycle básico, llamando a `reconcile_embeddings()` en el paso 0 antes del fetch.
+- [ ] CLI: `zotai s2 fetch-once`, `zotai s2 backfill-index`, `zotai s2 reconcile`.
+- [ ] Dashboard minimal: `/inbox` muestra lista sin scoring ni triage. `/metrics` ya muestra `chroma_docs_count`, `chroma_last_reconcile_at`, `chroma_pending_embeddings`.
 
-**Deliverable**: ver candidatos fluir al inbox tras ejecutar fetch.
+**Deliverable**: ver candidatos fluir al inbox tras ejecutar fetch, y la biblioteca poblada en ChromaDB tras `backfill-index`.
 
 ### Sprint 2 (3-5 días): Scoring básico + triage
 
@@ -412,12 +440,11 @@ Se dispara cuando un candidate se marca `accepted`.
 
 **Objetivo**: criterio de similitud semántica funciona, dashboard usable semanal.
 
-- [ ] Integración con ChromaDB del S3 (read-only).
-- [ ] `score_semantic` en scoring.py.
+- [ ] `score_semantic` en scoring.py — query contra la ChromaDB que el indexing module mantiene desde Sprint 1 (ADR 015). Ya no hace falta "integración con S3"; la ChromaDB es local a S2.
 - [ ] Breakdown visual de scores en cada card.
 - [ ] Keyboard shortcuts en inbox.
 - [ ] Bulk actions.
-- [ ] `/metrics` con precision observada.
+- [ ] `/metrics` con precision observada + breakdown por `source` de los embeddings (fulltext / abstract / title_only).
 - [ ] PDF download en push (best-effort).
 
 **Deliverable**: sistema usable semanalmente, métricas visibles.
@@ -443,16 +470,30 @@ Se dispara cuando un candidate se marca `accepted`.
 # ──────────── S2 Worker ────────────
 S2_FETCH_INTERVAL_HOURS=6
 S2_CANDIDATES_DB=/workspace/candidates.db
-# Container-side path. Montado desde la ChromaDB del host por el servicio
-# `dashboard` en docker-compose.yml. Ver ADR 011 y plan_03 §4.3 / §8.
+# Container-side path donde S2 escribe ChromaDB (owner per ADR 015).
+# Compose bind-mounts el path del host (ZOTERO_MCP_CHROMA_HOST_PATH) acá
+# con flag :rw. Read-only para `zotero-mcp serve` que corre en el host.
 S2_CHROMA_PATH=/workspace/chroma_db
-# Host-side source para el bind mount. Default coincide con el path que planta
-# `zotero-mcp setup`. Override si tenés ChromaDB en otra ubicación.
+# Host-side source para el bind mount. Default coincide con el path que
+# `zotero-mcp setup` espera leer. Cambiarlo en .env también requiere
+# coordinar con la config de zotero-mcp.
 ZOTERO_MCP_CHROMA_HOST_PATH=${HOME}/.config/zotero-mcp/chroma_db
 # Cambiar a `true` para deshabilitar APScheduler in-process y usar cron/Task
 # Scheduler externo. Ver ADR 012.
 S2_WORKER_DISABLED=false
 S2_ZOTERO_INBOX_COLLECTION=Inbox S2   # S2 crea la colección on-demand
+
+# ──────────── S2 Index reconciliation (ADR 015) ────────────
+# Max embeddings calculados por ciclo del worker. Limita costo y picos de
+# latencia; el residual converge en ciclos siguientes.
+S2_MAX_EMBED_PER_CYCLE=50
+# Safety threshold: si orphans/total > este ratio, NO borrar y requerir
+# intervención manual. Protege contra bugs de lectura de Zotero (ej. API
+# devuelve lista vacía erróneamente) que vaciarían ChromaDB por diff.
+S2_SAFE_DELETE_RATIO=0.10
+# Budget cap para el comando one-shot `zotai s2 backfill-index`. Independiente
+# del cap diario/mensual del worker.
+S2_MAX_COST_USD_BACKFILL=3.00
 
 # ──────────── S2 PDF fetch cascade ────────────
 S2_PDF_SOURCES=openaccess,doi,annas,libgen,scihub,rss
@@ -502,7 +543,10 @@ Cada una es un ticket para v1.1+.
 
 ## 15. Dependencias del S2
 
-- **S1** debe haber corrido: necesitamos biblioteca poblada para que el scoring funcione.
-- **S3** debe estar operativo: necesitamos ChromaDB para el score semántico. El acceso concreto se hace via bind mount read-only (`/workspace/chroma_db` dentro del container ← path del host). Ver ADR 011. Si ChromaDB está vacía o no existe todavía, `score_semantic=0.5` (neutral) y el dashboard sigue funcionando.
+- **S1** debe haber corrido: necesitamos biblioteca poblada para que el scoring funcione y para que el primer `backfill-index` tenga material que embebera.
+- **S2 es owner de ChromaDB** (ADR 015). El primer backfill se dispara con `zotai s2 backfill-index`. Los ciclos siguientes del worker mantienen el invariante "todo item no-cuarentenado en Zotero está indexado" via reconciliación por diff. El bind mount es `:rw` (`/workspace/chroma_db` dentro del container ← `${ZOTERO_MCP_CHROMA_HOST_PATH}` en el host). Ver ADR 011 (mecanismo del mount, amended) + ADR 015 (ownership). Si el corpus indexado tiene <`semantic_scoring.min_corpus_size` documentos, `score_semantic=neutral_fallback` (default 0.5) y el dashboard sigue funcionando.
+- **S3 NO es prerequisito de S2** bajo ADR 015. S3 (`zotero-mcp serve`) es lector puro del mismo store. Si el usuario nunca configuró S3, S2 funciona igual; lo único que pierde el usuario es la consulta conversacional desde Claude Desktop.
 - **Zotero abierto** con API local (igual que S1). S2 crea la colección `Inbox S2` (o el nombre en `S2_ZOTERO_INBOX_COLLECTION`) on-demand e idempotentemente en el primer push.
-- **Worker y dashboard corriendo**: por default APScheduler in-process en el mismo container del dashboard (ADR 012). Usuarios que no mantienen el dashboard 24/7 pueden setear `S2_WORKER_DISABLED=true` y usar cron / Task Scheduler externos (receta en `docs/setup-{linux,windows}.md`).
+- **Worker y dashboard corriendo**: por default APScheduler in-process en el mismo container del dashboard (ADR 012). Usuarios que no mantienen el dashboard 24/7 pueden setear `S2_WORKER_DISABLED=true` y usar cron / Task Scheduler externos invocando `zotai s2 fetch-once` (receta en `docs/setup-{linux,windows}.md`); el `fetch-once` ejecuta el reconcile como paso 0 igual que el worker, así que el invariante de ChromaDB se mantiene en ambos paths.
+- **`pdfplumber`**: ya es dependencia de S1 (Etapa 01); S2 la reusa para extraer fulltext de los PDFs adjuntos a los items de Zotero al momento de embebera (ADR 015 §3.2 / §6).
+- **Schema de `zotero-mcp`**: S2 escribe a una ChromaDB que `zotero-mcp serve` (host) lee. La compatibilidad de schema fue validada empíricamente (Fase 2 del plan de implementación de ADR 015) y se documenta como contrato en ADR 015 §6. Cualquier upgrade futuro de `zotero-mcp` debe re-validarse.

--- a/docs/plan_03_subsystem3.md
+++ b/docs/plan_03_subsystem3.md
@@ -83,10 +83,12 @@ Permitir al investigador consultar su biblioteca Zotero desde Claude Desktop med
 
 ### 4.3 ChromaDB local
 
-- **Path en el host** (donde `zotero-mcp` escribe): `~/.config/zotero-mcp/chroma_db/` por default. Configurable en `.env` via `ZOTERO_MCP_CHROMA_HOST_PATH` — típicamente coincide con lo que `zotero-mcp setup` elige.
-- **Path en el container S2** (donde S2 lee): `/workspace/chroma_db`. Es siempre este valor, consistente con la convención `/workspace/*` del resto del container. `S2_CHROMA_PATH=/workspace/chroma_db` por default.
-- **El puente**: el servicio `dashboard` de `docker-compose.yml` monta el path del host en `/workspace/chroma_db:ro` (read-only para S2). Ver **ADR 011** (`docs/decisions/011-chromadb-bind-mount.md`) para el rationale completo.
-- **S2 lee, nunca escribe.** El mount es `:ro`, así que un bug que intente `chroma.add()` falla fuerte en vez de divergir silenciosamente del índice que mantiene `zotero-mcp`.
+Bajo **ADR 015**, S2 es el owner del índice y S3 (`zotero-mcp serve`) es lector puro. La inversión respecto al diseño original simplifica el mantenimiento (no hay que sincronizar dos paths, ni invocar `zotero-mcp update-db` cron / manual) y elimina la ventana de staleness silenciosa.
+
+- **Path en el host** (donde S3 lee): `~/.config/zotero-mcp/chroma_db/` por default. Configurable en `.env` via `ZOTERO_MCP_CHROMA_HOST_PATH` — el path debe coincidir con lo que `zotero-mcp setup` haya elegido al configurar Claude Desktop.
+- **Path en el container S2** (donde S2 escribe): `/workspace/chroma_db`. Es siempre este valor, consistente con la convención `/workspace/*` del resto del container. `S2_CHROMA_PATH=/workspace/chroma_db` por default.
+- **El puente**: el servicio `dashboard` de `docker-compose.yml` monta el path del host en `/workspace/chroma_db:rw`. Ver **ADR 011** (`docs/decisions/011-chromadb-bind-mount.md`) — mecanismo del bind mount, ahora amended para `:rw` por ADR 015.
+- **S2 escribe, S3 lee.** No se ejecuta `zotero-mcp update-db` en ningún flujo operativo del proyecto. La actualización del índice ocurre dentro de S2: backfill inicial via `zotai s2 backfill-index`, mantenimiento continuo via reconciliación por diff en cada ciclo del worker (paso 0, ver `plan_02` §4 / §9). Schema de lo que S2 escribe está documentado en ADR 015 §6 — contrato explícito para que `zotero-mcp serve` pueda leerlo de manera estable.
 
 ---
 
@@ -121,14 +123,16 @@ zotero-mcp setup
 #   - Embedding model: openai
 #   - OpenAI model: text-embedding-3-large
 #   - Provide OpenAI API key
+# IMPORTANTE: anotar el path de ChromaDB que setup elige y, si difiere
+# del default (~/.config/zotero-mcp/chroma_db), setear
+# ZOTERO_MCP_CHROMA_HOST_PATH en .env del container S2 para que
+# coincidan. ADR 011 explica por qué la coordinación es necesaria.
 
-# 4. Build del índice inicial
-zotero-mcp update-db --fulltext
-# Tarda ~30-60 min para 1500 papers.
-# Costo: ~$1-2 en embeddings.
-
-# 5. Verificar
+# 4. Verificar conectividad MCP (sin construir índice)
 zotero-mcp db-status
+# El índice se construye desde S2 con `zotai s2 backfill-index`,
+# NO con `zotero-mcp update-db`. Bajo ADR 015 update-db no se usa
+# en ningún flujo operativo del proyecto.
 ```
 
 ### 5.3 Configurar Claude Desktop
@@ -185,18 +189,20 @@ Claude usa `zotero_fulltext` para acceder al PDF via Zotero, lee, responde.
 
 ### 7.1 Re-indexación
 
-Cuando:
-- S2 agrega nuevos papers → el índice de ChromaDB se desincroniza.
-- Se cambia el modelo de embeddings.
-- Pasa >1 mes sin update.
+**Bajo ADR 015 esto es responsabilidad de S2, no del usuario ni de S3.** El reconcile corre automáticamente como paso 0 de cada ciclo del worker (default cada 6h via APScheduler — ver ADR 012). Si querés forzar un reconcile fuera de ciclo:
 
-Comando:
 ```bash
-zotero-mcp update-db          # incremental, solo nuevos
-zotero-mcp update-db --force-rebuild   # rebuild completo
+docker compose run --rm onboarding zotai s2 reconcile
 ```
 
-**Automatización**: cron job diario que corre `update-db`, configurado en `docs/s3-setup.md`. O manualmente tras cada sesión de triage en S2.
+Para inspeccionar el estado actual del índice (cuántos docs, último ciclo, pendientes, huérfanos), abrir el dashboard de S2 en `http://127.0.0.1:8000/metrics`.
+
+**Casos especiales:**
+- **Bibliografía recién migrada** (S1 corrió, ChromaDB vacía): el primer comando es `zotai s2 backfill-index` con `S2_MAX_COST_USD_BACKFILL` como cap. Tarda 30-60 min para ~1500 papers, cuesta $1-2.
+- **Cambio de modelo de embeddings**: vaciar ChromaDB manualmente (`rm -rf $ZOTERO_MCP_CHROMA_HOST_PATH`) y re-correr `backfill-index`. El cambio de modelo es muy infrecuente; no hay automatización para esto.
+- **Index corrupto o sospechoso**: el reconcile es auto-curativo — borra y re-embebe lo que detecte como divergente. No hay comando "rebuild" porque no hace falta.
+
+**No usar `zotero-mcp update-db`.** Bajo ADR 015 ese comando no es parte del flujo operativo del proyecto; usarlo manualmente puede generar un schema inconsistente con el que escribe S2 (ver ADR 015 §6 para el contrato).
 
 ### 7.2 Troubleshooting
 
@@ -209,25 +215,29 @@ Problemas comunes:
 
 ---
 
-## 8. Integración con S2 (shared ChromaDB)
+## 8. Integración con S2 (shared ChromaDB, S2 es owner)
 
-S2 usa el mismo ChromaDB que `zotero-mcp` para su criterio `score_semantic`. Detalles en ADR 011; resumen:
+Bajo **ADR 015**, la dirección de la integración se invierte respecto a versiones previas:
 
-- **Un solo store físico en disco**: el que `zotero-mcp` mantiene en `${ZOTERO_MCP_CHROMA_HOST_PATH:-$HOME/.config/zotero-mcp/chroma_db}`. No hay copia ni sync job.
-- **S2 lo ve via bind mount** en `/workspace/chroma_db` (read-only). El container nombra `S2_CHROMA_PATH=/workspace/chroma_db`; el host decide qué directorio "real" se monta ahí.
-- **Si ChromaDB vacía o desincronizada** (p.ej. el usuario nunca terminó el setup de S3): S2 degrada gracefully, `score_semantic=0.5` (neutral). El dashboard muestra un warning apuntando a `docs/s3-setup.md`.
+- **S2 es el owner del store**. Mantiene el invariante "todo item no-cuarentenado en Zotero está indexado" via `reconcile_embeddings()` en cada ciclo del worker. Schema documentado en ADR 015 §6.
+- **S3 (`zotero-mcp serve`) lee el mismo store** sobre el path host. No invoca `zotero-mcp update-db` en ningún flujo del proyecto.
+- **Un solo store físico en disco**: el que vive en `${ZOTERO_MCP_CHROMA_HOST_PATH:-$HOME/.config/zotero-mcp/chroma_db}` en el host. Sin copia, sin sync job. Bind-mounted al container de S2 como `/workspace/chroma_db:rw` (ver ADR 011 amended por ADR 015).
+- **Si ChromaDB tiene <`semantic_scoring.min_corpus_size` documentos**: S2 degrada gracefully, `score_semantic=neutral_fallback` (0.5). El dashboard muestra un warning apuntando a "ejecutá `zotai s2 backfill-index`".
+- **Compatibilidad de schema**: validada empíricamente (Fase 2 del plan de implementación de ADR 015). Cualquier upgrade de `zotero-mcp` debe re-validarse contra el script `scripts/validate_chromadb_schema.py`; el resultado se loguea en CHANGELOG.
 
 ---
 
 ## 9. Deliverables de la implementación de S3
 
-- [ ] `docs/s3-setup.md` con guía paso a paso por OS.
+- [ ] `docs/s3-setup.md` con guía paso a paso por OS — incluyendo coordinación de `ZOTERO_MCP_CHROMA_HOST_PATH` con la config de zotero-mcp (ADR 011 + ADR 015).
 - [ ] `docs/s3-usage.md` con prompts recomendados para cada modo.
-- [ ] `scripts/validate-s3.py` con queries de prueba automatizadas.
-- [ ] `docs/s3-troubleshooting.md` con problemas comunes.
-- [ ] `docs/decisions/006-zotero-mcp.md` ADR justificando no desarrollar custom.
-- [ ] Script helper `scripts/reindex-s3.sh` (y `.ps1`) para re-indexación fácil.
-- [ ] Verificación de que `S2_CHROMA_PATH` está documentado coherentemente entre S2 y S3 (cumplido por ADR 011 y los edits de §4.3 / §8).
+- [ ] `scripts/validate-s3.py` con queries de prueba automatizadas (recall@20, latencia).
+- [ ] `docs/s3-troubleshooting.md` con problemas comunes — incluyendo "MCP no encuentra docs tras upgrade de zotero-mcp" → re-correr `scripts/validate_chromadb_schema.py`.
+- [ ] ADR 006 (zotero-mcp como upstream MCP server) y ADR 009 (S1/S2 usan pyzotero, S3 usa MCP) **ya escritos en PR #36**, parcialmente superseded por ADR 015.
+
+**Removed deliverables (eran parte del diseño previo, ya no aplican bajo ADR 015):**
+- ~~Script helper `scripts/reindex-s3.sh` (y `.ps1`)~~. La re-indexación es responsabilidad de S2 (`zotai s2 reconcile` o el ciclo automático del worker), no del usuario via shell. Ver §7.1.
+- ~~Paso "Build del índice inicial" en §5.2~~. El backfill se dispara desde S2 con `zotai s2 backfill-index`.
 
 ---
 

--- a/docs/plan_glossary.md
+++ b/docs/plan_glossary.md
@@ -56,7 +56,13 @@ SQLite con el estado del pipeline S1. Ubicación: `/workspace/state.db` dentro d
 SQLite con candidates, feeds, queries. Separado del `state.db`. Ubicación: `/workspace/candidates.db`.
 
 **Chroma DB**
-Base vectorial gestionada por `zotero-mcp` para embeddings. Ubicación canónica: `~/.config/zotero-mcp/chroma_db/`. S3 la escribe, S2 la lee.
+Base vectorial para embeddings de los items de la biblioteca Zotero del usuario. Ubicación canónica: `~/.config/zotero-mcp/chroma_db/` en el host (path por default de `zotero-mcp setup`); montada al container de S2 como `/workspace/chroma_db:rw`. **S2 la escribe** (owner, ver ADR 015) via `reconcile_embeddings()` por ciclo del worker + el comando one-shot `zotai s2 backfill-index`. **S3 (`zotero-mcp serve`) la lee** para responder queries MCP desde Claude Desktop. No se ejecuta `zotero-mcp update-db` en ningún flujo del proyecto.
+
+**Reconciliación de embeddings** (S2)
+Proceso que corre en cada ciclo del worker como paso 0, antes del fetch de RSS y del scoring. Compara el conjunto de keys en Zotero con el conjunto de ids en ChromaDB; embebe lo faltante (limitado por `S2_MAX_EMBED_PER_CYCLE`) y borra huérfanos cuando el ratio está bajo `S2_SAFE_DELETE_RATIO` (safety contra bugs de lectura de Zotero que vaciarían el store). Implementa el invariante "todo item no-cuarentenado en Zotero está indexado en ChromaDB" del ADR 015. Idempotente: correr dos veces seguidas con el mismo estado produce el mismo resultado. Disparable manualmente con `zotai s2 reconcile` o como parte de `zotai s2 fetch-once`.
+
+**Backfill de índice** (S2)
+Comando `zotai s2 backfill-index`: misma lógica de reconciliación pero con `max_per_cycle` efectivamente sin límite, progress bar, y cap de costo separado (`S2_MAX_COST_USD_BACKFILL`, default 3.00). Es el primer comando que el usuario corre tras completar S1 + setup de S3 — pobla ChromaDB inicialmente para que `score_semantic` arranque con datos. Idempotente; re-correrlo es seguro y barato.
 
 **Clasificador académico / no-académico** (S1 Etapa 01)
 Filtro upstream del pipeline S1. Decide, para cada PDF encontrado bajo `PDF_SOURCE_FOLDERS`, si es material bibliográfico o material de descarte (facturas, DNIs, tickets, manuales, etc.). Estrategia híbrida en 3 ramas: (1) **accept** automático por heurística positiva — DOI / arXiv / ISBN / keywords académicos en páginas 1-3; (2) **reject** automático por heurística negativa — ≤2 páginas + ausencia de texto o keywords de facturación en primera página; (3) **ambiguos** resueltos por `gpt-4o-mini` con prompt corto. Ver `plan_01_subsystem1.md` §3 Etapa 01 y §3.1.

--- a/src/zotai/cli.py
+++ b/src/zotai/cli.py
@@ -310,8 +310,52 @@ def s1_status() -> None:
 
 @s2_app.command("fetch-once")
 def s2_fetch_once() -> None:
-    """Run one RSS fetch cycle and persist new candidates."""
+    """Run one RSS fetch cycle and persist new candidates.
+
+    Step 0 of the cycle is the embedding-index reconcile (ADR 015), so
+    this command keeps the ChromaDB invariant in sync even when the
+    in-process scheduler is disabled (`S2_WORKER_DISABLED=true`).
+    """
     _not_implemented("s2 fetch-once", 11, 12)
+
+
+@s2_app.command("backfill-index")
+def s2_backfill_index(
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip the interactive confirmation prompt that shows the "
+            "estimated cost before embedding starts.",
+        ),
+    ] = False,
+) -> None:
+    """Embed every non-quarantined Zotero item into ChromaDB.
+
+    First-run command for S2 after S1 has populated the Zotero library.
+    Same reconcile_embeddings() code as the worker's step 0, but with
+    `max_per_cycle` lifted, a progress bar, and its own budget cap
+    (`S2_MAX_COST_USD_BACKFILL`, default $3.00). Idempotent — re-running
+    after a partial backfill resumes from where it left off.
+
+    Defined by ADR 015 §2; implementation lands in S2 Sprint 1 (#12).
+    """
+    _ = yes
+    _not_implemented("s2 backfill-index", 11, 12)
+
+
+@s2_app.command("reconcile")
+def s2_reconcile() -> None:
+    """Run a single reconcile_embeddings() cycle without RSS fetch.
+
+    Useful for: forcing the propagation of a recent push, debugging an
+    index/library divergence, or running from an external cron job that
+    drives reconciliation independently of the worker. Bounded by
+    `S2_MAX_EMBED_PER_CYCLE` and `S2_SAFE_DELETE_RATIO` defaults from
+    `.env` (same as the worker).
+    """
+    _not_implemented("s2 reconcile", 11, 12)
 
 
 @s2_app.command("dashboard")


### PR DESCRIPTION
## Summary

Fase 1 of the orden de trabajo for ADR 015. Ripples the ChromaDB ownership inversion (S2 owner / writer; S3 pure reader) across every document and config that previously described the pre-ADR-015 model. Purely editorial — no Python runtime code, only CLI stubs for the two new commands the indexing module will expose in Phase 11 (#12).

**What changes:**
- `plan_00` §4 + §5 — clarify ordering meaning of "S3"; decisions table extended with rows 010-015.
- `plan_01` §10 — Fuera de alcance line for ChromaDB inverted.
- `plan_02` §4 / §5 / §7.2 / §9 / §10 / §11 / §12 / §15 — architecture diagram, data model note, score_semantic fallback (`min_corpus_size`-based), worker pseudocode, push semantics, Sprint 1/3 deliverables, env vars, dependencies.
- `plan_03` §4.3 / §5.2 / §7.1 / §8 / §9 — ownership flipped, "Build initial index" removed, re-indexación section obsoleted, S2/S3 integration inverted.
- `plan_glossary.md` — Chroma DB entry inverted; new entries for "Reconciliación de embeddings" and "Backfill de índice".
- `CLAUDE.md` "Contratos entre subsistemas" — diagram + softened "solo via Zotero" claim.
- `.env.example` — S2_CHROMA_PATH comment inverted; new block for `S2_MAX_EMBED_PER_CYCLE`, `S2_SAFE_DELETE_RATIO`, `S2_MAX_COST_USD_BACKFILL`.
- `config/scoring.yaml` — added `semantic_scoring.min_corpus_size: 50`.
- `src/zotai/cli.py` — stubs for `zotai s2 backfill-index` (with `--yes`) and `zotai s2 reconcile`; enriched `s2 fetch-once` docstring.
- ADR 004 — two stale references (`zotero-mcp update-db`, "S3 writes") updated to point at S2 + ADR 015.

## What this PR does NOT do

- No Python runtime code (only stubs).
- No `docker-compose.yml` mount change — that lands in PR C (the `:rw` mount).
- No empirical schema validation — that's Fase 2.
- No indexing module code — that's Fase 3.

## Test plan

- [ ] `pytest -q` → 117 passed (no test changes).
- [ ] `mypy --strict src/zotai/cli.py` → clean.
- [ ] `grep -rn "zotero-mcp update-db|S3 writes" docs/` returns only legitimate hits (the ADRs that explain the inversion + explicit "no se ejecuta" notes).
- [ ] Reading `plan_02` cover-to-cover produces no contradictions with ADR 015.
- [ ] `.env.example` lines parse to `S2Settings` defaults — verified at runtime when the worker lands in Phase 11.

## References

- ADR 015 (`docs/decisions/015-s2-owns-embeddings-index.md`, merged in #40)
- ADR 011 amendment (`docs/decisions/011-chromadb-bind-mount.md`, merged in #40)
- Orden de trabajo §1 (provided in chat)