### PR TITLE
feat(docker): wire ChromaDB bind mount :rw on dashboard (ADR 015)

### DIFF
--- a/docker-compose.yml
+++ b/docker-compose.yml
@@ -5,9 +5,17 @@
 #   - dashboard  : long-running S2 FastAPI app + scheduled worker
 #
 # Volumes persist across runs:
-#   - ./workspace : state.db, candidates.db, staging/, reports/, chroma_db/
+#   - ./workspace : state.db, candidates.db, staging/, reports/
 #   - ./config    : feeds.yaml, taxonomy.yaml, scoring.yaml
 #   - ./data      : source PDFs (read-only for the container)
+#
+# ChromaDB lives on the host at ${ZOTERO_MCP_CHROMA_HOST_PATH:-~/.config/zotero-mcp/chroma_db}
+# (the path `zotero-mcp setup` plants by default) and is bind-mounted
+# read-write into the dashboard service at /workspace/chroma_db. S2 owns
+# writes to it (per ADR 015); zotero-mcp serve on the host reads from
+# the same path. The onboarding service deliberately does NOT mount it —
+# S1 has no reason to touch ChromaDB. See ADR 011 (mount mechanism,
+# amended for :rw) + ADR 015 (ownership inversion).
 #
 # Networking: bridge (default). Zotero Desktop's local API lives on the
 # host at localhost:23119 and is reached from inside the container as
@@ -44,6 +52,10 @@ services:
     volumes:
       - ./workspace:/workspace
       - ./config:/app/config
+      # ChromaDB shared with `zotero-mcp serve` on the host. S2 writes
+      # (owner per ADR 015), zotero-mcp serve reads. ADR 011 documents
+      # the mechanism; the path on the host is overridable via .env.
+      - ${ZOTERO_MCP_CHROMA_HOST_PATH:-${HOME}/.config/zotero-mcp/chroma_db}:/workspace/chroma_db:rw
     extra_hosts:
       - "host.docker.internal:host-gateway"
     ports:


### PR DESCRIPTION
## Summary

Wires the ChromaDB bind mount that ADR 011 originally anticipated for Phase 9 (#10), with the `:rw` flag that ADR 015 prescribes (S2 owns writes). Small, self-contained — purely compose + header comments, no code.

**Changes:**
- Dashboard service `volumes:` gains `${ZOTERO_MCP_CHROMA_HOST_PATH:-${HOME}/.config/zotero-mcp/chroma_db}:/workspace/chroma_db:rw`.
- Header explains the mount, the ownership model (S2 writes, `zotero-mcp serve` on host reads), and that `onboarding` service deliberately does NOT mount it (S1 has no reason to touch ChromaDB, per `plan_01` §10).
- `./workspace:/workspace` comment no longer lists `chroma_db/` — it is an independent mount now.

## Why separate from PR #41 (Fase 1 docs)

Principle #2 of the orden de trabajo for ADR 015 says "no mezclar documentación con código". Strictly speaking the compose file is config, but it has runtime effect, and keeping it in its own small PR is cleaner — consistent with what we did for PRs #37 (networking compose changes) and #38 (stage_03 code).

## Test plan

- [ ] `docker compose config` parses without error (could not run in this sandbox — no Docker CLI in the WSL distro; YAML inspected by eye).
- [ ] `ls -la workspace/` after `docker compose up dashboard` shows no stray `chroma_db` directory inside `./workspace`.
- [ ] `docker compose exec dashboard touch /workspace/chroma_db/.smoke && ls -la \$HOME/.config/zotero-mcp/chroma_db/.smoke` shows the file appears on the host.
- [ ] `docker compose up onboarding --profile onboarding -- zotai s1 --help` does not list or mount `/workspace/chroma_db`.

## References

- ADR 015 §7 — "docker-compose.yml: el mount `:ro` que ADR 011 había anticipado para Phase 9 aterriza como `:rw`"
- ADR 011 Amendment — the `:ro` → `:rw` flip justification
- plan_01 §10 — S1 never touches ChromaDB, so `onboarding` does not mount it