### PR TITLE
docs(s2): ADR 016 — RRF default for composite score

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -51,6 +51,22 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
   - No Python runtime code modified — purely editorial + CLI stubs +
     one YAML key. Tests still pass (115). Code module + empirical
     validation come in subsequent PRs per the orden de trabajo.
+- **S2 composite score — ADR 016**: `score_composite` now defaults to
+  Reciprocal Rank Fusion (RRF, Cormack/Clarke/Büttcher 2009) instead
+  of the previous linear weighted mean. Fixes two problems with the
+  old default: (1) `w_t=1, w_s=w_q=2` were arbitrary pre-data
+  guesses; (2) the weighted mean buried papers with high score on one
+  criterion and low on the others — exactly the "out-of-distribution
+  but matches a persistent query" case S2 is supposed to surface.
+  Changes: `config/scoring.yaml` gains `composite_score.method: rrf`
+  (with `rrf_k: 60`); the legacy `weights:` block stays as opt-in
+  when `method=weighted_mean`. `plan_02` §7.4 rewritten with RRF
+  pseudocode + calibration-deferred note explaining why RRF today and
+  a logistic-regression calibration via a successor ADR once ≥100
+  triage decisions exist. Dashboard `/inbox` (Phase 12) also exposes
+  per-criterion sort so a "queries=#1" paper can be surfaced
+  independently. Docs + config only; runtime lands with Sprint 2
+  (#13).
 
 - **Architecture — ADR 015**: S2 becomes the owner of the ChromaDB
   embeddings index; S3 (`zotero-mcp serve`) is reduced to a pure

--- a/config/scoring.yaml
+++ b/config/scoring.yaml
@@ -1,10 +1,24 @@
 # ─────────────────────────────────────────────────────────────
-# config/scoring.yaml — default weights for the S2 composite score.
-# Defaults match docs/plan_02_subsystem2.md §7.4.
-# Adjust via the dashboard at /config/weights once Phase 12 lands.
+# config/scoring.yaml — S2 scoring defaults. Matches plan_02 §7.4.
+# Adjustable via the dashboard at /config/weights once Phase 12 lands.
 # ─────────────────────────────────────────────────────────────
 version: 1
 
+composite_score:
+  # Method for combining score_tags / score_semantic / score_queries
+  # into score_composite. `rrf` (Reciprocal Rank Fusion) is the default
+  # per ADR 016: robust to distributional differences across criteria,
+  # no arbitrary weights, favors candidates that rank high on ANY
+  # criterion. `weighted_mean` is the legacy linear combination,
+  # documented for opt-in until calibration data exists.
+  method: rrf   # rrf | weighted_mean
+  # RRF's smoothing constant (Cormack et al. 2009). k=60 is the
+  # paper-standard default; rarely worth changing.
+  rrf_k: 60
+
+# Legacy weighted-mean weights. Ignored when composite_score.method=rrf.
+# Kept so users who set method=weighted_mean (e.g. for A/B comparison
+# against RRF) have sensible defaults to start from.
 weights:
   tags: 1.0
   semantic: 2.0

--- a/docs/decisions/016-rrf-composite-score.md
+++ b/docs/decisions/016-rrf-composite-score.md
@@ -1,0 +1,107 @@
+# ADR 016 — Reciprocal Rank Fusion for S2 composite score
+
+**Status**: Accepted
+**Date**: 2026-04-23
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+S2 computes three independent scores for every candidate paper (plan_02 §7):
+
+- `score_tags ∈ [0, 1]` — overlap between the paper's LLM-extracted tags and the user's library tag vocabulary (§7.1).
+- `score_semantic ∈ [0, 1]` — mean cosine of top-k nearest library papers in ChromaDB (§7.2).
+- `score_queries ∈ [0, 1]` — max cosine against the user's persistent queries (§7.3).
+
+These feed into a single `score_composite` that drives ranking in `/inbox`.
+
+The original spec defined composite as a **linear weighted mean**:
+
+```
+composite = (w_t·S_tags + w_s·S_sem + w_q·S_queries) / (w_t + w_s + w_q)
+with w_t=1, w_s=2, w_q=2 by default.
+```
+
+Two problems with this baseline:
+
+1. **Pesos arbitrarios.** `w_s = w_q = 2` and `w_t = 1` are pulled out of the air. There's no data to calibrate them before S2 has seen a hundred or so triage decisions, and weighted-mean behaviour is sensitive to those choices. The spec explicitly defers a "learning loop" to v1.1 (plan_02 §3) to avoid echo chamber — but there's a difference between *calibrating scales* (adjusting how much each signal counts) and *biasing by past decisions* (training a model to reproduce the user's taste). Calibration is not echo chamber.
+
+2. **Promedio ponderado destruye señales ortogonales.** A paper with `score_tags=0.1, score_semantic=0.1, score_queries=0.9` — exactly the "out-of-coverage but matches a specific query" case that the whole `PersistentQuery` feature exists to surface — produces `composite = (1·0.1 + 2·0.1 + 2·0.9) / 5 = 0.42`, which is middling and gets buried. The user then never sees the one paper they specifically asked for. The linear combination penalises exactly the kind of off-diagonal match that S2 is supposed to celebrate.
+
+We need a composite that (a) does not depend on arbitrary pre-data weights, (b) preserves the signal of "ranks high on any one criterion", and (c) has room to evolve into a calibrated model once we have decision data.
+
+## Decision
+
+**Reciprocal Rank Fusion (RRF, Cormack / Clarke / Büttcher 2009) is the default method for `score_composite`. The legacy weighted-mean is documented as an opt-in fallback.**
+
+Formally, for each candidate `d` and each criterion `c ∈ {tags, semantic, queries}`:
+
+$$
+S_{\text{RRF}}(d) = \sum_{c} \frac{1}{k + \text{rank}_c(d)}
+$$
+
+with `k = 60` (the paper-standard constant) and `rank_c(d)` the 1-indexed position of `d` after sorting the candidate pool by `score_c` descending. `score_composite` is then normalised to `[0, 1]` by dividing by `max(S_RRF)` in the pool.
+
+Concretely:
+
+1. **`config/scoring.yaml`** gains a `composite_score:` block:
+   ```yaml
+   composite_score:
+     method: rrf   # rrf | weighted_mean
+     rrf_k: 60
+   ```
+   The legacy `weights:` block remains in the file but is only consulted when `method: weighted_mean`.
+2. **`plan_02` §7.4** is rewritten with the RRF pseudocode and the calibration-deferred note.
+3. **Dashboard `/inbox`** adds per-criterion sort controls. `score_composite` is still the default sort, but a user who wants to see "top by queries" independently can flip the sort without losing the RRF-ranked view.
+4. **The `scoring_explanation` JSON** stored per candidate (plan_02 §5) gains a `rrf_ranks` field recording the rank of that candidate in each criterion at scoring time. This is what Sprint 3's UI breakdown visualisation reads; it is also the input a future calibration ADR will feed into logistic regression.
+5. **Calibration path**. Once `candidates.db` has ≥100 decisions with both `accepted`/`rejected` outcomes and the ranked-per-criterion data stored above, a successor ADR can compare RRF to a weighted-mean calibrated via logistic regression on `{score_tags, score_semantic, score_queries} → outcome`. Until then, RRF is the default and the weighted-mean option exists only for users who want to A/B compare.
+
+## Consequences
+
+### Positive
+
+- **No pre-data weight tuning.** RRF eliminates the `w_t, w_s, w_q` pre-spec guesswork. The only knob is `k`, and the paper-standard `k = 60` is appropriate across wildly different retrieval corpora; the user rarely needs to touch it.
+- **Ortogonales surgen.** A paper that ranks #1 on `queries` and #500 on both `tags` and `semantic` still gets `1/61 + 1/560 + 1/560 ≈ 0.0200`, which is ~40% of the score of a paper that ranks #1 on all three (`3/61 ≈ 0.0492`). That's visible in the inbox rather than buried. The user's persistent query is not punished for being out-of-distribution from their existing library.
+- **Robusto a distribuciones distintas.** RRF uses ranks, not raw scores, so wild differences in scale across criteria (tags might max out at 0.6, semantic at 0.95, queries at 0.85) don't silently bias the ranking. Weighted-mean requires per-criterion normalisation to avoid this; RRF gets it for free.
+- **Estandar de la industria.** Hybrid retrieval systems (learned-sparse + dense in modern search; BM25 + dense in pyserini, Vespa, Elastic) use RRF as the canonical fusion method. We gain a well-understood default instead of inventing one.
+- **Camino claro a calibración.** "No weights" is a real selling point *today* (pre-data); "weighted with calibrated coefficients" is the eventual story *when the data exists*. Keeping both methods in the config makes the transition an ADR update and an A/B run, not a rewrite.
+
+### Negative
+
+- **Rank-based ≠ score-based.** RRF throws away the actual score values — a paper with `score_semantic=0.95` and one with `score_semantic=0.85` rank adjacent, and their difference in `score_composite` is a single slot of rank, not the 0.10 gap in the underlying similarity. When the underlying score *is* well-calibrated and discriminative, weighted-mean might eke out marginally better rankings. For our case (three scores of uncertain calibration, especially at start), this is a feature, not a bug — but it's worth naming.
+- **Needs the full candidate pool at scoring time.** Ranks are relative to the pool, so you cannot compute `score_composite` one candidate at a time. The worker already processes a batch per cycle (`run_fetch_cycle` accumulates all new candidates before scoring), so this matches the existing flow — but a future streaming scoring design would need to revisit it.
+- **UI needs to explain RRF.** "Composite score" is intuitive as a weighted-mean; "a number derived from ranks across three criteria" takes one extra sentence in the `/inbox` onboarding note. The breakdown-per-criterion visualisation (planned for Sprint 3) does most of the explaining visually.
+
+### Neutral
+
+- **Weighted-mean stays in the config**. Not as the default, but available. A user who wants to tune weights manually during a calibration experiment can flip `method: weighted_mean` and set `weights.tags / semantic / queries` directly. No code removal; the implementation branches on `method`.
+- **`k = 60` is not load-bearing.** The whole point of RRF is that `k` absorbs noise; `k ∈ [10, 100]` typically produce indistinguishable rankings for small-to-medium pools. We lock to 60 for reproducibility.
+
+## Alternatives considered
+
+**A. Keep the weighted-mean and pick better weights.**
+Rejected. There are no "better weights" without decision data. Picking weights pre-data is guessing, and any guess has the ortogonal-signals-destruction problem — the only remedy is a weight vector so lopsided that one criterion effectively dominates, which defeats the point of having three.
+
+**B. Use `max()` instead of a weighted mean.**
+Considered seriously. `max(S_tags, S_sem, S_q)` has the same "any criterion wins" property as RRF without the rank machinery. Rejected because `max` does not distinguish between "ranks #1 on one criterion" and "ranks #1 on three criteria" — the latter is strictly stronger evidence and should rank higher. RRF preserves that ordering. Cheap enough to have both.
+
+**C. Learn a ranker from the first 100 decisions, then switch.**
+Rejected as the initial default — this IS the learning-loop path that plan_02 §3 defers to v1.1, and it does not solve the "what to do before 100 decisions exist" problem. RRF is the *pre-learning* default; a calibrated ranker is the *post-data* successor.
+
+**D. CombSUM / CombMNZ (other fusion methods).**
+Rejected. CombSUM sums raw scores (suffers the same calibration problem as weighted-mean); CombMNZ multiplies by the number of criteria that matched, which is similar in spirit to RRF but less standard and less forgiving of zero scores. RRF is the industry default for a reason.
+
+**E. Just use `score_semantic` alone and drop the other two.**
+Rejected. `score_semantic` degrades to `neutral_fallback=0.5` when ChromaDB is below `min_corpus_size` (ADR 015, plan_02 §7.2). Pre-backfill, the system would rank everything identically. The three-criterion design exists so S2 has signal even before ChromaDB is populated.
+
+## References
+
+- `docs/plan_02_subsystem2.md` §7 — the three per-criterion scores
+- `docs/plan_02_subsystem2.md` §7.4 — composite score (rewritten to use RRF)
+- `docs/plan_02_subsystem2.md` §3 — anti-objective "no learning loop en v1"; this ADR explains why RRF is *not* learning loop
+- `config/scoring.yaml` — `composite_score.method` and `rrf_k`
+- Cormack, G. V.; Clarke, C. L. A.; Büttcher, S. (2009). "Reciprocal rank fusion outperforms Condorcet and individual rank learning methods." SIGIR 2009. Canonical reference for RRF with `k = 60`.
+- [Elastic Search: Reciprocal rank fusion](https://www.elastic.co/guide/en/elasticsearch/reference/current/rrf.html) — a modern industry implementation using the same formula.

--- a/docs/plan_02_subsystem2.md
+++ b/docs/plan_02_subsystem2.md
@@ -254,19 +254,34 @@ Cada criterio produce un score `[0, 1]`. El score compuesto es combinación pond
 
 ### 7.4 Score compuesto
 
+**Método default: Reciprocal Rank Fusion (RRF)** sobre los tres scores por criterio. Ver ADR 016 para el rationale completo — resumen: un promedio ponderado destruye señales ortogonales (un paper con `queries=0.9` pero `tags=0.1, semantic=0.1` se entierra bajo pesos arbitrarios); RRF es robusto a distribuciones distintas de cada criterio y favorece a quienes aparecen arriba en *cualquiera* de los tres.
+
 ```python
-def composite_score(c: Candidate, weights: Weights) -> float:
-    return (
-        weights.tags * c.score_tags
-        + weights.semantic * c.score_semantic
-        + weights.queries * c.score_queries
-    ) / (weights.tags + weights.semantic + weights.queries)
+# Reciprocal Rank Fusion (Cormack, Clarke, Büttcher 2009).
+# Lower rank = better; k absorbs the noise at the tail.
+def composite_score(candidates: list[Candidate], k: int = 60) -> None:
+    for criterion in ("tags", "semantic", "queries"):
+        ranked = sorted(
+            candidates,
+            key=lambda c: getattr(c, f"score_{criterion}"),
+            reverse=True,
+        )
+        for rank, c in enumerate(ranked, start=1):
+            c.score_composite += 1.0 / (k + rank)
+    # Normalize to [0, 1] for UI and persistence.
+    max_rrf = max(c.score_composite for c in candidates) or 1.0
+    for c in candidates:
+        c.score_composite /= max_rrf
 ```
 
-**Weights default** (configurable en `config/scoring.yaml`):
-- `tags=1.0`
-- `semantic=2.0` (más importante, más discriminador)
-- `queries=2.0`
+**Configuración** (`config/scoring.yaml`, bloque `composite_score`):
+- `method: rrf` (default) | `weighted_mean` (legacy, documented for opt-in).
+- `rrf_k: 60` — constante estándar del paper original. Aumentarla suaviza, bajarla pesa más a los tops. Raramente hay que tocarla.
+- `weighted_mean` sigue disponible con `weights.{tags, semantic, queries}` por si el usuario quiere forzar calibración manual; no recomendado como default.
+
+**UI complement**: el dashboard `/inbox` ordena por `score_composite DESC` pero **expone también ordenamiento por criterio individual** (tabs o filtros). Un paper con `queries=0.9` (match perfecto a una query persistente) debe poder mostrarse primero aunque RRF lo ranke medio por tener `tags` y `semantic` bajos.
+
+**Calibración diferida**. RRF no necesita pesos — elimina la pregunta "¿cuánto vale tags vs semantic?". **Cuando haya ≥100 decisiones históricas** en `candidates.db` (una vez que el usuario lleve 2-3 meses de triage), un futuro ADR puede reintroducir pesos vía regresión logística sobre `score_tags, score_semantic, score_queries → {accepted, rejected}`, y comparar la precisión observada de RRF vs weighted-mean calibrado. **Calibrar escalas no es echo chamber** (el antipatrón que plan_02 §3 evita); sesgar el ranker con las aceptaciones del usuario sí lo sería — no es lo mismo. El dashboard `/metrics` ya expone `candidates_accepted / (accepted + rejected)` como precision observada por semana; esos datos son el input de la calibración futura.
 
 ---
 


### PR DESCRIPTION
## Summary

Spec change for S2 composite scoring. The weighted-mean formula in `plan_02` §7.4 had two design flaws:
1. **Arbitrary weights.** `w_t=1, w_s=w_q=2` were pulled out of the air. No data exists to calibrate them before the first 100 triage decisions.
2. **Ortogonal-signal destruction.** A paper with `queries=0.9, tags=0.1, semantic=0.1` — exactly the "matches a persistent query on a topic outside the current library" case the feature is built for — computes `composite=0.42` and gets buried.

**ADR 016** switches the default to **Reciprocal Rank Fusion** (Cormack et al. 2009, `k=60`). Rank-based, no pre-data scale calibration, "ranks high on any criterion wins" property preserves off-diagonal matches. The legacy weighted-mean stays in the config as opt-in.

**Changes:**
- New `docs/decisions/016-rrf-composite-score.md`.
- `plan_02` §7.4 rewritten with RRF pseudocode + calibration-deferred note explaining why this is *not* the learning loop that §3 anti-objective defers.
- `config/scoring.yaml` gains `composite_score: { method: rrf, rrf_k: 60 }`; `weights:` block remains for `method: weighted_mean`.
- `/inbox` dashboard (Phase 12) will expose per-criterion sort controls so a "queries=#1" paper can be surfaced independently of RRF ranking.

No runtime code; implementation lands with S2 Sprint 2 (#13).

## Test plan

- [ ] `pytest -q` → 117 passed (no test changes).
- [ ] Reading `plan_02` §7.4 + ADR 016 cover-to-cover produces no contradiction with §3 "no learning loop en v1".
- [ ] `config/scoring.yaml` has both `composite_score` (default `rrf`) and `weights` (legacy, for `weighted_mean`).

## References

- ADR 016 (this PR)
- plan_02 §7.4 (rewritten)
- [Cormack, Clarke, Büttcher. "Reciprocal rank fusion outperforms Condorcet and individual rank learning methods." SIGIR 2009](https://dl.acm.org/doi/10.1145/1571941.1572114) — RRF's canonical reference