### PR TITLE
docs(s2): ADR 017 — hybrid BM25 + dense retrieval for persistent queries

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -99,6 +99,16 @@ S2_SAFE_DELETE_RATIO=0.10
 # library is ~$1-2.
 S2_MAX_COST_USD_BACKFILL=3.00
 
+# ────────────── S2 Query scoring (ADR 017) ──────────────
+# Weight of BM25 in the convex hybrid with dense embeddings:
+# `score = alpha*BM25 + (1-alpha)*cos`. Useful range: [0.2, 0.6]; the
+# literature default (Pyserini / Elastic / LangChain hybrid) is ~0.4.
+# Short queries benefit from higher alpha (lexical anchors); long
+# conceptual queries benefit from lower alpha (dense dominates). Also
+# settable in config/scoring.yaml as `query_scoring.bm25_weight`; the
+# env var takes priority for per-run experimentation.
+S2_QUERY_BM25_WEIGHT=0.4
+
 # ────────────── S2 PDF fetch cascade ──────────────
 # Ordered, comma-separated list of sources to try when pushing an accepted
 # candidate with a missing PDF. Stops at first success. Remove an entry to

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,23 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **S2 query scoring — ADR 017**: `score_queries` moves from pure
+  dense cosine to a convex hybrid with BM25 — `α·BM25 + (1-α)·cos`,
+  default `α=0.4`. Fixes the known recall gap of dense-only retrieval
+  on short queries (3-7 tokens), which is exactly the shape of the
+  researcher's persistent queries. SQLite FTS5 (built-in since 3.9,
+  2015) backs BM25 — no new dependency. Changes: `plan_02` §7.3
+  rewritten with hybrid formula + FTS5 schema snippet, §5 notes the
+  new `candidate_fts` virtual table in `candidates.db` with sync
+  triggers, §12 adds `S2_QUERY_BM25_WEIGHT` env var, §15 adds SQLite
+  ≥ 3.9 to the dependency list. `config/scoring.yaml` gains a
+  `query_scoring.bm25_weight: 0.4` block. `.env.example` mirrors the
+  env var with guidance on the useful range. `plan_00` §5 decisions
+  table gets rows for ADR 016 (RRF, landing via #43) and ADR 017
+  (this PR). Docs + config only; implementation lands with Sprint 2
+  (#13). Calibration path (grid search over α once ≥100 decisions
+  exist) deferred to a successor ADR, same pattern as ADR 016.
+
 - **Architecture (Fase 1 of ADR 015 — docs alignment)**: rippled the
   S2-owns-embeddings inversion across all the documents that used to
   describe the pre-ADR-015 ownership model.

--- a/config/scoring.yaml
+++ b/config/scoring.yaml
@@ -28,3 +28,11 @@ semantic_scoring:
   # "empty / not empty") covers small libraries where k-NN over a handful
   # of papers would be uninformative noise. See ADR 015 §2.
   min_corpus_size: 50
+
+query_scoring:
+  # Convex hybrid of BM25 (lexical) and dense cosine: α·BM25 + (1-α)·cos.
+  # Default 0.4 per literature standard for short queries (Pyserini /
+  # Elastic / LangChain). Overridable at runtime via S2_QUERY_BM25_WEIGHT.
+  # See ADR 017 for rationale and why pure dense underperforms on
+  # ≤5-token queries.
+  bm25_weight: 0.4

--- a/docs/decisions/017-hybrid-query-retrieval.md
+++ b/docs/decisions/017-hybrid-query-retrieval.md
@@ -1,0 +1,120 @@
+# ADR 017 — Hybrid retrieval (BM25 + dense) for S2 persistent queries
+
+**Status**: Accepted
+**Date**: 2026-04-23
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+S2's `score_queries` (plan_02 §7.3) evaluates every incoming candidate against the user's active `PersistentQuery` list. The original spec defined this as a pure dense similarity: `cos(embedding(query), embedding(candidate.abstract))`, max-pooled across queries.
+
+Two empirical problems with pure-dense retrieval at this scale:
+
+1. **Short queries are where dense embeddings underperform.** The researcher's persistent queries are typically 3-7 tokens (*"fiscal multipliers in emerging markets"*, *"informalidad laboral Argentina"*, *"political economy of inflation"*). A well-documented behaviour of dense retrievers on short queries is that the embedding collapses to a generic topical centroid and loses the discriminative power of exact terms. BM25, by contrast, rewards exact / near-exact term matches — precisely the signal a short query carries. Combining the two covers both regimes.
+
+2. **Lexical anchors that matter.** Queries with proper nouns or rare technical terms (*"Argentina 2001 crisis"*, *"Calvo pricing"*, *"Kaldor facts"*) need the retrieval to honour the exact term, not paraphrase it. Pure dense ranks "Mexico 1995 crisis" similarly to "Argentina 2001 crisis" for a query about "Argentina 2001" — close topically but wrong. BM25 anchors on the exact term and disambiguates.
+
+This is not a novel problem. Hybrid retrieval (BM25 + dense, fused) is the de facto industry default now: Pyserini (Castor Lab, UWaterloo), Elastic's `rrf` and `rank_feature` queries, Vespa's hybrid ranker, LangChain's `EnsembleRetriever`, Weaviate's hybrid mode, and OpenAI's own retrieval benchmarks all ship with hybrid as the recommended configuration. The improvement over pure dense is measured at 5-15 recall points depending on corpus and query distribution.
+
+The question is *whether to adopt it for our specific case*, and *how to do it given our existing stack*.
+
+## Decision
+
+**`score_queries` computes a convex combination of BM25 (lexical) and dense cosine (semantic) per query, with `α = 0.4` as default**, and aggregates across queries with `max × PersistentQuery.weight`. SQLite's built-in FTS5 virtual table backs BM25; no new dependency.
+
+Formally, for candidate `c` and query `q`:
+
+$$
+S_{\text{query}}(c, q) = \alpha \cdot S_{\text{BM25}}(c, q) + (1 - \alpha) \cdot \cos(\vec{e}_q, \vec{e}_c)
+$$
+
+with `α = query_scoring.bm25_weight` (default `0.4`, overridable via `S2_QUERY_BM25_WEIGHT`). The BM25 component is normalised to `[0, 1]` with min-max over the batch; the cosine is normalised from `[-1, 1]` to `[0, 1]` with `(cos + 1) / 2`.
+
+Aggregation across multiple queries stays as the spec originally required: `max(S_query(c, q) × q.weight)` over active queries. Per-query weight stays in `PersistentQuery.weight` for users who want a topic to count more than others; default is `1.0`.
+
+### Implementation artefacts
+
+1. **`candidates.db` schema**. Add an FTS5 virtual table mirroring `Candidate`:
+
+   ```sql
+   CREATE VIRTUAL TABLE candidate_fts USING fts5(
+       id UNINDEXED,
+       title,
+       abstract,
+       tokenize = 'unicode61 remove_diacritics 2'
+   );
+   -- plus INSERT/UPDATE/DELETE triggers on Candidate to keep fts in sync.
+   ```
+
+   `remove_diacritics 2` ensures that "política" matches "politica" — critical for a Spanish-dominant corpus with inconsistent accent handling.
+
+2. **Query embedding cache**. `embedding(q)` is expensive (OpenAI call, ~$0.0001 per query). Cache per `PersistentQuery.id`, invalidate when `q.query_text` changes. Avoids re-embedding the same query every cycle.
+
+3. **Config surface**. `config/scoring.yaml` gains a `query_scoring:` block with `bm25_weight: 0.4`. `.env.example` exposes `S2_QUERY_BM25_WEIGHT` for per-run override (env takes priority over YAML).
+
+### Calibration path
+
+Same pattern as ADR 016 for the composite score: `α = 0.4` is a literature default, not a calibrated value. Once the `candidates.db` accumulates ≥100 triage decisions per query, a successor ADR can grid-search `α ∈ {0.2, 0.3, 0.4, 0.5, 0.6}` against observed precision and pick the point that maximises it. Until then, 0.4 is the universally-defensible default.
+
+## Consequences
+
+### Positive
+
+- **Recall on short queries.** The literature gap (5-15 recall points on short / lexical-anchor queries) is the single biggest gain available to S2 scoring at this stage. For a researcher whose persistent queries are typically 3-7 tokens and frequently include proper nouns (country names, event years, author surnames), hybrid is strictly better than dense alone.
+- **Zero new dependency.** SQLite 3.9+ (2015) has FTS5 built-in. The CPython 3.11 bundled sqlite is at least 3.40, so every target platform already has it. Nothing to `uv add`, nothing to document as "install separately".
+- **Cheap compute.** FTS5 BM25 is ~μs per query per document on SQLite, vs ~ms for a network-round-tripped embedding. The BM25 side effectively free; the dense side is the existing embedding cost.
+- **Diacritic-insensitive.** `remove_diacritics 2` is a free perk for Spanish. Queries like "politica fiscal" match "política fiscal" in stored abstracts and vice versa — no manual normalisation.
+- **Same aggregation as before.** The `max` over active queries + per-query `weight` stays intact. Existing spec semantics are preserved; only the per-query score is upgraded.
+- **Composable with ADR 016 RRF.** `score_queries` is one of the three criteria RRF ranks. Upgrading `score_queries` to be better-calibrated benefits RRF's fusion directly. No interaction risk — the two ADRs are orthogonal.
+
+### Negative
+
+- **BM25 needs a tokenizer choice.** `unicode61 remove_diacritics 2` is sensible for es/en mixed corpora but suboptimal for other languages (CJK in particular). Out of scope for v1 — the researcher's corpus is es/en. Documented as a future-ADR trigger if the language mix changes.
+- **FTS5 table is extra storage.** The virtual table roughly doubles the storage of the `title + abstract` columns. For a 1500-paper library that's a few MB — negligible.
+- **Two normalisations to reason about.** BM25 and cosine have different scales; the `[0, 1]` normalisation (min-max for BM25, affine for cosine) is standard but adds a small reasoning surface. The config surface keeps them opaque behind one `bm25_weight` knob.
+- **α is still a knob.** We traded "no learning loop" (ADR 016) for "one knob that defaults to 0.4". That knob has a defensible default from the literature, but it *is* a knob that will eventually want calibration. Same path as ADR 016's successor.
+
+### Neutral
+
+- **Doesn't affect `score_tags` or `score_semantic`.** Only `score_queries` changes. The three-criterion decomposition in plan_02 §7 stays.
+- **Reversible.** Setting `query_scoring.bm25_weight: 0.0` recovers pure dense behaviour. Setting `1.0` recovers pure BM25. A/B testing post-calibration is trivial.
+
+## Alternatives considered
+
+**A. Keep pure dense retrieval (the status quo spec).**
+Rejected. 5-15 recall points on the shape of queries the researcher actually writes is a large, known-fix gap. Leaving it on the table to "simplify" is penny-wise, pound-foolish — the first quarter of S2 in production would show the gap immediately.
+
+**B. Pure BM25.**
+Rejected. Pure lexical loses paraphrase matching entirely: "fiscal stimulus" in a query would miss a paper abstract that only uses "government spending multiplier". Dense catches those; hybrid catches both.
+
+**C. Per-query α.**
+Rejected. Different queries might benefit from different α (a query with rare proper nouns wants higher α; a long conceptual query wants lower α). Technically sound but adds a per-query config field that most users won't set. Keep global α for v1; revisit if per-query sees real demand.
+
+**D. RRF instead of convex combination, for this layer too.**
+Considered. RRF fuses ranked lists; here we have exactly two rankers, and a scalar α knob is more natural for fine-tuning on one slider. RRF would also introduce a second `k` constant (60 for composite_score per ADR 016, a separate k here). Convex combination is simpler at the per-query layer and consistent with the broader hybrid-retrieval literature (RRF is typically the *meta-fusion* across *different retrieval strategies*; a single BM25+dense hybrid is usually done with convex combination or tuned weights).
+
+**E. Elasticsearch / OpenSearch as the retrieval backend.**
+Rejected. A heavy extra service for a use case SQLite FTS5 handles natively at our scale (1500 papers, a handful of queries per cycle). ADR 002 picked SQLite as state store precisely to avoid this kind of creep; same argument applies here.
+
+**F. Weaviate / Qdrant for hybrid in one system.**
+Rejected. Same reason as E plus: we already committed to ChromaDB for semantic (ADR 015), and adding another vector store for queries would split responsibility weirdly. SQLite FTS5 + existing ChromaDB is the least new infrastructure.
+
+**G. OpenAI Embeddings with larger context for the query.**
+Rejected — wrong axis. The problem isn't that the query is *too short to embed*; OpenAI embeds short queries fine. The problem is that *dense similarity* of short-query embeddings against long-document embeddings systematically underweights exact-term matches. Bigger context on the query doesn't help. Hybrid does.
+
+## References
+
+- `docs/plan_02_subsystem2.md` §7.3 — rewritten to use hybrid retrieval
+- `docs/plan_02_subsystem2.md` §5 — note added about the FTS5 virtual table in `candidates.db`
+- `docs/plan_02_subsystem2.md` §12 — new env var `S2_QUERY_BM25_WEIGHT`
+- `docs/plan_02_subsystem2.md` §15 — SQLite ≥ 3.9 with FTS5 as a dependency
+- `docs/decisions/016-rrf-composite-score.md` — the sibling ADR; this one upgrades `score_queries`, that one fuses the three criteria
+- `config/scoring.yaml` — `query_scoring.bm25_weight`
+- SQLite documentation: [FTS5 extension](https://www.sqlite.org/fts5.html). BM25 is the default ranking function (§7).
+- Karpukhin et al. "Dense Passage Retrieval" (EMNLP 2020) — the canonical paper establishing dense retrieval's strengths on longer queries and weaknesses on short ones.
+- [Gao, Xiong. "Complementing Lexical Retrieval with Semantic Residual Embedding" (ECIR 2021)](https://arxiv.org/abs/2004.13969) — documents the recall gap we close here.
+- Castorini / Pyserini default configurations for hybrid retrieval (α ≈ 0.4 across TREC collections).

--- a/docs/plan_00_overview.md
+++ b/docs/plan_00_overview.md
@@ -89,6 +89,8 @@ Cada una con ADR correspondiente en `docs/decisions/`.
 | 013 | Bridge networking + `host.docker.internal` en lugar de `network_mode: host` | `network_mode: host` no funciona en Docker Desktop Mac/Win; bridge + `extra_hosts: host-gateway` es uniforme cross-platform. |
 | 014 | Stage 03 dedup: skip attach si el item existente ya tiene PDF | Respeta estado curado del usuario; agrega valor cuando solo había metadata sin PDF. |
 | 015 | **S2 es owner del índice de embeddings; S3 es lector puro** | Invierte ADR 006/009 parcialmente. Elimina trigger externo (cron / on-use) y la ventana de staleness. S2 mantiene el invariante via reconciliación por diff en cada ciclo del worker. Ver ADR 015. |
+| 016 | Reciprocal Rank Fusion default para `score_composite` de S2 | Promedio ponderado con pesos arbitrarios entierra señales ortogonales (ej. `queries=0.9, tags=0.1, semantic=0.1`). RRF (k=60) es rank-based, sin pesos pre-datos, favorece rank-alto en cualquier criterio. Weighted-mean queda como opt-in. |
+| 017 | Hybrid retrieval (BM25 + dense) para `score_queries` de S2 | Queries persistentes son cortas (3-7 tokens); dense puro underperforma por 5-15 recall points. SQLite FTS5 built-in provee BM25 sin nueva dep. α=0.4 literatura default; calibrar con ADR sucesor post-datos. |
 
 ---
 

--- a/docs/plan_02_subsystem2.md
+++ b/docs/plan_02_subsystem2.md
@@ -165,6 +165,15 @@ mantenimiento del invariante vive en
 `src/zotai/s2/indexing.py` (módulo dedicado, ver §11 Sprint 1) y se
 documenta como contrato de schema en ADR 015 §6.
 
+**Nota — tabla virtual FTS5 para hybrid query scoring** (ADR 017).
+Además de las tablas listadas arriba, `candidates.db` contiene una
+tabla virtual `candidate_fts(id, title, abstract)` construida con
+`fts5(... tokenize='unicode61 remove_diacritics 2')` y mantenida en
+sync vía triggers INSERT/UPDATE/DELETE sobre `Candidate`. Es la que
+responde la mitad BM25 del score híbrido en §7.3. Zero mantenimiento
+del usuario; los triggers se crean junto con el schema al
+`init_s2()`.
+
 ---
 
 ## 6. Sub-módulo: Feed ingestion
@@ -247,10 +256,36 @@ Cada criterio produce un score `[0, 1]`. El score compuesto es combinación pond
 **Input**: candidate, lista de `PersistentQuery`s activas.
 **Output**: `score_queries ∈ [0, 1]`.
 
-**Lógica**:
-1. Para cada query, computar match semántico: embedding(query) · embedding(candidate.abstract).
-2. Score final: `max(similarity_por_query)` o promedio ponderado por query weight.
-3. Si no hay queries activas, score=0.
+**Método: hybrid retrieval (BM25 + dense) por query** (ver ADR 017). Las queries persistentes suelen ser frases cortas (*"fiscal multipliers in emerging markets"*, *"informalidad laboral Argentina"*); en queries de ≤5 tokens la similitud puramente densa degrada — es un problema conocido de retrieval. La fusión convex de BM25 (lexical, exact-match friendly) + dense (semántico, paráfrasis friendly) mejora recall dramáticamente. SQLite tiene FTS5 built-in, así que no hace falta nueva dep.
+
+**Lógica** (para cada query activa `q` → candidate `c`):
+
+1. **BM25**: `SBM25(c, q) = bm25(candidate_fts, q)` sobre una tabla virtual `candidate_fts(id, title, abstract)` en `candidates.db` (FTS5). Normalizar a `[0,1]` con min-max sobre el batch del ciclo.
+2. **Dense**: `Sdense(c, q) = cos(embedding(q), embedding(c.abstract))`. `embedding(q)` se cachea por query para no re-embebera en cada ciclo. Normalizar el coseno de `[-1, 1]` a `[0, 1]` con `(cos + 1) / 2`.
+3. **Fusión**: `Squery(c, q) = α · SBM25 + (1 − α) · Sdense`, con `α = query_scoring.bm25_weight` (default 0.4, configurable en `config/scoring.yaml` y anulable per-run con `S2_QUERY_BM25_WEIGHT`).
+4. **Agregación sobre múltiples queries**: `score_queries(c) = max(Squery(c, q) por query q activa) * PersistentQuery.weight_q` con default `weight_q=1.0`. El `max` preserva la semántica "basta con matchear *una* query para ser relevante" que el spec original ya preveía.
+5. **Si no hay queries activas**: `score_queries = 0`.
+
+**Calibración de α**. La literatura (Pyserini, Elastic hybrid, LangChain EnsembleRetriever) sugiere `α ∈ [0.3, 0.5]` como punto de partida; 0.4 es razonable pre-datos. Igual que RRF (ADR 016), calibrar α con regresión logística queda para un ADR sucesor una vez que `candidates.db` acumule ≥100 decisiones con breakdowns por componente.
+
+**FTS5 setup** (detalle de implementación, se persiste en `candidates.db`):
+
+```sql
+CREATE VIRTUAL TABLE candidate_fts USING fts5(
+    id UNINDEXED,
+    title,
+    abstract,
+    tokenize = 'unicode61 remove_diacritics 2'  -- útil para español
+);
+
+-- Triggers para mantenerla sincronizada con la tabla Candidate.
+CREATE TRIGGER candidate_fts_insert AFTER INSERT ON candidate BEGIN
+    INSERT INTO candidate_fts(id, title, abstract) VALUES (new.id, new.title, new.abstract);
+END;
+-- (update + delete triggers análogos).
+```
+
+`remove_diacritics 2` hace que "política" matchee "politica" — útil para corpus mixto es/en donde los acentos son inconsistentes.
 
 ### 7.4 Score compuesto
 
@@ -495,6 +530,13 @@ S2_SAFE_DELETE_RATIO=0.10
 # del cap diario/mensual del worker.
 S2_MAX_COST_USD_BACKFILL=3.00
 
+# ──────────── S2 Query scoring (ADR 017) ────────────
+# Peso de BM25 en la fusión convex con dense: α·BM25 + (1−α)·cos. Default 0.4
+# (punto estándar de la literatura para queries cortas). También configurable
+# en config/scoring.yaml como `query_scoring.bm25_weight`; esta env var tiene
+# prioridad para experimentación per-run. Rango útil: [0.2, 0.6].
+S2_QUERY_BM25_WEIGHT=0.4
+
 # ──────────── S2 PDF fetch cascade ────────────
 S2_PDF_SOURCES=openaccess,doi,annas,libgen,scihub,rss
 S2_PDF_FETCH_MAX_ATTEMPTS_PER_CANDIDATE=6
@@ -550,3 +592,4 @@ Cada una es un ticket para v1.1+.
 - **Worker y dashboard corriendo**: por default APScheduler in-process en el mismo container del dashboard (ADR 012). Usuarios que no mantienen el dashboard 24/7 pueden setear `S2_WORKER_DISABLED=true` y usar cron / Task Scheduler externos invocando `zotai s2 fetch-once` (receta en `docs/setup-{linux,windows}.md`); el `fetch-once` ejecuta el reconcile como paso 0 igual que el worker, así que el invariante de ChromaDB se mantiene en ambos paths.
 - **`pdfplumber`**: ya es dependencia de S1 (Etapa 01); S2 la reusa para extraer fulltext de los PDFs adjuntos a los items de Zotero al momento de embebera (ADR 015 §3.2 / §6).
 - **Schema de `zotero-mcp`**: S2 escribe a una ChromaDB que `zotero-mcp serve` (host) lee. La compatibilidad de schema fue validada empíricamente (Fase 2 del plan de implementación de ADR 015) y se documenta como contrato en ADR 015 §6. Cualquier upgrade futuro de `zotero-mcp` debe re-validarse.
+- **SQLite ≥ 3.9 con FTS5** (ADR 017): las queries persistentes usan una tabla virtual FTS5 `candidate_fts` en `candidates.db` para el score BM25. SQLite 3.9 liberó FTS5 en 2015; cualquier Python 3.11 trae uno muy superior, así que no hay acción requerida del usuario — se documenta solo para cubrir el caso "builds exotics de SQLite sin soporte FTS5".

--- a/docs/plan_glossary.md
+++ b/docs/plan_glossary.md
@@ -47,7 +47,13 @@ Las cinco sub-etapas de enrichment: 04a (identifiers), 04b (OpenAlex), 04c (Sema
 Proceso scheduled que corre cada N horas, fetcheando feeds y procesando candidates. Vive en el mismo container que el dashboard pero es un proceso separado (APScheduler).
 
 **Scoring** (S2)
-Cálculo de tres sub-scores (`tags`, `semantic`, `queries`) y su combinación ponderada en `score_composite`.
+Cálculo de tres sub-scores (`tags`, `semantic`, `queries`) y su combinación en `score_composite`. Bajo ADR 016 la combinación default es Reciprocal Rank Fusion (no promedio ponderado); bajo ADR 017 el sub-score `queries` es a su vez un hybrid de BM25 (SQLite FTS5, lexical) + dense cosine.
+
+**Hybrid retrieval** (S2)
+Combinación convex de BM25 lexical + dense semántico para queries persistentes cortas: `α·BM25 + (1-α)·cos`, default `α=0.4`. BM25 corre sobre una tabla virtual FTS5 `candidate_fts` en `candidates.db`; el componente dense reusa los embeddings de ChromaDB. Cierra el gap de recall de ~5-15 puntos que tiene dense-only en queries de 3-7 tokens. Ver ADR 017.
+
+**Reciprocal Rank Fusion (RRF)** (S2)
+Método default para `score_composite`: `sum(1/(k+rank_c(d)))` sobre los tres criterios (tags / semantic / queries), con k=60. Robusto a distribuciones distintas por criterio, sin pesos pre-datos, favorece candidates que rankean alto en cualquier criterio individual. Ver ADR 016.
 
 **State DB / state.db** (S1)
 SQLite con el estado del pipeline S1. Ubicación: `/workspace/state.db` dentro del container.


### PR DESCRIPTION
## Summary

Second of the two scoring ADRs. Upgrades `score_queries` from pure dense cosine to a convex hybrid `α·BM25 + (1-α)·cos`, default `α=0.4`. Fixes the known 5-15 recall-point gap that pure dense retrieval has on short queries (3-7 tokens — exactly the shape of the researcher's persistent queries).

SQLite has FTS5 built-in since 3.9 (2015), so BM25 is a `CREATE VIRTUAL TABLE` away. No new dependency. Dense keeps using the ChromaDB embeddings that ADR 015 has S2 owning. `unicode61 remove_diacritics 2` tokenizer handles the es/en mixed corpus ("política" ↔ "politica" match).

**Changes:**
- New `docs/decisions/017-hybrid-query-retrieval.md` with full rationale + seven alternatives considered (pure BM25, pure dense, per-query α, RRF at this layer, Elasticsearch, Weaviate, wider query context).
- `plan_02` §7.3 rewritten (hybrid formula + FTS5 schema + trigger snippet + calibration path), §5 notes the `candidate_fts` virtual table, §12 adds `S2_QUERY_BM25_WEIGHT`, §15 adds SQLite ≥ 3.9 to deps.
- `config/scoring.yaml` gains `query_scoring.bm25_weight: 0.4`.
- `.env.example` mirrors the env var with guidance on the useful range `[0.2, 0.6]`.
- `plan_00` §5 decisions table: rows for ADR 016 (RRF, coming via #43) and ADR 017 (this PR).
- `plan_glossary.md` adds "Hybrid retrieval" + "Reciprocal Rank Fusion" entries, amends "Scoring".

No runtime code; implementation lands with S2 Sprint 2 (#13).

## Interaction with PR #43

Both PRs add rows to the `plan_00` §5 decisions table and both touch `config/scoring.yaml`. I added the ADR 016 row here so the table reads coherently once #43 lands, even if #43 doesn't get a chance to add it itself. **If #43 merges first**, this PR will need a small rebase on the table row for 016 (trivial — keep one of the two identical rows). **If this merges first**, #43 has no work (its scoring.yaml edit doesn't conflict; its table edit doesn't exist).

## Test plan

- [ ] `pytest -q` → 117 passed (no test changes).
- [ ] Reading `plan_02` §7.3 + ADR 017 cover-to-cover produces no contradiction with §3 "no learning loop en v1" — calibration of α is explicitly deferred, same pattern as ADR 016.
- [ ] `config/scoring.yaml` parses (YAML syntax check when the worker runs in Phase 11).

## References

- ADR 017 (this PR)
- ADR 016 (#43) — sibling, upgrades the composite score with RRF
- plan_02 §7.3 (rewritten)
- [SQLite FTS5 documentation](https://www.sqlite.org/fts5.html)
- [Gao, Xiong 2021 — "Complementing Lexical Retrieval with Semantic Residual Embedding"](https://arxiv.org/abs/2004.13969)