### PR TITLE
docs: LATAM corpus realism (plan_01) + S2 PDF cascade robustness (plan_02 §10)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -123,6 +123,12 @@ S2_PDF_FETCH_TIMEOUT_SECONDS=30
 # burning the worker's time. On exceed, remaining candidates are tagged
 # needs-pdf and surfaced in the dashboard for manual retry.
 S2_PDF_FETCH_MAX_MINUTES_WEEKLY=20
+# Circuit breaker: after this many consecutive failures from a single
+# source during one fetch cycle, skip that source for the rest of the
+# cycle. Protects the weekly budget from being drained by a mirror
+# that's fully down. Set to 0 to disable (not recommended for
+# adversarial mirrors like Sci-Hub / LibGen). See plan_02 §10.4.
+S2_PDF_FETCH_CIRCUIT_BREAKER_THRESHOLD=5
 
 # ────────────── S2 Dashboard ──────────────
 S2_DASHBOARD_HOST=127.0.0.1

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,35 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Changed
 
+- **Corpus LATAM reality check** (plan_01): §3 Etapa 03 and §3 Etapa 04
+  acknowledge explicitly that the "50-60% Ruta A" estimate assumes an
+  anglo-dominant corpus. For LATAM-heavy corpora (CEPAL Review, Desarrollo
+  Económico, Estudios Económicos, BID / CAF / BCRA papers, SciELO /
+  RedALyC journals), OpenAlex and Semantic Scholar coverage drops to
+  20-50% per journal, and the realistic split is closer to Ruta A 30-40% /
+  Ruta C 60-70%. Etapa 04 budget guidance updated: users with
+  LATAM-heavy corpora should bump `MAX_COST_USD_STAGE_04` from 2.00 to
+  ~4.00 before their first run. Quarantine success criterion amended:
+  <10% for anglo-dominant, <25% for LATAM-heavy, until the v1.1
+  extension with LATAM-specific metadata sources (REDIB / SciELO /
+  La Referencia / RedALyC) lands per the tracking issue. No code
+  changes — this is a realism adjustment to the spec.
+- **S2 PDF fetch cascade robustness** (plan_02 §10): two new subsections
+  added to the push flow to harden Sci-Hub / LibGen / Anna's Archive
+  against the operational reality that mirrors rotate domains, serve
+  HTML-of-error with 200 OK, and occasionally show CAPTCHA.
+  - **§10.3 Verificación post-descarga**: every source must deliver a
+    file that passes 4 checks in order — `Content-Type` starts with
+    `application/pdf`, magic bytes `%PDF-`, size ≥ 50 KB,
+    `pdfplumber.open()` parses without exception. Fail any → treat as
+    miss, try next source.
+  - **§10.4 Circuit breaker por fuente**: in-memory consecutive-failure
+    counter per source within one `run_fetch_cycle()`; 5 failures in a
+    row → skip that source for the rest of the cycle. Configurable via
+    `S2_PDF_FETCH_CIRCUIT_BREAKER_THRESHOLD=5` (default). Protects the
+    weekly wall-clock budget from being drained by a fully-down mirror.
+  `.env.example` and `plan_02` §12 reflect the new env var. Docs only;
+  implementation lands with Sprint 2 (#13).
 - **S2 query scoring — ADR 017**: `score_queries` moves from pure
   dense cosine to a convex hybrid with BM25 — `α·BM25 + (1-α)·cos`,
   default `α=0.4`. Fixes the known recall gap of dense-only retrieval

--- a/docs/plan_01_subsystem1.md
+++ b/docs/plan_01_subsystem1.md
@@ -178,6 +178,20 @@ zotai s1 ocr [--force-ocr] [--parallel N]
 - Ruta A: 50-60% del corpus (items con DOI detectado y translator exitoso).
 - Ruta C: 40-50% del corpus (items sin DOI + items donde A falló). Todos pasan por Etapa 04. La cascada 04a-d apunta a recuperar metadata en ≥80% de estos antes de mandar el resto a cuarentena en 04e.
 
+**Aviso — corpus LATAM-heavy**. Los números anteriores asumen corpus
+anglo-dominante (revistas indexadas en CrossRef / PMC / arXiv). Para
+corpus heavy en publicaciones latinoamericanas (CEPAL Review,
+Desarrollo Económico, Estudios Económicos, papers BID / CAF / BCRA,
+journals de SciELO y RedALyC), la cobertura de OpenAlex / Semantic
+Scholar cae notablemente — entre 20% y 50% según el journal. El split
+realista para el usuario-target del proyecto (investigador CONICET,
+foco LATAM) es más cerca de **Ruta A 30-40% / Ruta C 60-70%**. Eso
+empuja más items a la cascada de Etapa 04, y en particular a 04d
+(LLM), subiendo el costo. Ver §3 Etapa 04 "Aviso — corpus LATAM-heavy"
+para el ajuste de budget, y la issue tracker para la extensión con
+fuentes LATAM (REDIB, SciELO, La Referencia, RedALyC) que está
+planificada fuera del scope v1.
+
 **Criterio de éxito etapa 03**: 100% de items tienen `zotero_item_key`. Distribución de `import_route` razonable.
 
 **CLI**:
@@ -245,14 +259,16 @@ Do NOT invent information.
 
 **Presupuesto por sub-etapa**:
 - 04a-c: $0 (APIs gratuitas, solo rate limits).
-- 04d: max $2 configurable. Si excede, pausar y pedir confirmación.
+- 04d: max $2 configurable (`MAX_COST_USD_STAGE_04`, default 2.00). Si excede, pausar y pedir confirmación.
+
+**Aviso — corpus LATAM-heavy**. El default de $2 asume que la cascada 04a-c (gratis) resuelve 80%+ de los Ruta C. Para corpus LATAM-heavy (ver §3 Etapa 03 "Aviso — corpus LATAM-heavy"), la cobertura de OpenAlex y Semantic Scholar cae y una fracción mayor del corpus llega a 04d. Estimación pesimista: 40% del corpus (≈400 items sobre 1000) × $0.0004 / item = ~$1.60, todavía dentro de $2. Pero con ruido de retries malformados y papers largos puede exceder. **Recomendación para usuarios LATAM-heavy**: setear `MAX_COST_USD_STAGE_04=4.00` en `.env` antes de correr la etapa, y observar el costo real en el reporte de Etapa 06 para ajustar en corridas futuras. El cap duro sigue obligando a confirmación explícita antes de gastar extra.
 
 **Edge cases**:
 - API down (OpenAlex, Semantic Scholar): retry con backoff; tras 3 fallos, saltar item y continuar.
 - Título extraído es genérico ("Chapter 1", "Introduction"): detectable por longitud <5 palabras o coincidencia con blacklist. Saltar a siguiente sub-etapa directamente.
 - LLM retorna JSON malformado: reintentar 1 vez con mensaje corregir. Si falla, cuarentena.
 
-**Criterio de éxito etapa 04**: <10% del corpus original en cuarentena.
+**Criterio de éxito etapa 04**: <10% del corpus original en cuarentena para corpus anglo-dominante; **<25% para corpus LATAM-heavy** hasta que el scope v1.1 agregue fuentes específicas (REDIB / SciELO / La Referencia / RedALyC). Etapa 06 Validation reporta el % real y permite al usuario decidir si (a) el corpus justifica priorizar la issue de fuentes LATAM o (b) el % está dentro de lo aceptable para este investigador.
 
 **CLI**:
 ```bash

--- a/docs/plan_02_subsystem2.md
+++ b/docs/plan_02_subsystem2.md
@@ -456,6 +456,25 @@ Se dispara cuando un candidate se marca `accepted`.
 
 **Nota — el push no escribe a ChromaDB directamente**. La escritura a ChromaDB ocurre en el siguiente ciclo de reconciliación del worker (paso 0 del diagrama §4 / pseudocódigo §9), que detecta el nuevo item en Zotero y lo embebe. Esto mantiene un único path de escritura a ChromaDB, simple de testear y auditar (ver ADR 015). El precio: hay una ventana de hasta `S2_FETCH_INTERVAL_HOURS` entre el push y la disponibilidad del item en queries semánticas — aceptable para el flujo de S3 (Claude Desktop), donde el usuario raramente consulta sobre papers que aceptó hace minutos.
 
+### 10.3 Verificación post-descarga (toda fuente)
+
+Anna's Archive, LibGen y Sci-Hub son mirrors rotatorios: dominios que cambian, captchas esporádicos, y con frecuencia devuelven HTML de error con `status=200` (página de captcha, "Try later", landing page del mirror). Confiar en el status code es insuficiente. Cada fuente — incluso las "seguras" como OpenAlex OA URL y el resolver de DOI — debe entregar un archivo que pasa los **4 chequeos en orden**; falla cualquiera → tratar como miss y probar la siguiente fuente:
+
+1. **Content-Type** (del response header): debe empezar con `application/pdf`. Filtra HTML de error / landing pages.
+2. **Magic bytes**: los primeros 4 bytes del archivo son exactamente `%PDF-`. Filtra archivos binarios que no son PDF pero salen con MIME correcto (raro pero ha pasado con mirrors adversariales).
+3. **Tamaño ≥ 50 KB**. Filtra stubs / placeholders que algunos proxies devuelven cuando el upstream no tiene el paper.
+4. **`pdfplumber.open()` parsea sin excepción**. Filtra PDFs corruptos, truncados, o encriptados sin password.
+
+Si los 4 pasan, el PDF se considera válido y se adjunta. Si alguno falla, se loguea con la razón (`content_type_mismatch`, `magic_mismatch`, `too_small`, `parse_failed`) y se continúa a la siguiente fuente.
+
+### 10.4 Circuit breaker por fuente
+
+Mirrors fuera de servicio o saturados pueden tragarse todo el budget wall-clock del ciclo (`S2_PDF_FETCH_MAX_MINUTES_WEEKLY`) antes de rendirse. Para acotar el daño: **contador in-memory por fuente dentro del `run_fetch_cycle()`**. Cada falla (timeout, HTTP error ≠ 2xx, verificación §10.3 fallida) incrementa el contador de esa fuente. Al alcanzar **5 fallas consecutivas** en la misma sesión → saltar esa fuente para el resto del ciclo y loguear `s2.pdf_cascade.source_circuit_open { source, consecutive_failures }`. El contador se resetea al próximo ciclo del worker.
+
+**Configurable**: `S2_PDF_FETCH_CIRCUIT_BREAKER_THRESHOLD=5` (default). Setearlo a `0` desactiva el circuit breaker (útil si una fuente rota intermitentemente y querés que igual lo intente cada vez; no recomendado para Sci-Hub / LibGen).
+
+**Por qué consecutivas y no "5 fallas en la sesión"**: una fuente que falla una vez cada 20 intentos (5% fallo) sigue siendo útil; una fuente que falla 5 seguidas probablemente está caída completa. El circuit breaker mide el modo "caída completa" sin castigar la intermitencia normal.
+
 ---
 
 ## 11. Roadmap por sprints
@@ -557,6 +576,9 @@ S2_PDF_SOURCES=openaccess,doi,annas,libgen,scihub,rss
 S2_PDF_FETCH_MAX_ATTEMPTS_PER_CANDIDATE=6
 S2_PDF_FETCH_TIMEOUT_SECONDS=30
 S2_PDF_FETCH_MAX_MINUTES_WEEKLY=20
+# Circuit breaker: skip a source for the rest of the cycle after this
+# many consecutive failures. Setear a 0 desactiva el breaker. Ver §10.4.
+S2_PDF_FETCH_CIRCUIT_BREAKER_THRESHOLD=5
 
 # ──────────── S2 Dashboard ────────────
 S2_DASHBOARD_HOST=127.0.0.1


### PR DESCRIPTION
## Summary

Two small alignment changes addressing critiques 3.5 and 3.8 from the earlier spec review. Both are spec adjustments, no code.

### LATAM corpus realism (plan_01 §3 Etapa 03 + 04)

The "50-60% Ruta A" estimate assumes anglo-dominant corpus. Actual user profile (CONICET researcher, LATAM focus) has corpus where CEPAL Review / Desarrollo Económico / BID / CAF / SciELO / RedALyC sit at 20-50% OpenAlex coverage per journal, not >98%.

- §3 Etapa 03 — "Aviso — corpus LATAM-heavy" box with realistic split 30-40% / 60-70%.
- §3 Etapa 04 — matching box recommending bump `MAX_COST_USD_STAGE_04=4.00` for LATAM-heavy, cap observation in Etapa 06 for recalibration.
- Quarantine criterion split: <10% anglo-dominant, <25% LATAM-heavy until v1.1 LATAM sources extension lands.

### PDF cascade robustness (plan_02 §10)

Anna's / LibGen / Sci-Hub rotate domains, serve HTML-of-error at 200 OK, and have variable uptime. Two new subsections:

- **§10.3 Verificación post-descarga** — 4-check gate (Content-Type, magic bytes, size, pdfplumber parse).
- **§10.4 Circuit breaker por fuente** — 5 consecutive failures → skip source for rest of cycle; configurable `S2_PDF_FETCH_CIRCUIT_BREAKER_THRESHOLD=5`.

`.env.example` + plan_02 §12 mirror the new env var.

## Test plan

- [ ] `pytest -q` → 117 passed (no test changes).
- [ ] `plan_01` §3 Etapa 03 + Etapa 04 read coherently with the anglo / LATAM dual narrative.
- [ ] `plan_02` §10 sections 10.3 + 10.4 specify the runtime checks Sprint 2 (#13) will implement.

## Follow-up issue

Will open a tracking issue after this PR lands: **"Extend Stage 04 enrichment cascade with LATAM-specific metadata sources (REDIB, SciELO, La Referencia, RedALyC)"** — scoped for v1.1, waiting on real corpus data from the first run to prioritize.

## References

- plan_01 §3 Etapa 03, §3 Etapa 04
- plan_02 §10, §12
- Earlier spec review — critiques 3.5 and 3.8