### PR TITLE
test(adr-015): Fase 2 — validation script + user-side checklist for zotero-mcp schema

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -7,6 +7,21 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ## [Unreleased]
 
+### Added
+
+- **ADR 015 Fase 2 validation tooling**:
+  `scripts/validate_chromadb_schema.py` — standalone script that
+  populates a ChromaDB with the schema ADR 015 §6 prescribes (Zotero-
+  style 8-char IDs, real OpenAI `text-embedding-3-large` embeddings,
+  metadata `{title, year, item_type, doi, source, indexed_at,
+  source_subsystem}`). CLI flags: `--path`, `--collection-name`
+  (default `zotero_library`), `--num-items`, `--embedding-model`,
+  `--seed`. Requires `OPENAI_API_KEY` and the `s2` optional
+  dependencies (`chromadb>=0.5`). `docs/decisions/015-validation-checklist.md`
+  — user-side manual checklist for the five-step validation against
+  `zotero-mcp serve` + Claude Desktop that ADR 015 §5 requires before
+  Fase 3 code lands. Bloqueante para Fase 3.
+
 ### Changed
 
 - **Corpus LATAM reality check** (plan_01): §3 Etapa 03 and §3 Etapa 04

--- a/docs/decisions/015-validation-checklist.md
+++ b/docs/decisions/015-validation-checklist.md
@@ -1,0 +1,181 @@
+# ADR 015 — Fase 2 Validation Checklist
+
+**Anexo de**: `docs/decisions/015-s2-owns-embeddings-index.md` (§5).
+**Propósito**: validar empíricamente que `zotero-mcp serve` puede
+leer correctamente una ChromaDB escrita exclusivamente por código
+propio (el script `scripts/validate_chromadb_schema.py` que simula lo
+que S2 producirá en Fase 3), **antes** de implementar el indexador de
+Fase 3.
+
+---
+
+## Pre-requisitos
+
+- Python 3.11+ en el host.
+- Dependencia opcional `s2` instalada: `uv pip install -e '.[s2]'`
+  (trae `chromadb` que el script necesita).
+- `uv tool install "zotero-mcp-server[semantic]"` instalado y
+  configurado — setup interactivo completado al menos una vez
+  (`zotero-mcp setup`).
+- `OPENAI_API_KEY` exportada en la shell.
+- Claude Desktop instalado, con la config `claude_desktop_config.json`
+  apuntando al `zotero-mcp serve` que se va a probar (plan_03 §4.2).
+- Biblioteca Zotero con ≥5 items reales (no hace falta mucho; el
+  script inserta 5 items sintéticos con keys inventadas, pero Claude
+  Desktop espera que la biblioteca esté operativa para invocar las
+  MCP tools).
+
+---
+
+## Procedimiento
+
+### Paso 1 — Backup de la ChromaDB existente
+
+Si ya corriste `zotero-mcp update-db` alguna vez, el path por default
+`~/.config/zotero-mcp/chroma_db/` ya tiene contenido. **Backup primero**:
+
+```bash
+mv ~/.config/zotero-mcp/chroma_db ~/.config/zotero-mcp/chroma_db.bak
+```
+
+Si es la primera vez (no existe el directorio), saltá este paso.
+
+### Paso 2 — Poblar la ChromaDB con el script
+
+```bash
+export OPENAI_API_KEY=sk-...
+python scripts/validate_chromadb_schema.py \
+    --path ~/.config/zotero-mcp/chroma_db \
+    --collection-name zotero_library \
+    --num-items 5
+```
+
+El script imprime un reporte JSON al final con:
+- `path`, `collection_name`, `documents_count`, `embedding_model`,
+  `embedding_dimension`, `document_ids`, `sample_metadata`.
+
+**Verificar**: `embedding_dimension == 3072` (text-embedding-3-large),
+`documents_count == 5`, `sample_metadata` contiene las claves que ADR
+015 §6 prescribe (`title`, `year`, `item_type`, `doi`, `source`,
+`indexed_at`, `source_subsystem`).
+
+### Paso 3 — Arrancar `zotero-mcp serve`
+
+En una terminal aparte, con la misma config que usa Claude Desktop:
+
+```bash
+zotero-mcp serve
+```
+
+Debería arrancar sin errores sobre la ChromaDB recién populada. Si
+imprime algo como `collection not found` o `invalid schema`, documentar
+el error al pie de este archivo y **detener la validación** — el ADR
+015 §5 contempla este caso (reabrir el ADR con addendum).
+
+### Paso 4 — Consultas desde Claude Desktop
+
+Reiniciar Claude Desktop para que levante el MCP server actualizado.
+Verificar que el ícono de tools aparece y que las `zotero_*` tools
+están disponibles.
+
+Luego, probar en un chat:
+
+#### 4.1. `zotero_semantic_search`
+
+Query:
+
+> *"Usá `zotero_semantic_search` para buscar papers sobre 'moneda y
+> política monetaria en América Latina'. Listame los resultados."*
+
+**Esperado**: Claude debería devolver al menos 1-2 items. El más
+relevante es "Monetary policy and inflation expectations: evidence
+from Argentina". Acepta también "Informalidad laboral..." (tangencial
+pero comparte el eje LATAM) y "Fiscal multipliers in emerging
+economies" (tangencial — política económica).
+
+**Criterio de éxito**: los IDs de 8-char que aparecen en los
+resultados coinciden con los que imprimió el script en el Paso 2
+(`document_ids`).
+
+#### 4.2. `zotero_item_details`
+
+Tomar uno de los IDs que devolvió el search anterior y correr:
+
+> *"Usá `zotero_item_details` para el item `{ID}`."*
+
+**Esperado**: metadata completa: `title`, `year`, `item_type`, `doi`,
+y — si `zotero-mcp` tolera el campo extra — también `source`,
+`indexed_at`, `source_subsystem`.
+
+**Criterio de éxito**: ni crash, ni campos faltantes de los que S2
+escribe. Documentar al pie si `zotero-mcp` ignora silenciosamente
+alguno de los campos extra (normalmente está OK — chromadb acepta
+metadata arbitraria; la pregunta es solo si el cliente MCP los
+surface o no).
+
+### Paso 5 — Restaurar backup
+
+Si la validación pasa y querés volver al estado anterior:
+
+```bash
+rm -rf ~/.config/zotero-mcp/chroma_db
+mv ~/.config/zotero-mcp/chroma_db.bak ~/.config/zotero-mcp/chroma_db
+```
+
+Si la ChromaDB sintética te va a quedar como punto de partida
+(válido — el backup no tenía nada), simplemente descartar el `.bak`:
+
+```bash
+rm -rf ~/.config/zotero-mcp/chroma_db.bak
+```
+
+---
+
+## Resultado de la validación
+
+Completar al terminar:
+
+| Campo | Valor |
+|---|---|
+| Fecha de validación | _YYYY-MM-DD_ |
+| Versión de `zotero-mcp` | `zotero-mcp --version` |
+| OS (host) | _Linux / macOS / Windows + versión_ |
+| Paso 2 (script) | ☐ pasa ☐ falla |
+| Paso 3 (`serve`) | ☐ pasa ☐ falla |
+| Paso 4.1 (`semantic_search`) | ☐ pasa ☐ falla |
+| Paso 4.2 (`item_details`) | ☐ pasa ☐ falla |
+| Conclusión general | ☐ OK para Fase 3 ☐ reabrir ADR 015 con addendum |
+
+**Observaciones / issues encontrados** (si los hay):
+
+_Escribir acá._
+
+---
+
+## Qué hacer si falla
+
+Cada fallo implica un addendum a ADR 015 antes de pasar a Fase 3:
+
+- **Paso 2 falla** (script crashea): bug del script. Arreglar y
+  re-correr; no requiere addendum del ADR.
+- **Paso 3 falla** (`zotero-mcp serve` no arranca o se queja del
+  schema): el collection name, el schema, o los campos de metadata
+  no coinciden con lo que `zotero-mcp` espera. **Investigar el source
+  de `zotero-mcp`** (https://github.com/54yyyu/zotero-mcp), ajustar
+  el script + ADR 015 §6, repetir.
+- **Paso 4.1 falla** (`semantic_search` devuelve vacío o IDs que no
+  coinciden): chromadb está escrita pero `zotero-mcp` no usa la
+  collection o usa embeddings distintos. Verificar que el modelo de
+  embeddings configurado en `zotero-mcp setup` coincide con el
+  `--embedding-model` del script (ambos deben ser
+  `text-embedding-3-large` por ADR 004).
+- **Paso 4.2 falla** (crash en `zotero-mcp` al devolver detalles): el
+  server no tolera algún campo de metadata que el script escribe. Si
+  el problema es `source_subsystem` o `source`, evaluar sacarlos del
+  schema (ajustar ADR 015 §6) o verificar si `zotero-mcp` los ignora
+  silenciosamente (en cuyo caso es OK).
+
+**Regla general**: cualquier divergencia entre lo que ADR 015 §6
+prescribe y lo que `zotero-mcp` realmente espera justifica un
+addendum al ADR documentando el ajuste antes de implementar Fase 3.
+No arreglar al vuelo desde la Fase 3.

--- a/scripts/validate_chromadb_schema.py
+++ b/scripts/validate_chromadb_schema.py
@@ -1,0 +1,266 @@
+#!/usr/bin/env python3
+"""Populate a ChromaDB with the schema ADR 015 §6 prescribes and print
+the resulting state for manual validation against `zotero-mcp serve`.
+
+This script is Step 2.1 of the Fase 2 validation required by ADR 015.
+It does NOT run `zotero-mcp serve` itself; that step is manual and is
+tracked in `docs/decisions/015-validation-checklist.md`. What this
+script does is write a ChromaDB that the user can then point
+`zotero-mcp serve` at to verify that the server tolerates the schema
+S2 will produce in Fase 3.
+
+Usage:
+
+    python scripts/validate_chromadb_schema.py [--path DIR] \
+        [--collection-name zotero_library] [--num-items 5]
+
+The default path is a fresh temp directory; pass `--path` to write
+into `~/.config/zotero-mcp/chroma_db/` (after backing that up) and
+then run `zotero-mcp serve` against the same location.
+
+**Requires** `OPENAI_API_KEY` in the environment (real embeddings are
+requested so the store is equivalent to what S2 will produce).
+
+**Collection name assumption.** ADR 015 §6 prescribes `zotero_library`
+as the collection name. This matches `zotero-mcp`'s likely default,
+but the ADR §6 itself flags this as "verificar contra el default de
+zotero-mcp". If the checklist (`docs/decisions/015-validation-checklist.md`)
+finds a different name in a real `zotero-mcp` install, override via
+`--collection-name` and update ADR 015 §6 accordingly.
+"""
+
+from __future__ import annotations
+
+import argparse
+import json
+import os
+import random
+import string
+import sys
+import tempfile
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any
+
+
+# ─── Synthetic items ───────────────────────────────────────────────────────
+
+_SYNTHETIC_ITEMS: list[dict[str, Any]] = [
+    {
+        "title": "Fiscal multipliers in emerging economies",
+        "abstract": (
+            "We estimate the effect of government spending shocks on output "
+            "in a panel of emerging-market economies using local projections "
+            "and quarterly data from 1990-2019."
+        ),
+        "year": 2020,
+        "item_type": "journalArticle",
+        "doi": "10.1111/fake-multipliers-em-2020",
+    },
+    {
+        "title": "Informalidad laboral y productividad en América Latina",
+        "abstract": (
+            "Este trabajo examina la relación entre la tasa de informalidad "
+            "y la productividad total de los factores usando datos de hogares "
+            "de diez países latinoamericanos entre 2000 y 2018."
+        ),
+        "year": 2019,
+        "item_type": "journalArticle",
+        "doi": "10.1111/fake-informalidad-latam-2019",
+    },
+    {
+        "title": "Climate change mitigation in tropical forest economies",
+        "abstract": (
+            "We compare policy instruments — carbon taxes, REDD+ payments, "
+            "and direct land-use regulation — in a small open economy model "
+            "calibrated to three Amazon-basin countries."
+        ),
+        "year": 2022,
+        "item_type": "journalArticle",
+        "doi": "10.1111/fake-climate-tropical-2022",
+    },
+    {
+        "title": "Monetary policy and inflation expectations: evidence from Argentina",
+        "abstract": (
+            "Using high-frequency survey data, we document how households "
+            "update their inflation expectations in response to monetary "
+            "policy announcements in a high-inflation regime."
+        ),
+        "year": 2021,
+        "item_type": "journalArticle",
+        "doi": "10.1111/fake-inflation-argentina-2021",
+    },
+    {
+        "title": "Trade agreements and firm dynamics",
+        "abstract": (
+            "We study how preferential trade agreements affect firm entry, "
+            "exit, and productivity using administrative firm-level data "
+            "from Mexico and Colombia."
+        ),
+        "year": 2018,
+        "item_type": "journalArticle",
+        "doi": "10.1111/fake-trade-firms-2018",
+    },
+]
+
+
+# ─── Zotero-style key generator ────────────────────────────────────────────
+
+
+def _zotero_key(rng: random.Random) -> str:
+    """Generate an 8-char alphanumeric string matching Zotero's item-key shape.
+
+    Zotero keys use uppercase letters and digits in a base-36 encoding of an
+    incremented counter; we just need something shaped the same for a
+    schema compatibility test.
+    """
+    alphabet = string.ascii_uppercase + string.digits
+    return "".join(rng.choice(alphabet) for _ in range(8))
+
+
+# ─── OpenAI embedding ──────────────────────────────────────────────────────
+
+
+def _embed(texts: list[str], *, model: str) -> list[list[float]]:
+    """Call OpenAI's embeddings API and return one vector per input text."""
+    from openai import OpenAI  # local import keeps the script lazy
+
+    client = OpenAI()
+    response = client.embeddings.create(model=model, input=texts)
+    return [item.embedding for item in response.data]
+
+
+# ─── Main ──────────────────────────────────────────────────────────────────
+
+
+def _parse_args(argv: list[str]) -> argparse.Namespace:
+    parser = argparse.ArgumentParser(
+        description="Populate a ChromaDB with ADR 015 §6 schema for Fase 2 validation.",
+    )
+    parser.add_argument(
+        "--path",
+        type=Path,
+        default=None,
+        help="Directory for the ChromaDB PersistentClient. Default: fresh tempdir.",
+    )
+    parser.add_argument(
+        "--collection-name",
+        default="zotero_library",
+        help="Collection name (ADR 015 §6 prescribes `zotero_library`; verify "
+        "against real zotero-mcp and override here if different).",
+    )
+    parser.add_argument(
+        "--num-items",
+        type=int,
+        default=5,
+        help="How many synthetic items to insert (3-5, capped at the built-in "
+        "dataset size).",
+    )
+    parser.add_argument(
+        "--embedding-model",
+        default="text-embedding-3-large",
+        help="OpenAI model (per ADR 004). Default: text-embedding-3-large.",
+    )
+    parser.add_argument(
+        "--seed",
+        type=int,
+        default=0,
+        help="RNG seed for reproducible Zotero keys.",
+    )
+    return parser.parse_args(argv)
+
+
+def main(argv: list[str] | None = None) -> int:
+    args = _parse_args(argv if argv is not None else sys.argv[1:])
+
+    if not os.environ.get("OPENAI_API_KEY"):
+        print(
+            "ERROR: OPENAI_API_KEY not set. Export it before running this "
+            "script; real embeddings are required for the store to be "
+            "equivalent to what S2 will produce.",
+            file=sys.stderr,
+        )
+        return 2
+
+    if args.num_items < 1 or args.num_items > len(_SYNTHETIC_ITEMS):
+        print(
+            f"ERROR: --num-items must be between 1 and {len(_SYNTHETIC_ITEMS)}.",
+            file=sys.stderr,
+        )
+        return 2
+
+    path = args.path
+    owns_tempdir = False
+    if path is None:
+        tmp = tempfile.mkdtemp(prefix="chroma-adr015-")
+        path = Path(tmp)
+        owns_tempdir = True
+    path.mkdir(parents=True, exist_ok=True)
+
+    print(f"[1/5] Opening ChromaDB at {path}")
+    import chromadb  # lazy — optional dep (`pip install 'zotai[s2]'`)
+
+    client = chromadb.PersistentClient(path=str(path))
+
+    print(f"[2/5] Getting-or-creating collection: {args.collection_name!r}")
+    collection = client.get_or_create_collection(name=args.collection_name)
+
+    rng = random.Random(args.seed)
+    items = _SYNTHETIC_ITEMS[: args.num_items]
+    keys = [_zotero_key(rng) for _ in items]
+
+    print(f"[3/5] Embedding {len(items)} texts with {args.embedding_model}")
+    texts = [f"{item['title']}. {item['abstract']}" for item in items]
+    embeddings = _embed(texts, model=args.embedding_model)
+
+    now_iso = datetime.now(tz=UTC).isoformat()
+    metadatas: list[dict[str, Any]] = []
+    for item in items:
+        metadatas.append(
+            {
+                "title": item["title"],
+                "year": item["year"],
+                "item_type": item["item_type"],
+                "doi": item["doi"],
+                # source = which text fueled the embedding; ADR 015 §6.
+                "source": "s2_fulltext",
+                "indexed_at": now_iso,
+                "source_subsystem": "s2",
+            }
+        )
+
+    print(f"[4/5] Upserting {len(items)} documents into {args.collection_name!r}")
+    collection.upsert(ids=keys, embeddings=embeddings, metadatas=metadatas, documents=texts)
+
+    print("[5/5] Final state:")
+    count = collection.count()
+    sample = collection.get(limit=1, include=["metadatas", "embeddings"])
+    # Chroma returns numpy arrays for embeddings; use len() to avoid serialising.
+    sample_meta = sample["metadatas"][0] if sample["metadatas"] else None
+    sample_embed = sample["embeddings"][0] if sample["embeddings"] else None
+    embed_dim = len(sample_embed) if sample_embed is not None else None
+
+    report = {
+        "path": str(path),
+        "collection_name": args.collection_name,
+        "documents_count": count,
+        "embedding_model": args.embedding_model,
+        "embedding_dimension": embed_dim,
+        "document_ids": keys,
+        "sample_metadata": sample_meta,
+    }
+    print(json.dumps(report, indent=2, default=str))
+
+    if owns_tempdir:
+        print(
+            f"\nNote: ChromaDB lives in a temp dir at {path}.\n"
+            "To test with `zotero-mcp serve`, either point its config at "
+            "this path or re-run with `--path ~/.config/zotero-mcp/chroma_db` "
+            "(back up any existing store first)."
+        )
+
+    return 0
+
+
+if __name__ == "__main__":
+    sys.exit(main())


### PR DESCRIPTION
## Summary

Fase 2 of the orden de trabajo for ADR 015. **Blocks Fase 3** (the actual `src/zotai/s2/indexing.py` implementation) until you run through the checklist and confirm `zotero-mcp serve` tolerates the ChromaDB schema ADR 015 §6 prescribes.

Two artefacts:

- **`scripts/validate_chromadb_schema.py`** — standalone script. Opens a ChromaDB, gets-or-creates the `zotero_library` collection, writes 5 synthetic items with Zotero-shape IDs + real OpenAI `text-embedding-3-large` embeddings + ADR 015 §6 metadata. Prints a JSON report. `--help` runs without `chromadb` installed (lazy import).
- **`docs/decisions/015-validation-checklist.md`** — user-side manual checklist. 5 steps: backup, run script, `zotero-mcp serve`, test semantic_search + item_details from Claude Desktop, restore. Failure-mode matrix maps each possible break to a specific ADR 015 addendum.

No runtime code in `src/`, no test changes. Tests still pass (117).

## What you need to do

1. Merge this PR.
2. When you have ~15 min: follow `docs/decisions/015-validation-checklist.md` end-to-end. Requires `zotero-mcp setup` done, Claude Desktop, `OPENAI_API_KEY`.
3. Fill in the result table at the bottom of the checklist (copy-paste your verdict + date).
4. Commit the filled checklist (or tell me the results and I'll commit).
5. Once the checklist shows "OK for Fase 3", I start `src/zotai/s2/indexing.py` with tests.

If any step fails, **don't debug in Fase 3** — the checklist's "qué hacer si falla" matrix tells you which addendum to land on ADR 015 first.

## Test plan (pre-merge)

- [ ] `python scripts/validate_chromadb_schema.py --help` runs and prints usage (done locally).
- [ ] `pytest -q` → 117 passed (done locally).
- [ ] Reading ADR 015 §5 + this checklist produces no contradiction.

## References

- ADR 015 §5 (validation requirement) and §6 (schema contract)
- Orden de trabajo Fase 2 (the instruction that became this PR)