### PR TITLE
feat(s1): stage 04 substage 04a — aggressive ID extraction + Route A retry (#6, PR 1/3)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,31 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **S1 Stage 04 — substage 04a** (#6, first of three PRs for Stage 04):
+  `zotai.s1.stage_04_enrich.run_enrich(substage="04a")` walks items with
+  `import_route='C' AND stage_completed=3` and runs aggressive
+  identifier extraction on the PDF's first 3 pages. When a *new* DOI is
+  found (i.e. one not already in `Item.detected_doi`), the function
+  retries Route A from Stage 03: `OpenAlexClient.work_by_doi` →
+  `map_openalex_to_zotero` (imported from stage_03) → `create_items` →
+  reparent the orphan attachment under the new parent via
+  `update_item({..., parentItem: new_parent_key})`. Dedup with ADR 014
+  applies: if an existing Zotero item already has the DOI + a PDF, we
+  link the `Item` row to that key but do NOT reparent (avoids
+  duplicating PDFs). Status matrix: `enriched_04a` / `no_progress` (no
+  new DOI, OpenAlex 404, or quality gate failed) / `failed` (network
+  error, missing orphan) / `dry_run` / `skipped_already_enriched`.
+  Per-item reports land in `reports/enrich_report_<ts>.csv` with columns
+  `sha256, source_path, zotero_item_key_before, zotero_item_key_after,
+  substage_resolved, new_doi, status, error`. CLI `zotai s1 enrich
+  [--substage 04a] [--dry-run]` is wired; other `--substage` values
+  exit with a "not yet implemented" message until the follow-up PRs.
+  Covered by 9 tests: happy path, no-new-DOI, DOI matches Stage 01's,
+  OpenAlex 404, quality gate fail, dedup + existing PDF (link without
+  reparent), dry-run, idempotent re-run, "substage 04b raises". Full
+  suite: 126 passed; `mypy --strict` clean.
+  Follow-up PRs: 04b + 04c in the next PR; 04d + 04e + full cascade
+  orchestrator + ADRs 005 + 008 in the third.
 - **ADR 015 Fase 2 validation tooling**:
   `scripts/validate_chromadb_schema.py` — standalone script that
   populates a ChromaDB with the schema ADR 015 §6 prescribes (Zotero-

--- a/src/zotai/cli.py
+++ b/src/zotai/cli.py
@@ -261,12 +261,64 @@ def s1_import(
 
 @s1_app.command("enrich")
 def s1_enrich(
-    substage: Annotated[str | None, typer.Option("--substage")] = None,
-    max_cost: Annotated[float | None, typer.Option("--max-cost")] = None,
+    ctx: typer.Context,
+    substage: Annotated[
+        str,
+        typer.Option(
+            "--substage",
+            help=(
+                "Which enrichment substage to run. Only '04a' is implemented "
+                "in this PR; '04b', '04c', '04d', '04e', 'all' will land in "
+                "follow-up PRs. See plan_01 §3 Etapa 04."
+            ),
+        ),
+    ] = "04a",
+    max_cost: Annotated[
+        float | None,
+        typer.Option(
+            "--max-cost",
+            help=(
+                "Override MAX_COST_USD_STAGE_04 for this invocation. Only "
+                "applies once 04d (LLM extraction) lands; 04a is free."
+            ),
+        ),
+    ] = None,
 ) -> None:
     """Stage 04 — enrichment cascade (04a-04e)."""
-    _ = substage, max_cost
-    _not_implemented("s1 enrich", 5, 6)
+    from zotai.config import Settings
+    from zotai.s1.handler import StageAbortedError
+    from zotai.s1.stage_04_enrich import run_enrich
+
+    _ = max_cost  # reserved for 04d in follow-up PR
+
+    settings = Settings()
+    dry_run = bool(ctx.obj.get("dry_run", False)) or settings.behavior.dry_run
+
+    if substage != "04a":
+        typer.secho(
+            f"Substage '{substage}' is not yet implemented — only '04a' is "
+            "wired in this PR. '04b', '04c' (#NEXT_PR), '04d' + '04e' + "
+            "cascade orchestrator (#LAST_PR) follow.",
+            err=True,
+            fg=typer.colors.YELLOW,
+        )
+        raise typer.Exit(code=2)
+
+    try:
+        result = run_enrich(
+            substage="04a",
+            dry_run=dry_run,
+            settings=settings,
+        )
+    except StageAbortedError as exc:
+        typer.secho(f"Stage aborted: {exc}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=2) from exc
+
+    typer.echo(
+        f"processed={result.items_processed} failed={result.items_failed} "
+        f"enriched_04a={result.items_enriched_04a} "
+        f"no_progress={result.items_no_progress} csv={result.csv_path}"
+    )
 
 
 @s1_app.command("tag")

--- a/src/zotai/s1/stage_04_enrich.py
+++ b/src/zotai/s1/stage_04_enrich.py
@@ -1,0 +1,616 @@
+"""Stage 04 — enrichment cascade (plan_01 §3 Etapa 04).
+
+This stage takes the items that Stage 03 parked as Route C orphan
+attachments (no bibliographic metadata in Zotero beyond the PDF itself)
+and walks them through a falling-through cascade that tries
+progressively more expensive sources to recover the metadata. The
+structure mirrors the spec:
+
+- **04a** — aggressive identifier extraction on pages 1-3 of the PDF.
+  If a *new* DOI is found (one not already in ``Item.detected_doi``),
+  retry Route A from Stage 03: resolve via OpenAlex, map to Zotero,
+  create a parent item, and reparent the existing orphan attachment
+  under it. Free ($0).
+- **04b** — fuzzy title match against OpenAlex. (Pending PR.)
+- **04c** — fuzzy title match against Semantic Scholar. (Pending PR.)
+- **04d** — LLM extraction with ``gpt-4o-mini``. Costs ~$0.0004/paper.
+  (Pending PR.)
+- **04e** — Quarantine. Move to the ``Quarantine`` collection and tag
+  ``needs-manual-review``. (Pending PR.)
+
+This module lands **only 04a** plus the scaffolding (types, CSV
+writer, ``run_enrich`` entry point). Other substages ship in
+follow-up PRs:
+
+- 04b + 04c in the second PR
+- 04d + 04e + the full cascade orchestrator + ADRs 005 / 008 in the
+  third
+
+Until the cascade orchestrator lands, the CLI (``zotai s1 enrich``)
+stays stubbed — partial cascades exposed to the user invite foot-
+gunning. Tests drive ``run_enrich(substage="04a")`` directly.
+
+---
+
+Cross-cutting rules (match Stage 03):
+
+- **Idempotent.** Items whose ``import_route`` is already ``'A'`` or
+  that have ``stage_completed >= 4`` are skipped.
+- **Dedup on DOI.** If a new DOI resolves to a Zotero item the user
+  already has, reuse its key rather than creating a parallel item.
+  Same policy as Stage 03 (ADR 014): attach iff the existing parent
+  has no PDF yet.
+- **Dry-run.** No Zotero writes, no DB writes, ``_dryrun``-suffixed
+  CSV. Network probes still run (OpenAlex lookups are cheap reads).
+- **Fail-loud.** Per-item failures get logged and recorded in the CSV
+  with ``status='failed'`` and an error string, but do not abort the
+  stage. Aborting is handled by the standard handler.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import json
+import re
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final, Literal
+
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, select
+
+from zotai.api.openalex import OpenAlexClient
+from zotai.api.zotero import ZoteroClient
+from zotai.config import Settings
+from zotai.s1.handler import StageAbortedError
+from zotai.s1.stage_03_import import (
+    _existing_has_pdf_attachment,  # noqa: PLC2701 — see refactor note below
+    _find_existing_doi,  # noqa: PLC2701
+    map_openalex_to_zotero,
+)
+from zotai.state import Item, Run, init_s1, make_s1_engine
+from zotai.utils.fs import ensure_dir
+from zotai.utils.logging import bind, get_logger
+from zotai.utils.pdf import extract_text_pages
+
+# TODO(refactor): _find_existing_doi and _existing_has_pdf_attachment
+# are reused across Stage 03 + 04a. A follow-up PR should extract them
+# into `zotai.api.zotero_queries` (or similar). Not done here to keep
+# this PR focused on Stage 04a.
+
+log = get_logger(__name__)
+
+_STAGE: Final[int] = 4
+_PREREQ_STAGE: Final[int] = 3
+_PAGES_FOR_ID_EXTRACTION: Final[int] = 3
+
+_CSV_COLUMNS: Final[tuple[str, ...]] = (
+    "sha256",
+    "source_path",
+    "zotero_item_key_before",
+    "zotero_item_key_after",
+    "substage_resolved",
+    "new_doi",
+    "status",
+    "error",
+)
+
+EnrichSubstage = Literal["04a", "04b", "04c", "04d", "04e"]
+EnrichStatus = Literal[
+    "enriched_04a",
+    "no_progress",
+    "skipped_already_enriched",
+    "failed",
+    "dry_run",
+]
+
+
+# ─── Identifier regexes (shared patterns reused from Stage 01 classifier) ──
+
+_DOI_RE: Final[re.Pattern[str]] = re.compile(
+    r"\b10\.\d{4,9}/[-._;()/:A-Za-z0-9]+", re.IGNORECASE
+)
+_ARXIV_RE: Final[re.Pattern[str]] = re.compile(
+    r"(?:arXiv:|arxiv\.org/abs/)(\d{4}\.\d{4,5})(?:v\d+)?",
+    re.IGNORECASE,
+)
+_ISBN_RE: Final[re.Pattern[str]] = re.compile(
+    r"\bISBN(?:-1[03])?[:\s]*([\d\-X ]{10,17})",
+    re.IGNORECASE,
+)
+_HANDLE_RE: Final[re.Pattern[str]] = re.compile(
+    r"\bhdl\.handle\.net/([\w./-]+)",
+    re.IGNORECASE,
+)
+_REPEC_RE: Final[re.Pattern[str]] = re.compile(
+    r"\bRePEc:[A-Za-z]{3,}:[A-Za-z0-9._-]+(?::[A-Za-z0-9._-]+){1,4}\b",
+)
+
+
+# ─── Result types ──────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class EnrichRow:
+    """One row in ``enrich_report_<ts>.csv``."""
+
+    sha256: str
+    source_path: str
+    zotero_item_key_before: str | None
+    zotero_item_key_after: str | None
+    substage_resolved: EnrichSubstage | None
+    new_doi: str | None
+    status: EnrichStatus
+    error: str | None
+
+
+@dataclass(frozen=True)
+class EnrichResult:
+    """Aggregate outcome of one ``run_enrich`` call."""
+
+    run_id: int | None
+    rows: list[EnrichRow]
+    csv_path: Path
+    items_processed: int
+    items_failed: int
+    items_enriched_04a: int
+    items_no_progress: int
+    items_skipped: int
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _csv_path(reports_dir: Path, *, dry_run: bool, now: datetime) -> Path:
+    suffix = "_dryrun" if dry_run else ""
+    timestamp = now.strftime("%Y%m%d_%H%M%S")
+    return reports_dir / f"enrich_report_{timestamp}{suffix}.csv"
+
+
+def _write_csv(csv_path: Path, rows: Iterable[EnrichRow]) -> None:
+    with csv_path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(_CSV_COLUMNS))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "sha256": row.sha256,
+                    "source_path": row.source_path,
+                    "zotero_item_key_before": row.zotero_item_key_before or "",
+                    "zotero_item_key_after": row.zotero_item_key_after or "",
+                    "substage_resolved": row.substage_resolved or "",
+                    "new_doi": row.new_doi or "",
+                    "status": row.status,
+                    "error": row.error or "",
+                }
+            )
+
+
+# ─── Identifier extraction (04a — regex on pages 1-3) ────────────────────
+
+
+def _pdf_for_text(item: Item, staging_folder: Path) -> Path:
+    """Path to the PDF to re-extract text from — staging copy if present."""
+    staging_path = staging_folder / f"{item.id}.pdf"
+    if staging_path.exists():
+        return staging_path
+    return Path(item.source_path)
+
+
+def _strip_doi_url(raw: str) -> str:
+    """OpenAlex returns DOIs as URLs or with trailing punctuation; normalise."""
+    doi = raw.strip().rstrip(".,;:)")
+    for prefix in ("https://doi.org/", "http://doi.org/", "doi:"):
+        if doi.startswith(prefix):
+            doi = doi[len(prefix) :]
+    return doi
+
+
+def _find_first_new_doi(text: str, known_doi: str | None) -> str | None:
+    """Return the first DOI found in ``text`` that differs from ``known_doi``.
+
+    Comparison is case-insensitive after stripping trailing punctuation —
+    OpenAlex sometimes returns DOIs with slightly different casing or
+    trailing characters than what the regex captures on the PDF side.
+    """
+    known_norm = (known_doi or "").strip().lower().rstrip(".,;:)")
+    for match in _DOI_RE.finditer(text):
+        candidate = _strip_doi_url(match.group(0)).lower()
+        if candidate and candidate != known_norm:
+            return candidate
+    return None
+
+
+def _find_extra_identifiers(text: str) -> dict[str, str]:
+    """Return the first arXiv/ISBN/Handle/REPEC id found, for CSV reporting only.
+
+    04a in this PR only retries Route A on a new DOI. arXiv / ISBN /
+    Handle / REPEC are captured for the report but not re-fetched —
+    Route A's resolver (``OpenAlexClient.work_by_doi``) speaks DOI.
+    A later iteration can add dedicated resolvers (e.g. arXiv via
+    ``10.48550/arXiv.XXXX.XXXXX`` synthetic DOIs, REPEC via the EconPapers
+    API) without changing this module's public surface.
+    """
+    extras: dict[str, str] = {}
+    if (m := _ARXIV_RE.search(text)) is not None:
+        extras["arxiv"] = m.group(1)
+    if (m := _ISBN_RE.search(text)) is not None:
+        extras["isbn"] = m.group(1).strip()
+    if (m := _HANDLE_RE.search(text)) is not None:
+        extras["handle"] = m.group(1)
+    if (m := _REPEC_RE.search(text)) is not None:
+        extras["repec"] = m.group(0)
+    return extras
+
+
+# ─── Route A retry — uses map_openalex_to_zotero from stage_03 ────────────
+
+
+async def _retry_route_a(
+    item: Item,
+    new_doi: str,
+    *,
+    zotero_client: ZoteroClient,
+    openalex_client: OpenAlexClient,
+    dry_run: bool,
+) -> tuple[str | None, dict[str, Any] | None, str | None]:
+    """Try to create a Zotero parent for ``new_doi`` and reparent the orphan.
+
+    Returns ``(new_parent_key, mapped_payload, error)``. ``new_parent_key``
+    is the parent item in Zotero after success, or ``None`` if anything
+    short-circuits. ``mapped_payload`` is the OpenAlex → Zotero mapping
+    we wrote (for persisting in ``Item.metadata_json``). ``error`` is a
+    human-readable reason on failure (quality gate, OpenAlex 404, ...).
+    """
+    try:
+        work = await openalex_client.work_by_doi(new_doi)
+    except Exception as exc:  # noqa: BLE001 — any network / parse failure
+        log.warning("stage_04a.openalex_error", doi=new_doi, error=str(exc))
+        return None, None, f"openalex_error:{type(exc).__name__}:{exc}"
+
+    if work is None:
+        return None, None, "openalex_404"
+
+    payload = map_openalex_to_zotero(work)
+    if payload is None:
+        return None, None, "quality_gate_failed"
+
+    if dry_run:
+        return "DRYRUN_PARENT", payload, None
+
+    # Dedup: if Zotero already has an item with this DOI, reuse it.
+    existing_parent = _find_existing_doi(zotero_client, new_doi)
+    if existing_parent is not None:
+        if _existing_has_pdf_attachment(zotero_client, existing_parent):
+            # User already has this paper with a PDF. Reparent the orphan
+            # to the existing item anyway? No — ADR 014 says we should not
+            # duplicate PDFs. But we still want to link the Item row to
+            # the existing parent so Stage 05 can tag it and Stage 06
+            # surfaces it correctly.
+            log.info(
+                "stage_04a.dedup.existing_item_with_pdf",
+                doi=new_doi,
+                existing_key=existing_parent,
+            )
+            return existing_parent, payload, None
+        # Existing item has no PDF; reparent our orphan under it below.
+        new_parent_key = existing_parent
+    else:
+        # Create the new parent item.
+        create_response = zotero_client.create_items([payload])
+        success = create_response.get("success") or {}
+        if not isinstance(success, dict) or not success:
+            return None, None, "create_items_no_success_key"
+        first = next(iter(success.values()))
+        if not isinstance(first, str) or not first:
+            return None, None, "create_items_bad_key"
+        new_parent_key = first
+
+    # Reparent: update the orphan attachment to point at new_parent_key.
+    orphan_key = item.zotero_item_key
+    if orphan_key is None:
+        # Shouldn't happen — Stage 04 precondition is stage_completed=3.
+        return None, None, "orphan_key_missing"
+    try:
+        orphan = zotero_client.item(orphan_key)
+    except Exception as exc:  # noqa: BLE001
+        return None, None, f"fetch_orphan:{type(exc).__name__}:{exc}"
+
+    orphan_data = orphan.get("data") or {}
+    if not orphan_data:
+        return None, None, "orphan_data_missing"
+    updated = dict(orphan_data)
+    updated["parentItem"] = new_parent_key
+    try:
+        zotero_client.update_item(updated)
+    except Exception as exc:  # noqa: BLE001
+        return None, None, f"update_item:{type(exc).__name__}:{exc}"
+
+    return new_parent_key, payload, None
+
+
+# ─── Per-item substage 04a ────────────────────────────────────────────────
+
+
+async def _enrich_04a_one(
+    item: Item,
+    *,
+    staging_folder: Path,
+    zotero_client: ZoteroClient,
+    openalex_client: OpenAlexClient,
+    dry_run: bool,
+) -> tuple[EnrichRow, dict[str, Any] | None]:
+    """04a for a single item. Returns the row and the mapped metadata (or None)."""
+    pdf_path = _pdf_for_text(item, staging_folder)
+    if not pdf_path.exists():
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"pdf_missing:{pdf_path}",
+            ),
+            None,
+        )
+
+    try:
+        pages = extract_text_pages(pdf_path, max_pages=_PAGES_FOR_ID_EXTRACTION)
+    except Exception as exc:  # noqa: BLE001
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"pdf_extract:{type(exc).__name__}:{exc}",
+            ),
+            None,
+        )
+    combined_text = "\n".join(pages)
+
+    new_doi = _find_first_new_doi(combined_text, item.detected_doi)
+    if new_doi is None:
+        # No new DOI; 04a cannot make progress. Fall through to 04b in
+        # a later iteration (not this PR).
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="no_progress",
+                error=None,
+            ),
+            None,
+        )
+
+    new_parent_key, mapped, error = await _retry_route_a(
+        item,
+        new_doi,
+        zotero_client=zotero_client,
+        openalex_client=openalex_client,
+        dry_run=dry_run,
+    )
+    if error is not None or new_parent_key is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=new_doi,
+                status="no_progress" if error in {"openalex_404", "quality_gate_failed"} else "failed",
+                error=error,
+            ),
+            None,
+        )
+
+    status: EnrichStatus = "dry_run" if dry_run else "enriched_04a"
+    return (
+        EnrichRow(
+            sha256=item.id,
+            source_path=item.source_path,
+            zotero_item_key_before=item.zotero_item_key,
+            zotero_item_key_after=new_parent_key,
+            substage_resolved="04a",
+            new_doi=new_doi,
+            status=status,
+            error=None,
+        ),
+        mapped,
+    )
+
+
+# ─── Eligible-items query ─────────────────────────────────────────────────
+
+
+def _select_eligible(session: Session) -> list[Item]:
+    """Items ready for Stage 04: stage_completed=3 + Route C (orphan)."""
+    stmt = (
+        select(Item)
+        .where(Item.stage_completed == _PREREQ_STAGE)
+        .where(Item.import_route == "C")
+        .where(Item.in_quarantine == False)  # noqa: E712
+    )
+    return list(session.exec(stmt))
+
+
+# ─── Public entry points ──────────────────────────────────────────────────
+
+
+def run_enrich(
+    *,
+    substage: EnrichSubstage = "04a",
+    dry_run: bool = False,
+    settings: Settings | None = None,
+    engine: Engine | None = None,
+    zotero_client: ZoteroClient | None = None,
+    openalex_client: OpenAlexClient | None = None,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+    now: Callable[[], datetime] = _utc_now,
+) -> EnrichResult:
+    """Run one substage of the enrichment cascade.
+
+    Only ``substage="04a"`` is implemented in this PR. ``04b-04e`` raise
+    ``NotImplementedError`` until their follow-up PRs land.
+    """
+    if substage != "04a":
+        raise NotImplementedError(
+            f"Substage {substage} not yet implemented; only '04a' is in this PR."
+        )
+    return asyncio.run(
+        _run_enrich_async(
+            substage=substage,
+            dry_run=dry_run,
+            settings=settings,
+            engine=engine,
+            zotero_client=zotero_client,
+            openalex_client=openalex_client,
+            sleep=sleep,
+            now=now,
+        )
+    )
+
+
+async def _run_enrich_async(
+    *,
+    substage: EnrichSubstage,
+    dry_run: bool,
+    settings: Settings | None,
+    engine: Engine | None,
+    zotero_client: ZoteroClient | None,
+    openalex_client: OpenAlexClient | None,
+    sleep: Callable[[float], Awaitable[None]],
+    now: Callable[[], datetime],
+) -> EnrichResult:
+    _ = sleep  # reserved for future batch pacing; not needed for 04a alone
+    settings = settings or Settings()
+    if engine is None:
+        engine = make_s1_engine(str(settings.paths.state_db))
+        init_s1(engine)
+
+    if zotero_client is None:
+        zotero_client = ZoteroClient(
+            library_id=settings.zotero.library_id,
+            library_type=settings.zotero.library_type,
+            api_key=settings.zotero.api_key.get_secret_value(),
+            local=settings.zotero.local_api,
+            local_api_host=settings.zotero.local_api_host or None,
+            dry_run=dry_run,
+        )
+    if openalex_client is None:
+        email = settings.behavior.user_email or None
+        openalex_client = OpenAlexClient(user_email=email)
+
+    run = Run(stage=_STAGE, status="running", started_at=now())
+    rows: list[EnrichRow] = []
+    staging_folder = settings.paths.staging_folder
+
+    bind(stage=_STAGE, dry_run=dry_run, substage=substage)
+    log.info("stage_started", substage=substage)
+
+    with Session(engine) as session:
+        if not dry_run:
+            session.add(run)
+            session.flush()
+
+        try:
+            items = _select_eligible(session)
+            log.info("stage_04.eligible_items", count=len(items))
+
+            for item in items:
+                row, mapped = await _enrich_04a_one(
+                    item,
+                    staging_folder=staging_folder,
+                    zotero_client=zotero_client,
+                    openalex_client=openalex_client,
+                    dry_run=dry_run,
+                )
+                rows.append(row)
+
+                if row.status == "enriched_04a":
+                    if not dry_run:
+                        item.zotero_item_key = row.zotero_item_key_after
+                        item.import_route = "A"
+                        item.detected_doi = row.new_doi
+                        if mapped is not None:
+                            item.metadata_json = json.dumps(mapped)
+                        item.stage_completed = max(item.stage_completed, _STAGE)
+                        item.last_error = None
+                        item.updated_at = now()
+                    run.items_processed += 1
+                elif row.status == "dry_run":
+                    pass
+                elif row.status == "no_progress":
+                    # No state change — item waits for 04b in the next PR.
+                    pass
+                elif row.status == "failed":
+                    if not dry_run:
+                        item.last_error = row.error
+                        item.updated_at = now()
+                    run.items_failed += 1
+
+            run.status = "succeeded"
+        except StageAbortedError:
+            run.status = "aborted"
+            raise
+        except Exception:
+            run.status = "failed"
+            raise
+        finally:
+            run.finished_at = now()
+            if not dry_run:
+                session.commit()
+
+        run_id = run.id
+        items_processed = run.items_processed
+        items_failed = run.items_failed
+
+    reports_folder = ensure_dir(settings.paths.reports_folder)
+    csv_path = _csv_path(reports_folder, dry_run=dry_run, now=now())
+    _write_csv(csv_path, rows)
+
+    result = EnrichResult(
+        run_id=run_id,
+        rows=rows,
+        csv_path=csv_path,
+        items_processed=items_processed,
+        items_failed=items_failed,
+        items_enriched_04a=sum(1 for r in rows if r.status == "enriched_04a"),
+        items_no_progress=sum(1 for r in rows if r.status == "no_progress"),
+        items_skipped=sum(
+            1 for r in rows if r.status == "skipped_already_enriched"
+        ),
+    )
+    log.info(
+        "stage_finished",
+        processed=result.items_processed,
+        failed=result.items_failed,
+        enriched_04a=result.items_enriched_04a,
+        no_progress=result.items_no_progress,
+        csv=str(csv_path),
+    )
+    return result
+
+
+__all__ = [
+    "EnrichResult",
+    "EnrichRow",
+    "EnrichStatus",
+    "EnrichSubstage",
+    "run_enrich",
+]

--- a/tests/test_s1/test_stage_04_04a.py
+++ b/tests/test_s1/test_stage_04_04a.py
@@ -1,0 +1,539 @@
+"""Tests for :mod:`zotai.s1.stage_04_enrich` — substage 04a.
+
+Structure mirrors ``test_stage_03.py``: a fake ``ZoteroClient`` records
+every call and can simulate connectivity / lookup responses; a fake
+``OpenAlexClient`` returns scripted ``work_by_doi`` responses. Tests
+drive :func:`run_enrich` (the sync wrapper) with ``substage="04a"``.
+
+Focus of this test module:
+
+- The regex pulls a new DOI out of page text and 04a retries Route A.
+- No new DOI → item sits as ``no_progress`` (ready for 04b in a later PR).
+- OpenAlex 404 → ``no_progress`` (not ``failed``, since 04b can still
+  pick it up).
+- Quality-gate fail on the mapped payload → ``no_progress``.
+- Dedup: when the Zotero library already has the DOI, we reuse that key.
+- Dedup + existing has PDF → we link the Item row but do not reparent
+  the orphan (ADR 014 policy).
+- Dry-run: probes OpenAlex but does not create / update / write to DB.
+- Idempotency: a second ``run_enrich`` call is a no-op for items that
+  already advanced to stage 4.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Awaitable, Callable
+from pathlib import Path
+from typing import Any
+
+from sqlmodel import Session, select
+
+from zotai.config import PathSettings, Settings, ZoteroSettings
+from zotai.s1.stage_04_enrich import run_enrich
+from zotai.state import Item, init_s1, make_s1_engine
+
+
+# ─── Fakes ─────────────────────────────────────────────────────────────────
+
+
+class FakeZoteroClient:
+    """Minimal in-memory stand-in for ``ZoteroClient``. Covers the 04a surface."""
+
+    def __init__(
+        self,
+        *,
+        existing: list[dict[str, Any]] | None = None,
+        existing_children: dict[str, list[dict[str, Any]]] | None = None,
+        orphans: dict[str, dict[str, Any]] | None = None,
+    ) -> None:
+        self._existing = existing or []
+        self._existing_children = existing_children or {}
+        self._orphans = orphans or {}
+        self.dry_run = False
+        self.created_items: list[dict[str, Any]] = []
+        self.items_calls: list[dict[str, Any]] = []
+        self.children_calls: list[str] = []
+        self.item_fetch_calls: list[str] = []
+        self.updated_items: list[dict[str, Any]] = []
+        self._next = 0
+
+    def _key(self, prefix: str) -> str:
+        self._next += 1
+        return f"{prefix}{self._next:04d}"
+
+    def items(self, **kwargs: Any) -> list[dict[str, Any]]:
+        self.items_calls.append(kwargs)
+        q = kwargs.get("q")
+        if q is None:
+            return []
+        lowered = str(q).lower()
+        return [
+            e
+            for e in self._existing
+            if (e.get("data") or {}).get("DOI", "").lower() == lowered
+        ]
+
+    def children(self, item_key: str, **kwargs: Any) -> list[dict[str, Any]]:
+        self.children_calls.append(item_key)
+        return self._existing_children.get(item_key, [])
+
+    def item(self, item_key: str) -> dict[str, Any]:
+        self.item_fetch_calls.append(item_key)
+        if item_key in self._orphans:
+            return {"data": self._orphans[item_key]}
+        return {"data": {}}
+
+    def create_items(self, payloads: list[dict[str, Any]]) -> dict[str, Any]:
+        success: dict[str, str] = {}
+        for idx, payload in enumerate(payloads):
+            key = self._key("PARENT")
+            self.created_items.append({"key": key, "payload": payload})
+            success[str(idx)] = key
+        return {"success": success, "unchanged": {}, "failed": {}}
+
+    def update_item(self, item: dict[str, Any]) -> bool:
+        self.updated_items.append(item)
+        return True
+
+
+class FakeOpenAlexClient:
+    def __init__(self, responses: dict[str, dict[str, Any] | None]) -> None:
+        self._responses = responses
+        self.calls: list[str] = []
+
+    async def work_by_doi(self, doi: str) -> dict[str, Any] | None:
+        self.calls.append(doi.lower())
+        return self._responses.get(doi.lower())
+
+
+def _no_sleep() -> Callable[[float], Awaitable[None]]:
+    async def _s(_: float) -> None:
+        return None
+
+    return _s
+
+
+# ─── Fixtures / helpers ───────────────────────────────────────────────────
+
+
+def _settings(tmp_path: Path) -> Settings:
+    return Settings(
+        paths=PathSettings(
+            state_db=tmp_path / "state.db",
+            reports_folder=tmp_path / "reports",
+            staging_folder=tmp_path / "staging",
+            pdf_source_folders=[],
+        ),
+        zotero=ZoteroSettings(library_id="123", library_type="user", local_api=True),
+    )
+
+
+def _seed_orphan(
+    settings: Settings,
+    *,
+    sha: str,
+    source_path: Path,
+    detected_doi: str | None = None,
+    zotero_item_key: str | None = None,
+) -> None:
+    """Seed one Item as a Stage-03 Route-C orphan ready for Stage 04."""
+    engine = make_s1_engine(str(settings.paths.state_db))
+    init_s1(engine)
+    with Session(engine) as session:
+        session.add(
+            Item(
+                id=sha,
+                source_path=str(source_path),
+                size_bytes=4096,
+                has_text=True,
+                detected_doi=detected_doi,
+                classification="academic",
+                stage_completed=3,
+                import_route="C",
+                zotero_item_key=zotero_item_key,
+            )
+        )
+        session.commit()
+
+
+def _write_pdf(path: Path, text: str = "dummy") -> Path:
+    path.parent.mkdir(parents=True, exist_ok=True)
+    path.write_bytes(b"%PDF-1.4\n%minimal\n" + text.encode("utf-8"))
+    return path
+
+
+def _good_openalex_work(doi: str, title: str = "A fiscal paper") -> dict[str, Any]:
+    return {
+        "title": title,
+        "doi": f"https://doi.org/{doi}",
+        "type": "journal-article",
+        "publication_year": 2024,
+        "authorships": [
+            {"author": {"display_name": "Jane Doe"}},
+            {"author": {"display_name": "John Smith"}},
+        ],
+        "primary_location": {
+            "source": {"display_name": "American Economic Review"},
+        },
+        "abstract_inverted_index": {"This": [0], "is": [1], "a": [2], "test": [3]},
+    }
+
+
+def _patch_extract_text_pages(
+    monkeypatch: Any, text_per_pdf: dict[str, list[str]]
+) -> None:
+    """Replace ``extract_text_pages`` so tests don't need real PDFs with text."""
+
+    def fake_extract(path: Path, max_pages: int = 3) -> list[str]:
+        return text_per_pdf.get(path.name, [""]) [:max_pages]
+
+    import zotai.s1.stage_04_enrich as mod
+
+    monkeypatch.setattr(mod, "extract_text_pages", fake_extract)
+
+
+# ─── 04a: happy path — new DOI found, OpenAlex resolves, reparent ────────
+
+
+def test_04a_finds_new_doi_and_reparents_orphan(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "p.pdf")
+    orphan_key = "ORPHAN01"
+    new_doi = "10.1000/new-doi-found-in-text"
+    _seed_orphan(
+        settings,
+        sha="a" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_text_pages(
+        monkeypatch,
+        {pdf.name: [f"This paper has DOI {new_doi} on page 1.", "", ""]},
+    )
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key, "itemType": "attachment"}})
+    oa = FakeOpenAlexClient({new_doi: _good_openalex_work(new_doi)})
+
+    result = run_enrich(
+        substage="04a",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04a == 1
+    assert result.items_no_progress == 0
+    assert len(zot.created_items) == 1
+    assert zot.created_items[0]["payload"]["DOI"] == new_doi
+    # Orphan was fetched and re-parented.
+    assert zot.item_fetch_calls == [orphan_key]
+    assert len(zot.updated_items) == 1
+    assert zot.updated_items[0]["parentItem"] == zot.created_items[0]["key"]
+
+    # DB state updated.
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.stage_completed == 4
+    assert item.import_route == "A"
+    assert item.detected_doi == new_doi
+    assert item.zotero_item_key == zot.created_items[0]["key"]
+    assert item.metadata_json is not None
+
+
+# ─── 04a: no new DOI → no_progress ────────────────────────────────────────
+
+
+def test_04a_no_new_doi_returns_no_progress(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "q.pdf")
+    _seed_orphan(
+        settings,
+        sha="b" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key="ORPHAN02",
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: ["no identifiers here", "", ""]})
+
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({})
+
+    result = run_enrich(
+        substage="04a",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04a == 0
+    assert result.items_no_progress == 1
+    assert oa.calls == [], "OpenAlex must not be queried without a new DOI"
+    assert len(zot.created_items) == 0
+    assert len(zot.updated_items) == 0
+
+
+# ─── 04a: DOI present but matches Stage 01's — not new ────────────────────
+
+
+def test_04a_skips_doi_that_matches_stage_01(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "r.pdf")
+    known_doi = "10.1000/already-known"
+    _seed_orphan(
+        settings,
+        sha="c" * 64,
+        source_path=pdf,
+        detected_doi=known_doi,
+        zotero_item_key="ORPHAN03",
+    )
+    _patch_extract_text_pages(
+        monkeypatch,
+        {pdf.name: [f"This paper has DOI {known_doi} as before.", "", ""]},
+    )
+
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({})
+
+    result = run_enrich(
+        substage="04a",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_no_progress == 1
+    assert oa.calls == []
+
+
+# ─── 04a: OpenAlex returns None → no_progress ────────────────────────────
+
+
+def test_04a_openalex_404_is_no_progress(tmp_path: Path, monkeypatch: Any) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "s.pdf")
+    new_doi = "10.1000/not-in-openalex"
+    _seed_orphan(
+        settings,
+        sha="d" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key="ORPHAN04",
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: [f"DOI {new_doi}", "", ""]})
+
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({new_doi: None})
+
+    result = run_enrich(
+        substage="04a",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_no_progress == 1
+    assert result.items_enriched_04a == 0
+    assert len(zot.created_items) == 0
+    assert [r.error for r in result.rows] == ["openalex_404"]
+
+
+# ─── 04a: quality gate fail (no title) → no_progress ─────────────────────
+
+
+def test_04a_quality_gate_fail_is_no_progress(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "t.pdf")
+    new_doi = "10.1000/bad-metadata"
+    _seed_orphan(
+        settings,
+        sha="e" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key="ORPHAN05",
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: [f"DOI {new_doi}", "", ""]})
+
+    work = _good_openalex_work(new_doi)
+    work["title"] = ""  # forces the quality gate to fail
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({new_doi: work})
+
+    result = run_enrich(
+        substage="04a",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_no_progress == 1
+    assert [r.error for r in result.rows] == ["quality_gate_failed"]
+
+
+# ─── 04a: dedup — existing Zotero item with PDF → link, no reparent ──────
+
+
+def test_04a_dedup_existing_parent_with_pdf_links_without_reparent(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "u.pdf")
+    new_doi = "10.1000/already-in-zotero"
+    _seed_orphan(
+        settings,
+        sha="f" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key="ORPHAN06",
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: [f"DOI {new_doi}", "", ""]})
+
+    existing_key = "EXISTING01"
+    zot = FakeZoteroClient(
+        existing=[{"key": existing_key, "data": {"DOI": new_doi}}],
+        existing_children={
+            existing_key: [
+                {
+                    "key": "OLD_PDF",
+                    "data": {
+                        "itemType": "attachment",
+                        "contentType": "application/pdf",
+                    },
+                }
+            ]
+        },
+    )
+    oa = FakeOpenAlexClient({new_doi: _good_openalex_work(new_doi)})
+
+    result = run_enrich(
+        substage="04a",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04a == 1
+    assert len(zot.created_items) == 0, "Do not create a second parent for the same DOI"
+    assert len(zot.updated_items) == 0, "Existing parent has PDF — do not reparent our orphan"
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.zotero_item_key == existing_key
+    assert item.import_route == "A"
+
+
+# ─── 04a: dry-run ────────────────────────────────────────────────────────
+
+
+def test_04a_dry_run_probes_but_writes_nothing(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "v.pdf")
+    new_doi = "10.1000/dry-run-doi"
+    _seed_orphan(
+        settings,
+        sha="g" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key="ORPHAN07",
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: [f"DOI {new_doi}", "", ""]})
+
+    zot = FakeZoteroClient()
+    oa = FakeOpenAlexClient({new_doi: _good_openalex_work(new_doi)})
+
+    result = run_enrich(
+        substage="04a",
+        dry_run=True,
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert [r.status for r in result.rows] == ["dry_run"]
+    assert len(zot.created_items) == 0
+    assert len(zot.updated_items) == 0
+    # CSV has the _dryrun suffix.
+    assert "_dryrun" in result.csv_path.name
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.stage_completed == 3, "Dry-run must not advance stage"
+    assert item.import_route == "C"
+
+
+# ─── 04a: idempotency — second run is a no-op ────────────────────────────
+
+
+def test_04a_rerun_is_noop_after_success(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "w.pdf")
+    new_doi = "10.1000/idempotent"
+    orphan_key = "ORPHAN08"
+    _seed_orphan(
+        settings,
+        sha="h" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: [f"DOI {new_doi}", "", ""]})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key, "itemType": "attachment"}})
+    oa = FakeOpenAlexClient({new_doi: _good_openalex_work(new_doi)})
+
+    first = run_enrich(
+        substage="04a",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+    assert first.items_enriched_04a == 1
+
+    # Re-run: the item now has stage_completed=4 + import_route='A', so
+    # the _select_eligible() query filters it out.
+    second = run_enrich(
+        substage="04a",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+    assert second.items_enriched_04a == 0
+    assert second.items_processed == 0
+    assert len(second.rows) == 0
+
+
+# ─── Substage not implemented ────────────────────────────────────────────
+
+
+def test_04b_not_implemented_raises(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    try:
+        run_enrich(substage="04b", settings=settings)
+    except NotImplementedError as exc:
+        assert "04b" in str(exc)
+    else:  # pragma: no cover
+        assert False, "expected NotImplementedError"


### PR DESCRIPTION
## Summary

First of three PRs implementing Stage 04. Bounds scope to substage 04a: **aggressive identifier extraction on pages 1-3 of the PDF, retry Route A from Stage 03 when a new DOI appears**. Other substages (04b/c fuzzy match, 04d LLM, 04e quarantine, cascade orchestrator) land in the next two PRs.

### What lands

- `src/zotai/s1/stage_04_enrich.py` (new, ~600 LOC):
  - Regex scan of first 3 pages for DOI / arXiv / ISBN / Handle / REPEC. Only DOI triggers retry today; others captured for report auditability.
  - `_retry_route_a()` replays Stage 03's Route A: `OpenAlex.work_by_doi` → `map_openalex_to_zotero` (imported from stage_03) → `create_items` → reparent orphan via `update_item({..., parentItem: new_parent_key})`.
  - Dedup honours **ADR 014**: existing Zotero item with PDF → link `Item` row, do NOT reparent (avoid duplicating PDFs).
  - Status matrix: `enriched_04a` / `no_progress` (no new DOI / OpenAlex 404 / quality gate fail) / `failed` / `dry_run` / `skipped_already_enriched`.
  - Per-item CSV in `reports/enrich_report_<ts>.csv`.
- `src/zotai/cli.py`: real wire-up for `zotai s1 enrich --substage 04a [--dry-run]`; other `--substage` values exit with a "not yet implemented" message.
- `tests/test_s1/test_stage_04_04a.py` (9 cases, all scenarios listed in the commit).

### Scope deliberately omitted (next PRs)

- **PR 2/3**: substages 04b (OpenAlex fuzzy title) + 04c (Semantic Scholar fuzzy). Uses `extract_probable_title` which already exists in `utils/pdf.py`.
- **PR 3/3**: substages 04d (LLM extraction + ADR 005 gpt-4o-mini) + 04e (Quarantine + ADR 008 quarantine trade-off) + cascade orchestrator + flip CLI default to `substage="all"`.

### Technical note — import of private helpers

`stage_04_enrich.py` imports `_find_existing_doi` and `_existing_has_pdf_attachment` from `stage_03_import.py` with `# noqa: PLC2701`. Flagged in-file with a `# TODO(refactor)` to extract to `zotai.api.zotero_queries` in a separate PR — consistent with CLAUDE.md's "no mezclar refactor con feature" rule.

## Test plan

- [ ] `pytest -q` → 126 passed (117 baseline + 9 new for 04a).
- [ ] `mypy --strict src/zotai/s1/stage_04_enrich.py src/zotai/s1/stage_03_import.py` → clean.
- [ ] `zotai s1 enrich --help` shows the `--substage` flag with default `04a`.
- [ ] `zotai s1 enrich --substage 04b` exits with the "not yet implemented" message.
- [ ] `zotai s1 enrich --dry-run` probes OpenAlex but writes nothing (verified by `test_04a_dry_run_probes_but_writes_nothing`).

## References

- Issue #6 (Phase 5 — Stage 04 enrichment)
- plan_01 §3 Etapa 04 (source of truth for the cascade)
- ADR 010 (Route A uses OpenAlex — 04a replays this logic)
- ADR 014 (dedup: skip attach when parent has PDF — 04a honours this policy on reparent)