### PR TITLE
chore(s2): surface ADR 015/017 env vars in S2Settings

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,32 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **S2 settings — ADR 015 / ADR 017 env vars surfaced in `S2Settings`**:
+  nine knobs that `.env.example` and `plan_02` §12 already document now
+  round-trip through `zotai.config.S2Settings` instead of being silently
+  dropped by `extra="ignore"`. Fields added with defaults matching
+  `.env.example`: `max_embed_per_cycle=50`, `safe_delete_ratio=0.10`,
+  `max_cost_usd_backfill=3.0`, `query_bm25_weight=0.4`,
+  `pdf_fetch_max_attempts_per_candidate=6`,
+  `pdf_fetch_timeout_seconds=30`, `pdf_fetch_max_minutes_weekly=20`,
+  `pdf_fetch_circuit_breaker_threshold=5`, `worker_disabled=False`.
+  Validators enforce the documented ranges: `_positive` (>=1) extended
+  to cover `max_embed_per_cycle` +
+  `pdf_fetch_max_attempts_per_candidate` +
+  `pdf_fetch_timeout_seconds` + `pdf_fetch_max_minutes_weekly`; new
+  `_non_negative` (>=0) on `max_cost_usd_backfill` and
+  `pdf_fetch_circuit_breaker_threshold` (the latter accepts 0 because
+  plan_02 §10.4 documents `0` as the way to disable the breaker); new
+  `_unit_interval` on `safe_delete_ratio` and `query_bm25_weight`. No
+  runtime code consumes these yet — S2 Sprint 1 (#12) is the first
+  consumer; the point of this PR is to keep the CLAUDE.md "fail-loud"
+  principle: users who set these in `.env` today (following
+  `.env.example`) are heard by the settings layer instead of being
+  silently ignored. Covered by 7 new tests in `tests/test_config.py`
+  (defaults, env reads including `threshold=0` and `worker_disabled`,
+  plus validator rejections for out-of-range values). Full suite: 133
+  passed; `mypy --strict src/zotai/config.py` clean.
+
 - **S1 Stage 04 — substage 04a** (#6, first of three PRs for Stage 04):
   `zotai.s1.stage_04_enrich.run_enrich(substage="04a")` walks items with
   `import_route='C' AND stage_completed=3` and runs aggressive

--- a/src/zotai/config.py
+++ b/src/zotai/config.py
@@ -170,7 +170,13 @@ class BehaviorSettings(_GroupBase):
 
 
 class S2Settings(_GroupBase):
-    """Subsystem 2 — worker, dashboard, and PDF-cascade config."""
+    """Subsystem 2 — worker, dashboard, indexing, and PDF-cascade config.
+
+    The indexing / reconcile / PDF-fetch knobs land with Sprint 1 (#12); they
+    are declared here ahead of the code so setting them in ``.env`` today does
+    not silently no-op under ``extra="ignore"``. See ADR 015 (ownership) and
+    ADR 017 (hybrid query retrieval).
+    """
 
     model_config = SettingsConfigDict(
         env_prefix="S2_",
@@ -183,12 +189,25 @@ class S2Settings(_GroupBase):
     fetch_interval_hours: int = 6
     candidates_db: Path = Path("/workspace/candidates.db")
     chroma_path: Path = Path("/workspace/chroma_db")
+    worker_disabled: bool = False
     zotero_inbox_collection: str = "Inbox S2"
+    # Index reconciliation (ADR 015).
+    max_embed_per_cycle: int = 50
+    safe_delete_ratio: float = 0.10
+    max_cost_usd_backfill: float = 3.0
+    # Query scoring (ADR 017) — convex hybrid α·BM25 + (1-α)·cos.
+    query_bm25_weight: float = 0.4
+    # PDF fetch cascade (plan_02 §10).
     # ``NoDecode`` stops pydantic-settings 2.3+ from trying to JSON-parse the
     # comma-separated env value before our ``_split_csv`` validator runs.
     pdf_sources: Annotated[list[str], NoDecode] = Field(
         default_factory=lambda: ["openaccess", "doi", "annas", "libgen", "scihub", "rss"]
     )
+    pdf_fetch_max_attempts_per_candidate: int = 6
+    pdf_fetch_timeout_seconds: int = 30
+    pdf_fetch_max_minutes_weekly: int = 20
+    # ``0`` explicitly disables the breaker; see plan_02 §10.4.
+    pdf_fetch_circuit_breaker_threshold: int = 5
     dashboard_host: str = "127.0.0.1"
     dashboard_port: int = 8000
     max_cost_usd_daily: float = 0.50
@@ -201,11 +220,32 @@ class S2Settings(_GroupBase):
             return [s.strip().lower() for s in v.split(",") if s.strip()]
         return v
 
-    @field_validator("fetch_interval_hours", "dashboard_port")
+    @field_validator(
+        "fetch_interval_hours",
+        "dashboard_port",
+        "max_embed_per_cycle",
+        "pdf_fetch_max_attempts_per_candidate",
+        "pdf_fetch_timeout_seconds",
+        "pdf_fetch_max_minutes_weekly",
+    )
     @classmethod
     def _positive(cls, v: int) -> int:
         if v < 1:
             raise ValueError("value must be >= 1")
+        return v
+
+    @field_validator("max_cost_usd_backfill", "pdf_fetch_circuit_breaker_threshold")
+    @classmethod
+    def _non_negative(cls, v: float) -> float:
+        if v < 0:
+            raise ValueError("value must be >= 0")
+        return v
+
+    @field_validator("safe_delete_ratio", "query_bm25_weight")
+    @classmethod
+    def _unit_interval(cls, v: float) -> float:
+        if not 0.0 <= v <= 1.0:
+            raise ValueError("value must be in [0.0, 1.0]")
         return v
 
 

--- a/tests/test_config.py
+++ b/tests/test_config.py
@@ -39,8 +39,17 @@ def _isolate_env(monkeypatch: pytest.MonkeyPatch, tmp_path: Path) -> None:
             "FETCH_INTERVAL_HOURS",
             "CANDIDATES_DB",
             "CHROMA_PATH",
+            "WORKER_DISABLED",
             "ZOTERO_INBOX_COLLECTION",
+            "MAX_EMBED_PER_CYCLE",
+            "SAFE_DELETE_RATIO",
+            "MAX_COST_USD_BACKFILL",
+            "QUERY_BM25_WEIGHT",
             "PDF_SOURCES",
+            "PDF_FETCH_MAX_ATTEMPTS_PER_CANDIDATE",
+            "PDF_FETCH_TIMEOUT_SECONDS",
+            "PDF_FETCH_MAX_MINUTES_WEEKLY",
+            "PDF_FETCH_CIRCUIT_BREAKER_THRESHOLD",
             "DASHBOARD_HOST",
             "DASHBOARD_PORT",
             "MAX_COST_USD_DAILY",
@@ -124,5 +133,79 @@ def test_s2_dashboard_port_rejects_negative(
     monkeypatch: pytest.MonkeyPatch,
 ) -> None:
     monkeypatch.setenv("S2_DASHBOARD_PORT", "0")
+    with pytest.raises(Exception):
+        S2Settings()
+
+
+def test_s2_indexing_and_query_defaults() -> None:
+    """ADR 015 + ADR 017 knobs declared in `.env.example` round-trip through
+    ``Settings()`` instead of being silently dropped by ``extra='ignore'``.
+    """
+    s = S2Settings()
+    assert s.max_embed_per_cycle == 50
+    assert s.safe_delete_ratio == 0.10
+    assert s.max_cost_usd_backfill == 3.0
+    assert s.query_bm25_weight == 0.4
+    assert s.pdf_fetch_max_attempts_per_candidate == 6
+    assert s.pdf_fetch_timeout_seconds == 30
+    assert s.pdf_fetch_max_minutes_weekly == 20
+    assert s.pdf_fetch_circuit_breaker_threshold == 5
+    assert s.worker_disabled is False
+
+
+def test_s2_reads_indexing_env(monkeypatch: pytest.MonkeyPatch) -> None:
+    monkeypatch.setenv("S2_MAX_EMBED_PER_CYCLE", "200")
+    monkeypatch.setenv("S2_SAFE_DELETE_RATIO", "0.05")
+    monkeypatch.setenv("S2_MAX_COST_USD_BACKFILL", "5.0")
+    monkeypatch.setenv("S2_QUERY_BM25_WEIGHT", "0.6")
+    monkeypatch.setenv("S2_PDF_FETCH_CIRCUIT_BREAKER_THRESHOLD", "0")
+    monkeypatch.setenv("S2_WORKER_DISABLED", "true")
+    s = S2Settings()
+    assert s.max_embed_per_cycle == 200
+    assert s.safe_delete_ratio == 0.05
+    assert s.max_cost_usd_backfill == 5.0
+    assert s.query_bm25_weight == 0.6
+    # ``0`` is the documented way to disable the circuit breaker
+    # (plan_02 §10.4), so the non-negative validator must accept it.
+    assert s.pdf_fetch_circuit_breaker_threshold == 0
+    assert s.worker_disabled is True
+
+
+def test_s2_safe_delete_ratio_rejects_out_of_range(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("S2_SAFE_DELETE_RATIO", "1.5")
+    with pytest.raises(Exception):
+        S2Settings()
+
+
+def test_s2_query_bm25_weight_rejects_negative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("S2_QUERY_BM25_WEIGHT", "-0.1")
+    with pytest.raises(Exception):
+        S2Settings()
+
+
+def test_s2_max_embed_per_cycle_rejects_zero(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("S2_MAX_EMBED_PER_CYCLE", "0")
+    with pytest.raises(Exception):
+        S2Settings()
+
+
+def test_s2_circuit_breaker_rejects_negative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("S2_PDF_FETCH_CIRCUIT_BREAKER_THRESHOLD", "-1")
+    with pytest.raises(Exception):
+        S2Settings()
+
+
+def test_s2_max_cost_backfill_rejects_negative(
+    monkeypatch: pytest.MonkeyPatch,
+) -> None:
+    monkeypatch.setenv("S2_MAX_COST_USD_BACKFILL", "-1.0")
     with pytest.raises(Exception):
         S2Settings()


### PR DESCRIPTION
## Summary

- Adds nine S2 knobs that `.env.example` and `plan_02` §12 already document to `zotai.config.S2Settings`, with validators that enforce the documented ranges.
- No runtime code consumes them yet — S2 Sprint 1 (#12) is the first consumer. This PR is pre-emptive so that users who follow `.env.example` today are heard by the settings layer instead of being silently dropped by `extra="ignore"`. Upholds CLAUDE.md's "Fail-loud" principle.
- No changes to docs, Dockerfile, or other subsystems. `mypy --strict` clean on `src/zotai/config.py`. Full suite: **133 passed** (was 126; +7 new tests in `tests/test_config.py`).

### Fields

| Field | Default | Validator | Source |
|---|---|---|---|
| `max_embed_per_cycle` | `50` | `>=1` | ADR 015 §2.1 |
| `safe_delete_ratio` | `0.10` | `[0.0, 1.0]` | ADR 015 §2.1 |
| `max_cost_usd_backfill` | `3.0` | `>=0` | ADR 015 §8 |
| `query_bm25_weight` | `0.4` | `[0.0, 1.0]` | ADR 017 |
| `pdf_fetch_max_attempts_per_candidate` | `6` | `>=1` | plan_02 §10 |
| `pdf_fetch_timeout_seconds` | `30` | `>=1` | plan_02 §10 |
| `pdf_fetch_max_minutes_weekly` | `20` | `>=1` | plan_02 §10 |
| `pdf_fetch_circuit_breaker_threshold` | `5` | `>=0` (0 disables) | plan_02 §10.4 |
| `worker_disabled` | `False` | bool | ADR 012 |

## Motivation

Review de alineación detectó que `.env.example` declara estos nueve env vars y los referencian plan_02, ADR 015 y ADR 017, pero `S2Settings` con `extra="ignore"` los absorbe sin round-trip. Un usuario que setea `S2_SAFE_DELETE_RATIO=0.05` hoy no recibe ninguna señal de que el código lo descarta — es el antipatrón "trabajo silencioso" que `plan_glossary.md` nombra. Agregar los campos ahora cuesta ~30 líneas y reduce deuda cognitiva cuando Sprint 1 arranque.

## Test plan

- [x] `pytest tests/test_config.py` — 13 passed
- [x] `pytest` full suite — 133 passed (was 126; +7 new tests)
- [x] `mypy --strict src/zotai/config.py` — clean
- [x] Verified the 7 new tests cover: defaults, env reads (including `threshold=0` and `worker_disabled=true`), `safe_delete_ratio` out-of-range, `query_bm25_weight` negative, `max_embed_per_cycle=0`, `pdf_fetch_circuit_breaker_threshold=-1`, `max_cost_usd_backfill=-1.0`.
- [ ] S2 Sprint 1 (#12) will consume these in code.

## Related

- ADR 015 — S2 owns the embeddings index (`docs/decisions/015-s2-owns-embeddings-index.md`)
- ADR 017 — Hybrid BM25 + dense retrieval (`docs/decisions/017-hybrid-query-retrieval.md`)
- plan_02 §10 / §12 — PDF cascade knobs + env vars
- #12 — S2 Sprint 1 (first consumer)