### PR TITLE
feat(s1): stage 04 substages 04d + 04e + cascade orchestrator (#6, PR 3/3, closes #6)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,58 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **S1 Stage 04 — substages 04d + 04e + cascade orchestrator `--substage all`**
+  (#6, third of three PRs for Stage 04; closes #6):
+  - **04d — LLM extraction** (`gpt-4o-mini`). `zotai.s1.stage_04_enrich._enrich_04d_one`
+    sends the first two pages of the PDF to
+    `OpenAIClient.extract_metadata` (already wired in Phase 1), parses
+    the JSON response into a new Pydantic schema `LLMExtractedMetadata`
+    (with retry-once on malformed JSON), and maps it to a Zotero
+    payload via `map_llm_extraction_to_zotero`. The mapper's quality
+    gate rejects results with missing title, missing authors, or an
+    `item_type` outside the plan_01 §3.04d allow-list (`journalArticle`,
+    `book`, `bookSection`, `thesis`, `report`, `preprint`,
+    `conferencePaper`). Budget enforcement lives in `OpenAIClient`
+    (`MAX_COST_USD_STAGE_04`, overridable per-run via `--max-cost`);
+    `BudgetExceededError` is caught in the orchestrator so tripping
+    the cap routes remaining items directly to 04e without retrying
+    the LLM.
+  - **04e — Quarantine** (ADR 008). `_enrich_04e_one` ensures a
+    `Quarantine` collection exists on-demand (new
+    `ZoteroClient.create_collections` + `addto_collection` wrappers),
+    tags the orphan with `needs-manual-review`, adds it to the
+    collection, flips `Item.in_quarantine=True`, and writes a purpose-
+    built `reports/quarantine_report_<ts>.csv` with columns `sha256,
+    source_path, text_snippet, reason` — the triage surface plan_01
+    §3.04e prescribes.
+  - **Cascade orchestrator `--substage all`**. Per-item loop walks
+    `04a → 04b → 04c → 04d → 04e`, short-circuiting on the first
+    success. Quarantine is the terminal fallback when all free +
+    paid substages miss. Once the 04d budget trips during an `all`
+    run, the nonlocal `budget_exhausted` flag skips the LLM for
+    remaining items so they go straight to 04e.
+  - **Shared helper `_create_parent_and_reparent`** (extracted in PR
+    2/3) now serves 04a, 04b, 04c, and 04d uniformly: create parent
+    via `map_*_to_zotero` output, ADR 014 dedup on DOI, reparent orphan.
+  - **CLI** `zotai s1 enrich --substage {04a|04b|04c|04d|04e|all}`
+    with working `--max-cost` override; the banner for unsupported
+    values is removed.
+  - **`EnrichStatus`** adds `enriched_04d`, `quarantined_04e`,
+    `budget_exceeded`. **`EnrichResult`** adds `items_enriched_04d`,
+    `items_quarantined`, `quarantine_csv_path: Path | None`.
+  - **ADRs** `005-gpt-4o-mini-tagging-extraction.md` and
+    `008-quarantine-in-s1.md` — retrospective, closing the two
+    plan_00 §5 entries that were pending.
+  - Covered by 13 new tests (34 total in `tests/test_s1/test_stage_04.py`):
+    04d happy path, retry-once on malformed JSON, retries exhausted,
+    budget exceeded, invalid item_type; 04e happy path (collection
+    created, tagged, CSV written), reuses existing Quarantine; cascade
+    early-exit (04a hits → no LLM), cascade falls through to 04d,
+    cascade quarantines on exhaustion, cascade budget-tripped routes
+    remaining items to 04e; three direct mapper tests; Stage aborts
+    cleanly without `OPENAI_API_KEY` on `--substage 04d`. Full suite:
+    **158 passed** (was 145). `mypy --strict` clean on modified files.
+
 - **S1 Stage 04 — substages 04b + 04c** (#6, second of three PRs for
   Stage 04): `zotai.s1.stage_04_enrich.run_enrich(substage="04b")` and
   `run_enrich(substage="04c")` now extend the cascade with title fuzzy

--- a/docs/decisions/005-gpt-4o-mini-tagging-extraction.md
+++ b/docs/decisions/005-gpt-4o-mini-tagging-extraction.md
@@ -1,0 +1,157 @@
+# ADR 005 — `gpt-4o-mini` as the LLM for tagging and extraction
+
+**Status**: Accepted
+**Date**: 2026-04-23
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+Three tasks in the pipeline need an LLM:
+
+- **Stage 01 classifier** (Rama 3 of the academic / non-academic gate,
+  plan_01 §3.1). One JSON-mode call per ambiguous PDF; the prompt is a
+  page-1 snippet and a page-count hint; the response is
+  `{"is_academic", "confidence", "reason"}`.
+- **Stage 04d — LLM extraction** (plan_01 §3 Etapa 04d). One JSON-mode
+  call per item that fell through 04a/b/c; the prompt is the first two
+  pages of the PDF; the response is a schema of
+  `{title, authors, year, item_type, venue, doi, abstract}` that we
+  validate against a Pydantic model and map to a Zotero payload.
+- **Stage 05 — tagging** (plan_01 §3 Etapa 05, not yet implemented).
+  One JSON-mode call per item; the prompt is the paper metadata + the
+  taxonomy; the response is `{tema: [...], metodo: [...]}`.
+
+All three share the same pattern: **short prompt, structured JSON
+response, zero conversational context**. The quality ceiling is
+"recover metadata that's already in the text" or "map an abstract to a
+fixed taxonomy", not "reason from weak signals".
+
+Three candidate models were considered:
+
+- `gpt-4o-mini` — small, cheap, JSON mode, long context.
+- `gpt-4o` — strongest model in the family; much higher cost.
+- Open-weights local model (e.g. Llama-3.1-8B via Ollama) — zero
+  marginal cost but substantial setup + maintenance burden, and
+  the researcher's laptop is the expected deployment environment
+  (not a GPU server).
+
+## Decision
+
+**Use `gpt-4o-mini` as the default for all three JSON-mode tasks.**
+
+Encoded in `.env.example` as `OPENAI_MODEL_TAG=gpt-4o-mini` and
+`OPENAI_MODEL_EXTRACT=gpt-4o-mini`, mirrored in
+`OpenAISettings.model_tag` / `model_extract` with the same default.
+
+Budget caps in `.env`:
+
+- `MAX_COST_USD_STAGE_01=1.00` — the Stage 01 classifier.
+- `MAX_COST_USD_STAGE_04=2.00` — only 04d uses it (04a/b/c are free).
+  **LATAM-heavy corpora** bump this to `~4.00` per plan_01 §3 Etapa 04
+  "Aviso — corpus LATAM-heavy".
+- `MAX_COST_USD_STAGE_05=1.00` — per-paper tagging (Stage 05, future PR).
+
+`BudgetExceededError` in `zotai.api.openai_client` is raised *before*
+the call so no accidental overspend happens. For Stage 04d this error
+is caught in the orchestrator: once tripped, the remaining items route
+directly to 04e (quarantine) without further LLM calls.
+
+## Consequences
+
+### Positive
+
+- **Cost is small enough to ignore for single-user corpora.** The price
+  table in `zotai.api.openai_client._PRICING` (Jan 2026: $0.00015 input
+  / $0.0006 output per 1K tokens) puts a 1000-paper S1 run at well
+  under $2 for the LLM-using stages combined. Empirical observation
+  from Stage 01's classifier on the project owner's own corpus (~1000
+  PDFs): **~$0.12 for the LLM gate**, consistent with the pre-data
+  estimate.
+- **Same client surface across all three stages.** `OpenAIClient` has
+  one `_check_budget` / `_charge` ledger that covers everything; the
+  caller picks the method (`classify_document` / `extract_metadata` /
+  `tag_paper`).
+- **JSON mode removes most adversarial parsing.** Each caller still
+  validates the response (Pydantic schema for 04d; allow-list check
+  for 05's tag IDs), but the shape of the response is never "free-form
+  prose the user has to prompt-engineer around".
+- **Quality is enough for the job.** On 04d's task ("extract metadata
+  already present in the first two pages") `gpt-4o-mini` converges to
+  near the ceiling — the failure mode is almost always "the text
+  isn't in the pages" (bad scan, missing front matter), not "the
+  model couldn't read good text". On 01's classifier the task is
+  trivially above `gpt-4o-mini`'s quality floor.
+
+### Negative / Costs assumed
+
+- **Vendor lock-in on the LLM path.** If OpenAI raises prices >2× or
+  changes the JSON-mode contract, three stages need to migrate. We
+  accept this by keeping `OpenAIClient` narrow (~200 lines) so a
+  swap to an OpenAI-compatible provider (Together, Groq, local vLLM
+  with OpenAI shim) is mechanical.
+- **No use of `gpt-4o` for 04d's "hard" items.** When 04d fails we
+  don't escalate to a bigger model — the item goes to quarantine (ADR
+  008). Rationale: escalation doubles the per-item cost for a
+  population of items where the bottleneck is PDF quality, not model
+  quality. Revisit if empirical data shows a large fraction of
+  quarantine items whose metadata is in the text but `gpt-4o-mini`
+  misread it.
+- **Quality drift on price updates.** OpenAI sometimes reprices models.
+  `_PRICING` in `zotai/api/openai_client.py` hardcodes Jan 2026
+  numbers; update with each release cycle (acknowledged in the module
+  docstring).
+
+## Alternatives considered and discarded
+
+**A. `gpt-4o` as the default.** Discarded. ~16× the cost of
+`gpt-4o-mini` for a quality improvement that is not measurable on
+these three JSON tasks. If anything, the observed failure mode is
+"the information was not in the text we sent" — a larger model
+doesn't help.
+
+**B. `gpt-3.5-turbo`.** Discarded. Cheaper than `gpt-4o-mini` in Jan
+2025 pricing but OpenAI has effectively deprecated it for new
+deployments and JSON mode on it is less reliable. The cost delta
+against `gpt-4o-mini` is small enough to not matter for our volumes.
+
+**C. Local open-weights (Llama-3.1-8B-Instruct via Ollama).** Discarded
+**for v1**. Pros: zero marginal cost, full data control (relevant for
+the paper-contents-in-prompt case in 04d). Cons: (a) the researcher's
+deployment is their laptop, not a GPU server — CPU inference on an
+8B model is slow enough to stretch Stage 04d's walk time from minutes
+to hours; (b) Ollama installation + model download is additional
+onboarding surface for a user who already has to set up Docker,
+Zotero, and an OpenAI key; (c) JSON-mode reliability on 7-8B models
+is not at the level `gpt-4o-mini` offers out of the box. Revisit if
+(i) the owner's next laptop has a capable GPU and (ii) a future
+release of Ollama / llama.cpp lands a comparable structured-output
+mode.
+
+**D. Separate models for 04d and the other stages.** Discarded. A
+single default minimises configuration surface and reasoning about
+cross-stage cost budgeting. If 04d later needs a stronger model, a
+separate ADR can add that branch.
+
+## Observed costs (reference)
+
+Measured on the project owner's corpus after merging PR #48 (Stage
+04a) and before the full Stage 04 cascade:
+
+- Stage 01 classifier: **$0.12** on ~1000 PDFs (below the $1.00 cap).
+- Stage 04d: not yet measured (lands with PR #50's successor).
+  Pre-data estimate from plan_01: ~$0.40 anglo / ~$1.60 LATAM-heavy
+  on a 1000-paper corpus. To be updated here once the first real run
+  lands.
+
+## Relation to other ADRs
+
+- **ADR 004** (`text-embedding-3-large` for embeddings) — orthogonal:
+  this ADR covers chat models, 004 covers embedding models. Both
+  together are captured in `OpenAISettings`.
+- **ADR 008** (Quarantine in S1) — complementary: 04d's "give up and
+  quarantine" path is the reason we don't need a stronger / more
+  expensive model to squeeze a few more items out of the cascade.

--- a/docs/decisions/008-quarantine-in-s1.md
+++ b/docs/decisions/008-quarantine-in-s1.md
@@ -1,0 +1,158 @@
+# ADR 008 — Quarantine collection in S1 instead of all-or-nothing import
+
+**Status**: Accepted
+**Date**: 2026-04-23
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+Stage 04 of S1 runs a cascade (04a-d) that tries progressively more
+expensive sources to recover bibliographic metadata for an orphan PDF
+attachment:
+
+- 04a — identifier regex on pages 1-3, retry Route A via OpenAlex.
+- 04b — fuzzy title match against OpenAlex.
+- 04c — fuzzy title match against Semantic Scholar.
+- 04d — `gpt-4o-mini` extraction from the first two pages of the PDF.
+
+**A non-trivial fraction of the corpus will fall through all four.**
+Empirical upper bounds from plan_01 §3 Etapa 04:
+
+- **<10%** of the corpus for **anglo-dominant** corpora (journal
+  articles indexed by CrossRef / PMC / arXiv).
+- **<25%** for **LATAM-heavy** corpora (CEPAL Review, Desarrollo
+  Económico, Estudios Económicos, BID / CAF / BCRA working papers,
+  SciELO / RedALyC journals) until the v1.1 extension lands with
+  LATAM-specific metadata sources (tracked in issue #46).
+
+The items that fall through are not malformed — they are real papers
+whose metadata happens to be unreachable by our cascade. Common causes:
+pre-2010 books without DOIs, LATAM journals not indexed by OpenAlex,
+reports published outside the academic ecosystem, scans where the
+title page is missing or illegible.
+
+The question is **what to do with those items**:
+
+## Decision
+
+**Keep them in Zotero, but in a separate collection called
+`Quarantine`, tagged `needs-manual-review`.**
+
+Implementation is Stage 04e:
+
+- **Idempotent collection creation.** `_ensure_quarantine_collection`
+  looks up the collection by name (`Quarantine`, configurable in a
+  future revision) and creates it only if absent.
+- **Tagging.** `add_tags(item, [needs-manual-review])` on the orphan
+  attachment. The tag is how the user surfaces them in Zotero Search
+  or exports them via Better BibTeX.
+- **Linking to the collection.** `addto_collection(collection, item)`.
+- **Paper trail.** A dedicated `reports/quarantine_report_<ts>.csv`
+  with columns `(sha256, source_path, text_snippet, reason)` so the
+  user can decide in a single pass whether the item deserves manual
+  research or should be left as-is.
+- **State flag.** `Item.in_quarantine=True`, `stage_completed=4`.
+  Stage 05 (tagging) skips quarantined items because their metadata
+  is insufficient for LLM taxonomy matching.
+
+The Quarantine collection is named in the glossary (`plan_glossary.md`)
+and in the README so the user sees it up-front as an expected outcome,
+not a failure mode.
+
+## Consequences
+
+### Positive
+
+- **Resolves the completeness vs. quality tension.** The "all-or-
+  nothing" alternative either loses low-quality items (completeness
+  loss) or pollutes the main library with stubs (quality loss).
+  Quarantine gives the user both: completeness (every PDF is in Zotero
+  somewhere) and quality (the main library stays clean).
+- **Matches the 1-pass triage the user already does.** The
+  `quarantine_report.csv` is explicitly shaped as a triage list —
+  path + text snippet + reason — so the user can pick the 5% worth
+  chasing down manually and leave the rest alone.
+- **Composable with Stage 06 validation.** Stage 06 reports the
+  quarantine ratio against the thresholds in plan_01 §3 Etapa 04
+  criterion (<10% anglo / <25% LATAM), and nudges the user toward
+  issue #46 if the ratio exceeds the LATAM threshold.
+- **No data loss.** The PDF is already attached in Zotero (Stage 03
+  Route C orphan); quarantine doesn't move or re-upload it, just
+  tags + collection-links.
+- **Scoped negative signal.** A "quarantined" item is not the same as
+  a "failed" item — the user can re-run `zotai s1 enrich --substage
+  all` after adding a new metadata source (e.g. once #46 lands
+  SciELO support) and items move out of quarantine automatically.
+
+### Negative / Costs assumed
+
+- **User cognitive load: a third collection name to understand.** The
+  library now has three reserved names: main (root), `Quarantine`,
+  `Inbox S2`. README + `plan_glossary.md` mitigate by documenting
+  them once, with an explicit sentence that tells the user: "You
+  don't manage these; the system creates and manages them on
+  demand."
+- **Tag name coordination.** `needs-manual-review` is hardcoded in
+  `stage_04_enrich.py`. It's not under `config/taxonomy.yaml`
+  because the researcher's taxonomy and the system's
+  housekeeping tags are orthogonal (the former is their scientific
+  vocabulary; the latter is pipeline metadata). Renaming requires a
+  code change.
+- **Re-running `--substage 04e` is safe but not idempotent at the
+  Zotero level.** `add_tags` and `addto_collection` are both
+  idempotent in effect (Zotero silently dedup-coerces); the stage
+  also checks `Item.in_quarantine` before adding a row to the CSV,
+  so `quarantine_report.csv` only grows on genuinely new
+  quarantinings.
+- **Renaming the Quarantine collection** in Zotero Desktop between
+  runs → the next run creates a new `Quarantine` collection. Same
+  tradeoff as the `Inbox S2` collection (plan_02 §10): the user who
+  renames also changes the env var. Not bundled as a first-class
+  feature today; promoted to one if the use case appears.
+
+## Alternatives considered and discarded
+
+**A. Hard fail: skip items that don't enrich, leave them as orphan
+attachments in the main library.** Discarded. Users would not see the
+trail from Stage 04; the items would look identical to Route-C
+orphans that just hadn't been processed. Any later cascade run
+(e.g. after adding a new metadata source) would re-process them, which
+is fine, but the UX cost in the meantime is high — the user has no
+way to know that 100-250 items in the main library are "stuck" vs.
+"in the normal state before 04 ran".
+
+**B. Tag only, no collection.** Discarded. The tag surfaces items in
+search, but the user's mental model of "where in my Zotero are the
+failures" wants a place, not a filter. Zotero's tag UI is secondary
+to its collection UI, and the user's triage pattern in other tools
+(Rayyan / Covidence) also uses "buckets" (=collections), not tags.
+
+**C. Separate Zotero library.** Discarded. Too heavy — library
+creation is a manual, mult-step Zotero operation, not idempotent via
+the API, and interferes with Better BibTeX / sync setup. Collections
+are the right unit.
+
+**D. LLM quality escalation before quarantine.** I.e., re-run 04d
+with `gpt-4o` (or a longer prompt with the full PDF) on items that
+failed the first 04d attempt. Discarded for v1; revisit with data
+(ADR 005 §Alternatives D). The tradeoff: users pay 10-20× more on
+items that are *probably* unrecoverable (the failure mode is usually
+PDF quality, not model quality), for a single-digit reduction in the
+quarantine fraction.
+
+## Relation to other ADRs
+
+- **ADR 005** (`gpt-4o-mini` for tagging/extraction) — complementary:
+  the bound on 04d's per-item spend is only acceptable because we
+  have a fallback for items the model can't extract.
+- **ADR 010** (Ruta A uses OpenAlex, not Zotero translator) — context:
+  OpenAlex coverage gaps in LATAM are the single biggest driver of
+  items reaching 04e. Issue #46 is the v1.1 fix for that.
+- **ADR 014** (Stage 03 dedup skips attach when existing item has a
+  PDF) — orthogonal: applies on the way in, before Stage 04 runs.
+- **Plan_01** §3 Etapa 04 "Criterio de éxito" thresholds (<10% anglo /
+  <25% LATAM) are directly enforced by this ADR's reporting path.

--- a/src/zotai/api/zotero.py
+++ b/src/zotai/api/zotero.py
@@ -113,5 +113,34 @@ class ZoteroClient:
             return True
         return bool(self._client.add_tags(item, *tags))
 
+    def create_collections(
+        self, payload: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        """Create Zotero collections; returns pyzotero's ``{success, ...}`` shape.
+
+        Each dict must contain a ``name`` key. Used by Stage 04e to ensure
+        the ``Quarantine`` collection exists on-demand (ADR 008).
+        """
+        if self.dry_run:
+            log.info(
+                "zotero.create_collections.dry_run",
+                names=[p.get("name") for p in payload],
+            )
+            return {"success": {}, "unchanged": {}, "failed": {}}
+        return cast(dict[str, Any], self._client.create_collections(payload))
+
+    def addto_collection(
+        self, collection_key: str, item: dict[str, Any]
+    ) -> bool:
+        """Add an existing item to an existing collection."""
+        if self.dry_run:
+            log.info(
+                "zotero.addto_collection.dry_run",
+                collection=collection_key,
+                item_key=item.get("key"),
+            )
+            return True
+        return bool(self._client.addto_collection(collection_key, item))
+
 
 __all__ = ["ZoteroClient"]

--- a/src/zotai/cli.py
+++ b/src/zotai/cli.py
@@ -268,10 +268,11 @@ def s1_enrich(
             "--substage",
             help=(
                 "Which enrichment substage to run. '04a' (identifier "
-                "extraction), '04b' (OpenAlex fuzzy title match), and "
-                "'04c' (Semantic Scholar fuzzy title match) are wired; "
-                "'04d', '04e' and the cascade orchestrator 'all' land in "
-                "the follow-up PR. See plan_01 §3 Etapa 04."
+                "extraction), '04b' (OpenAlex fuzzy), '04c' (Semantic "
+                "Scholar fuzzy), '04d' (gpt-4o-mini extraction — costs "
+                "money, bounded by MAX_COST_USD_STAGE_04), '04e' "
+                "(Quarantine), or 'all' for the full per-item cascade "
+                "04a → 04b → 04c → 04d → 04e. See plan_01 §3 Etapa 04."
             ),
         ),
     ] = "04a",
@@ -280,29 +281,27 @@ def s1_enrich(
         typer.Option(
             "--max-cost",
             help=(
-                "Override MAX_COST_USD_STAGE_04 for this invocation. Only "
-                "applies once 04d (LLM extraction) lands; 04a/04b/04c are free."
+                "Override MAX_COST_USD_STAGE_04 for this invocation "
+                "(hard cap on 04d's LLM spend). Once the budget trips, "
+                "'all' routes remaining items directly to 04e."
             ),
         ),
     ] = None,
 ) -> None:
-    """Stage 04 — enrichment cascade (04a-04e)."""
+    """Stage 04 — enrichment cascade (04a-04e + 'all' orchestrator)."""
     from typing import cast
 
     from zotai.config import Settings
     from zotai.s1.handler import StageAbortedError
     from zotai.s1.stage_04_enrich import EnrichSubstage, run_enrich
 
-    _ = max_cost  # reserved for 04d in follow-up PR
-
     settings = Settings()
     dry_run = bool(ctx.obj.get("dry_run", False)) or settings.behavior.dry_run
 
-    if substage not in ("04a", "04b", "04c"):
+    if substage not in ("04a", "04b", "04c", "04d", "04e", "all"):
         typer.secho(
-            f"Substage '{substage}' is not yet implemented. Supported in "
-            "this PR: '04a' | '04b' | '04c'. '04d' + '04e' + cascade "
-            "orchestrator ('all') land in PR 3/3 of #6.",
+            f"Substage '{substage}' is not valid. Choose one of: "
+            "'04a' | '04b' | '04c' | '04d' | '04e' | 'all'.",
             err=True,
             fg=typer.colors.YELLOW,
         )
@@ -312,20 +311,28 @@ def s1_enrich(
         result = run_enrich(
             substage=cast(EnrichSubstage, substage),
             dry_run=dry_run,
+            max_cost=max_cost,
             settings=settings,
         )
     except StageAbortedError as exc:
         typer.secho(f"Stage aborted: {exc}", err=True, fg=typer.colors.RED)
         raise typer.Exit(code=2) from exc
 
+    quarantine_part = (
+        f" quarantine_csv={result.quarantine_csv_path}"
+        if result.quarantine_csv_path
+        else ""
+    )
     typer.echo(
         f"processed={result.items_processed} failed={result.items_failed} "
         f"enriched_04a={result.items_enriched_04a} "
         f"enriched_04b={result.items_enriched_04b} "
         f"enriched_04c={result.items_enriched_04c} "
+        f"enriched_04d={result.items_enriched_04d} "
+        f"quarantined={result.items_quarantined} "
         f"no_progress={result.items_no_progress} "
         f"skipped_generic_title={result.items_skipped_generic_title} "
-        f"csv={result.csv_path}"
+        f"csv={result.csv_path}{quarantine_part}"
     )
 
 

--- a/src/zotai/s1/stage_04_enrich.py
+++ b/src/zotai/s1/stage_04_enrich.py
@@ -3,45 +3,41 @@
 This stage takes the items that Stage 03 parked as Route C orphan
 attachments (no bibliographic metadata in Zotero beyond the PDF itself)
 and walks them through a falling-through cascade that tries
-progressively more expensive sources to recover the metadata. The
-structure mirrors the spec:
+progressively more expensive sources to recover the metadata:
 
 - **04a** — aggressive identifier extraction on pages 1-3 of the PDF.
   If a *new* DOI is found (one not already in ``Item.detected_doi``),
-  retry Route A from Stage 03: resolve via OpenAlex, map to Zotero,
-  create a parent item, and reparent the existing orphan attachment
-  under it. Free ($0).
-- **04b** — fuzzy title match against OpenAlex. (Pending PR.)
-- **04c** — fuzzy title match against Semantic Scholar. (Pending PR.)
-- **04d** — LLM extraction with ``gpt-4o-mini``. Costs ~$0.0004/paper.
-  (Pending PR.)
-- **04e** — Quarantine. Move to the ``Quarantine`` collection and tag
-  ``needs-manual-review``. (Pending PR.)
+  retry Route A from Stage 03 via OpenAlex. Free ($0).
+- **04b** — fuzzy title match against OpenAlex
+  (``rapidfuzz.fuzz.token_set_ratio >= 85``). Free ($0).
+- **04c** — fuzzy title match against Semantic Scholar. Free ($0).
+- **04d** — LLM (``gpt-4o-mini``) JSON extraction from the first two
+  pages, validated against :class:`LLMExtractedMetadata`. Bounded by
+  ``MAX_COST_USD_STAGE_04`` (ADR 005). Once the budget trips, remaining
+  items route directly to 04e without further LLM calls.
+- **04e** — Quarantine: tag ``needs-manual-review``, add to the
+  ``Quarantine`` collection, append to ``quarantine_report.csv`` (ADR
+  008).
 
-This module lands **only 04a** plus the scaffolding (types, CSV
-writer, ``run_enrich`` entry point). Other substages ship in
-follow-up PRs:
-
-- 04b + 04c in the second PR
-- 04d + 04e + the full cascade orchestrator + ADRs 005 / 008 in the
-  third
-
-Until the cascade orchestrator lands, the CLI (``zotai s1 enrich``)
-stays stubbed — partial cascades exposed to the user invite foot-
-gunning. Tests drive ``run_enrich(substage="04a")`` directly.
+``run_enrich(substage="all")`` drives the per-item cascade end-to-end;
+individual substages are callable directly for debugging or partial
+runs. On a successful hit (04a-04d) the item advances to
+``stage_completed=4, import_route='A'``; on quarantine (04e) the item
+advances to ``stage_completed=4, in_quarantine=True``.
 
 ---
 
 Cross-cutting rules (match Stage 03):
 
 - **Idempotent.** Items whose ``import_route`` is already ``'A'`` or
-  that have ``stage_completed >= 4`` are skipped.
+  that have ``stage_completed >= 4`` are skipped by ``_select_eligible``.
 - **Dedup on DOI.** If a new DOI resolves to a Zotero item the user
   already has, reuse its key rather than creating a parallel item.
   Same policy as Stage 03 (ADR 014): attach iff the existing parent
   has no PDF yet.
 - **Dry-run.** No Zotero writes, no DB writes, ``_dryrun``-suffixed
-  CSV. Network probes still run (OpenAlex lookups are cheap reads).
+  CSV. Network probes still run (OpenAlex/SemanticScholar lookups are
+  cheap reads).
 - **Fail-loud.** Per-item failures get logged and recorded in the CSV
   with ``status='failed'`` and an error string, but do not abort the
   stage. Aborting is handled by the standard handler.
@@ -59,10 +55,12 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final, Literal
 
+from pydantic import BaseModel, Field, ValidationError
 from rapidfuzz import fuzz
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, select
 
+from zotai.api.openai_client import BudgetExceededError, OpenAIClient
 from zotai.api.openalex import OpenAlexClient
 from zotai.api.semantic_scholar import SemanticScholarClient
 from zotai.api.zotero import ZoteroClient
@@ -79,10 +77,12 @@ from zotai.utils.fs import ensure_dir
 from zotai.utils.logging import bind, get_logger
 from zotai.utils.pdf import extract_probable_title, extract_text_pages
 
-# TODO(refactor): _find_existing_doi and _existing_has_pdf_attachment
-# are reused across Stage 03 + 04a. A follow-up PR should extract them
-# into `zotai.api.zotero_queries` (or similar). Not done here to keep
-# this PR focused on Stage 04a.
+# TODO(refactor): _find_existing_doi, _existing_has_pdf_attachment, and
+# _split_name are now reused across Stage 03 and every 04 substage via
+# _create_parent_and_reparent. A follow-up chore PR should promote them
+# to `zotai.api.zotero_queries` (or similar) and drop the noqa imports
+# below. Deferred — trivial, not worth mixing with Stage 04 feature
+# work; pick up when Stage 05 lands (it will want the same helpers).
 
 log = get_logger(__name__)
 
@@ -92,6 +92,37 @@ _PAGES_FOR_ID_EXTRACTION: Final[int] = 3
 # plan_01 §3 Stage 04b/c: ``rapidfuzz.fuzz.token_set_ratio >= 85`` gates
 # every fuzzy title match. Common constant avoids drift between 04b and 04c.
 _FUZZ_THRESHOLD: Final[int] = 85
+# Stage 04d sends the first two pages to the LLM — enough for the title
+# + authors + abstract to be visible on a typical first-page layout.
+_PAGES_FOR_LLM_EXTRACTION: Final[int] = 2
+# 04d JSON mode — retry once if the first response fails validation
+# (malformed JSON, missing fields, off-schema item_type). After the
+# retry we fall through to 04e (quarantine).
+_LLM_MAX_RETRIES: Final[int] = 1
+# Zotero item types the LLM is allowed to emit (plan_01 §3 Stage 04d).
+# Keeps 04d's output on the small set that `map_llm_extraction_to_zotero`
+# maps directly without a lookup table.
+_LLM_ALLOWED_ITEM_TYPES: Final[frozenset[str]] = frozenset(
+    {
+        "journalArticle",
+        "book",
+        "bookSection",
+        "thesis",
+        "report",
+        "preprint",
+        "conferencePaper",
+    }
+)
+# Stage 04e — Quarantine.
+_QUARANTINE_COLLECTION_NAME: Final[str] = "Quarantine"
+_QUARANTINE_TAG: Final[str] = "needs-manual-review"
+_QUARANTINE_CSV_COLUMNS: Final[tuple[str, ...]] = (
+    "sha256",
+    "source_path",
+    "text_snippet",
+    "reason",
+)
+_QUARANTINE_SNIPPET_CHARS: Final[int] = 200
 
 _CSV_COLUMNS: Final[tuple[str, ...]] = (
     "sha256",
@@ -104,19 +135,22 @@ _CSV_COLUMNS: Final[tuple[str, ...]] = (
     "error",
 )
 
-EnrichSubstage = Literal["04a", "04b", "04c", "04d", "04e"]
+EnrichSubstage = Literal["04a", "04b", "04c", "04d", "04e", "all"]
 EnrichStatus = Literal[
     "enriched_04a",
     "enriched_04b",
     "enriched_04c",
+    "enriched_04d",
+    "quarantined_04e",
     "no_progress",
     "skipped_already_enriched",
     "skipped_generic_title",
+    "budget_exceeded",
     "failed",
     "dry_run",
 ]
 _ENRICHED_STATUSES: Final[frozenset[str]] = frozenset(
-    {"enriched_04a", "enriched_04b", "enriched_04c"}
+    {"enriched_04a", "enriched_04b", "enriched_04c", "enriched_04d"}
 )
 
 
@@ -171,9 +205,14 @@ class EnrichResult:
     items_enriched_04a: int
     items_enriched_04b: int
     items_enriched_04c: int
+    items_enriched_04d: int
+    items_quarantined: int
     items_no_progress: int
     items_skipped: int
     items_skipped_generic_title: int
+    # Path of the quarantine_report.csv (plan_01 §3.04e). ``None`` when
+    # no item was quarantined in this run.
+    quarantine_csv_path: Path | None = None
 
 
 def _utc_now() -> datetime:
@@ -882,6 +921,439 @@ async def _enrich_04c_one(
     )
 
 
+# ─── LLM extraction (04d) ────────────────────────────────────────────────
+
+
+class _LLMAuthor(BaseModel):
+    """One author name as the LLM emits it."""
+
+    first: str = ""
+    last: str = ""
+
+
+class LLMExtractedMetadata(BaseModel):
+    """Pydantic schema for the JSON the LLM returns in substage 04d.
+
+    Fields default to empty / None so a partial response that
+    Pydantic accepts still lets us run the quality gate on top of it.
+    The gate lives in :func:`map_llm_extraction_to_zotero`, not here.
+    """
+
+    title: str | None = None
+    authors: list[_LLMAuthor] = Field(default_factory=list)
+    year: int | None = None
+    item_type: str | None = None
+    venue: str | None = None
+    doi: str | None = None
+    abstract: str | None = None
+
+
+def map_llm_extraction_to_zotero(
+    extracted: LLMExtractedMetadata,
+) -> dict[str, Any] | None:
+    """Map an LLM extraction to a Zotero item payload.
+
+    Returns ``None`` when the quality gate fails — missing title, missing
+    authors, or an ``item_type`` not in :data:`_LLM_ALLOWED_ITEM_TYPES`.
+    Callers that receive ``None`` fall through to 04e (quarantine).
+    """
+    title = (extracted.title or "").strip()
+    if not title:
+        return None
+
+    creators: list[dict[str, str]] = []
+    for author in extracted.authors:
+        first = author.first.strip()
+        last = author.last.strip()
+        if not first and not last:
+            continue
+        creators.append(
+            {"creatorType": "author", "firstName": first, "lastName": last}
+        )
+    if not creators:
+        return None
+
+    item_type = (extracted.item_type or "").strip() or "journalArticle"
+    if item_type not in _LLM_ALLOWED_ITEM_TYPES:
+        return None
+
+    date_str = str(extracted.year) if isinstance(extracted.year, int) else ""
+    venue = (extracted.venue or "").strip()
+    abstract = (extracted.abstract or "").strip()
+    doi = (extracted.doi or "").strip()
+
+    payload: dict[str, Any] = {
+        "itemType": item_type,
+        "title": title,
+        "creators": creators,
+        "date": date_str,
+        "abstractNote": abstract,
+    }
+    if doi:
+        payload["DOI"] = doi
+    if venue:
+        payload["publicationTitle"] = venue
+    return payload
+
+
+def _parse_llm_response(usage: Any) -> LLMExtractedMetadata | None:
+    """Parse the LLM's ``UsageRecord.response`` into :class:`LLMExtractedMetadata`.
+
+    Returns ``None`` on malformed JSON or schema mismatch — callers retry
+    once, then fall through to 04e.
+    """
+    response = getattr(usage, "response", None)
+    choices = getattr(response, "choices", None) or []
+    if not choices:
+        return None
+    message = getattr(choices[0], "message", None)
+    content = getattr(message, "content", None) if message is not None else None
+    if not isinstance(content, str) or not content:
+        return None
+    try:
+        raw = json.loads(content)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return LLMExtractedMetadata.model_validate(raw)
+    except ValidationError:
+        return None
+
+
+async def _enrich_04d_one(
+    item: Item,
+    *,
+    staging_folder: Path,
+    zotero_client: ZoteroClient,
+    openai_client: OpenAIClient,
+    dry_run: bool,
+) -> tuple[EnrichRow, dict[str, Any] | None]:
+    """04d for a single item: first 2 pages → LLM JSON → Zotero.
+
+    Budget enforcement lives inside ``openai_client``; a ``BudgetExceeded
+    Error`` bubbles up so the orchestrator can short-circuit the rest of
+    the cascade. Per-call JSON parsing retries once; after that the item
+    falls through to 04e as ``no_progress``.
+    """
+    pdf_path = _pdf_for_text(item, staging_folder)
+    if not pdf_path.exists():
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"pdf_missing:{pdf_path}",
+            ),
+            None,
+        )
+
+    try:
+        pages = extract_text_pages(pdf_path, max_pages=_PAGES_FOR_LLM_EXTRACTION)
+    except Exception as exc:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"pdf_extract:{type(exc).__name__}:{exc}",
+            ),
+            None,
+        )
+    text = "\n".join(pages).strip()
+    if not text:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="no_progress",
+                error="empty_pdf_text",
+            ),
+            None,
+        )
+
+    extracted: LLMExtractedMetadata | None = None
+    last_error: str | None = None
+    for _attempt in range(_LLM_MAX_RETRIES + 1):
+        try:
+            usage = await openai_client.extract_metadata(text=text)
+        except BudgetExceededError:
+            # Propagate: the orchestrator routes remaining items to 04e.
+            raise
+        except Exception as exc:
+            last_error = f"openai_error:{type(exc).__name__}:{exc}"
+            continue
+        extracted = _parse_llm_response(usage)
+        if extracted is not None:
+            break
+        last_error = "llm_json_invalid"
+
+    if extracted is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="no_progress",
+                error=last_error or "llm_no_extraction",
+            ),
+            None,
+        )
+
+    payload = map_llm_extraction_to_zotero(extracted)
+    if payload is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="no_progress",
+                error="quality_gate_failed",
+            ),
+            None,
+        )
+
+    doi = (extracted.doi or "").strip() or None
+    parent_key, error = await _create_parent_and_reparent(
+        item,
+        payload,
+        doi=doi,
+        zotero_client=zotero_client,
+        dry_run=dry_run,
+    )
+    if error is not None or parent_key is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=doi,
+                status="failed",
+                error=error,
+            ),
+            None,
+        )
+
+    status: EnrichStatus = "dry_run" if dry_run else "enriched_04d"
+    return (
+        EnrichRow(
+            sha256=item.id,
+            source_path=item.source_path,
+            zotero_item_key_before=item.zotero_item_key,
+            zotero_item_key_after=parent_key,
+            substage_resolved="04d",
+            new_doi=doi,
+            status=status,
+            error=None,
+        ),
+        payload,
+    )
+
+
+# ─── Quarantine (04e) ────────────────────────────────────────────────────
+
+
+def _ensure_quarantine_collection(
+    zotero_client: ZoteroClient, name: str = _QUARANTINE_COLLECTION_NAME
+) -> str | None:
+    """Return the Zotero key of the quarantine collection, creating it if needed.
+
+    Idempotent: looks up by ``name`` first, creates only if absent. Returns
+    ``None`` when the client is in dry-run mode so 04e can still record the
+    intent without hitting the API.
+    """
+    if zotero_client.dry_run:
+        return None
+    for col in zotero_client.collections():
+        data = col.get("data") or {}
+        if data.get("name") == name:
+            key = col.get("key") or data.get("key")
+            if isinstance(key, str) and key:
+                return key
+    created = zotero_client.create_collections([{"name": name}])
+    success = created.get("success") or {}
+    if isinstance(success, dict):
+        for key in success.values():
+            if isinstance(key, str) and key:
+                return key
+    return None
+
+
+async def _enrich_04e_one(
+    item: Item,
+    *,
+    staging_folder: Path,
+    zotero_client: ZoteroClient,
+    quarantine_collection_key: str | None,
+    last_error: str | None,
+    dry_run: bool,
+) -> tuple[EnrichRow, str]:
+    """Move the orphan into the Quarantine collection and tag it.
+
+    Returns the row and the short text snippet used for the
+    ``quarantine_report.csv`` (plan_01 §3.04e). Never raises on Zotero
+    write failures — surfaces them in the row instead so the rest of the
+    batch keeps moving.
+    """
+    orphan_key = item.zotero_item_key
+    pdf_path = _pdf_for_text(item, staging_folder)
+    snippet = ""
+    if pdf_path.exists():
+        try:
+            pages = extract_text_pages(pdf_path, max_pages=1)
+            if pages:
+                snippet = pages[0].strip().replace("\n", " ")[
+                    :_QUARANTINE_SNIPPET_CHARS
+                ]
+        except Exception as exc:
+            log.warning(
+                "stage_04e.snippet_extract_failed",
+                sha256=item.id,
+                error=str(exc),
+            )
+
+    if orphan_key is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=None,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error="orphan_key_missing",
+            ),
+            snippet,
+        )
+
+    if dry_run:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=orphan_key,
+                zotero_item_key_after=orphan_key,
+                substage_resolved="04e",
+                new_doi=None,
+                status="dry_run",
+                error=last_error,
+            ),
+            snippet,
+        )
+
+    # Fetch current orphan so add_tags / addto_collection get the latest version.
+    try:
+        orphan = zotero_client.item(orphan_key)
+    except Exception as exc:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=orphan_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"fetch_orphan:{type(exc).__name__}:{exc}",
+            ),
+            snippet,
+        )
+
+    try:
+        zotero_client.add_tags(orphan, [_QUARANTINE_TAG])
+    except Exception as exc:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=orphan_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"add_tags:{type(exc).__name__}:{exc}",
+            ),
+            snippet,
+        )
+
+    if quarantine_collection_key is not None:
+        try:
+            zotero_client.addto_collection(quarantine_collection_key, orphan)
+        except Exception as exc:
+            return (
+                EnrichRow(
+                    sha256=item.id,
+                    source_path=item.source_path,
+                    zotero_item_key_before=orphan_key,
+                    zotero_item_key_after=None,
+                    substage_resolved=None,
+                    new_doi=None,
+                    status="failed",
+                    error=f"addto_collection:{type(exc).__name__}:{exc}",
+                ),
+                snippet,
+            )
+
+    return (
+        EnrichRow(
+            sha256=item.id,
+            source_path=item.source_path,
+            zotero_item_key_before=orphan_key,
+            zotero_item_key_after=orphan_key,
+            substage_resolved="04e",
+            new_doi=None,
+            status="quarantined_04e",
+            error=last_error,
+        ),
+        snippet,
+    )
+
+
+def _quarantine_csv_path(reports_dir: Path, *, dry_run: bool, now: datetime) -> Path:
+    suffix = "_dryrun" if dry_run else ""
+    timestamp = now.strftime("%Y%m%d_%H%M%S")
+    return reports_dir / f"quarantine_report_{timestamp}{suffix}.csv"
+
+
+def _write_quarantine_csv(
+    path: Path, rows: Iterable[tuple[EnrichRow, str]]
+) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(_QUARANTINE_CSV_COLUMNS))
+        writer.writeheader()
+        for row, snippet in rows:
+            writer.writerow(
+                {
+                    "sha256": row.sha256,
+                    "source_path": row.source_path,
+                    "text_snippet": snippet,
+                    "reason": row.error or "cascade_exhausted",
+                }
+            )
+
+
 # ─── Eligible-items query ─────────────────────────────────────────────────
 
 
@@ -903,34 +1375,41 @@ def run_enrich(
     *,
     substage: EnrichSubstage = "04a",
     dry_run: bool = False,
+    max_cost: float | None = None,
     settings: Settings | None = None,
     engine: Engine | None = None,
     zotero_client: ZoteroClient | None = None,
     openalex_client: OpenAlexClient | None = None,
     semantic_scholar_client: SemanticScholarClient | None = None,
+    openai_client: OpenAIClient | None = None,
     sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
     now: Callable[[], datetime] = _utc_now,
 ) -> EnrichResult:
-    """Run one substage of the enrichment cascade.
+    """Run one substage (or the full cascade) of Stage 04.
 
-    ``04a`` (identifier extraction + OpenAlex DOI retry), ``04b`` (title
-    fuzzy match against OpenAlex), and ``04c`` (title fuzzy match against
-    Semantic Scholar) are wired. ``04d`` (LLM extraction) and ``04e``
-    (quarantine) raise ``NotImplementedError`` until PR 3/3 of issue #6.
+    ``04a`` — identifier extraction + OpenAlex DOI retry.
+    ``04b`` — title fuzzy match against OpenAlex.
+    ``04c`` — title fuzzy match against Semantic Scholar.
+    ``04d`` — LLM (``gpt-4o-mini``) extraction with budget enforcement
+    (``MAX_COST_USD_STAGE_04``, overridable via ``max_cost``).
+    ``04e`` — Quarantine: tag ``needs-manual-review`` + move to the
+    Quarantine collection + append to ``quarantine_report.csv``.
+    ``all`` — per-item cascade 04a → 04b → 04c → 04d → 04e.
+
+    Once 04d's budget is exhausted during an ``all`` or ``04d`` run, the
+    remaining items route directly to 04e without retrying the LLM.
     """
-    if substage in ("04d", "04e"):
-        raise NotImplementedError(
-            f"Substage {substage} not yet implemented — '04a', '04b', '04c' only."
-        )
     return asyncio.run(
         _run_enrich_async(
             substage=substage,
             dry_run=dry_run,
+            max_cost=max_cost,
             settings=settings,
             engine=engine,
             zotero_client=zotero_client,
             openalex_client=openalex_client,
             semantic_scholar_client=semantic_scholar_client,
+            openai_client=openai_client,
             sleep=sleep,
             now=now,
         )
@@ -941,15 +1420,17 @@ async def _run_enrich_async(
     *,
     substage: EnrichSubstage,
     dry_run: bool,
+    max_cost: float | None,
     settings: Settings | None,
     engine: Engine | None,
     zotero_client: ZoteroClient | None,
     openalex_client: OpenAlexClient | None,
     semantic_scholar_client: SemanticScholarClient | None,
+    openai_client: OpenAIClient | None,
     sleep: Callable[[float], Awaitable[None]],
     now: Callable[[], datetime],
 ) -> EnrichResult:
-    _ = sleep  # reserved for future batch pacing; not needed for the free substages
+    _ = sleep  # reserved for future batch pacing
     settings = settings or Settings()
     if engine is None:
         engine = make_s1_engine(str(settings.paths.state_db))
@@ -971,12 +1452,127 @@ async def _run_enrich_async(
         ss_key = settings.semantic_scholar.api_key.get_secret_value() or None
         semantic_scholar_client = SemanticScholarClient(api_key=ss_key)
 
+    # 04d / "all" need the OpenAI client + a budget. Build lazily so the
+    # free substages don't require ``OPENAI_API_KEY``.
+    needs_llm = substage in ("04d", "all")
+    if needs_llm and openai_client is None:
+        openai_api_key = settings.openai.api_key.get_secret_value()
+        if not openai_api_key:
+            raise StageAbortedError(
+                "Substage 04d / 'all' requires OPENAI_API_KEY. Set it in .env "
+                "or pass openai_client explicitly."
+            )
+        budget = (
+            max_cost if max_cost is not None else settings.budgets.max_cost_usd_stage_04
+        )
+        openai_client = OpenAIClient(api_key=openai_api_key, budget_usd=budget)
+
+    # 04e / "all" may quarantine items; look up the collection once.
+    needs_quarantine = substage in ("04e", "all")
+    quarantine_collection_key: str | None = None
+    if needs_quarantine:
+        quarantine_collection_key = _ensure_quarantine_collection(zotero_client)
+
     run = Run(stage=_STAGE, status="running", started_at=now())
     rows: list[EnrichRow] = []
+    quarantine_rows: list[tuple[EnrichRow, str]] = []
     staging_folder = settings.paths.staging_folder
 
     bind(stage=_STAGE, dry_run=dry_run, substage=substage)
     log.info("stage_started", substage=substage)
+
+    # Tracks whether 04d's budget has been exhausted during the current run;
+    # once tripped, remaining items route directly to 04e without retrying
+    # the LLM (cheaper than catching BudgetExceededError on every item).
+    budget_exhausted = False
+
+    async def _run_per_item_cascade(
+        item: Item,
+    ) -> tuple[EnrichRow, dict[str, Any] | None, str | None]:
+        """Walk an item through 04a → 04b → 04c → 04d → 04e.
+
+        Returns ``(row, mapped_payload, last_error)``. ``mapped_payload``
+        is set only on a successful enrichment; ``last_error`` carries the
+        most recent non-progress reason for the quarantine_report.csv.
+        """
+        nonlocal budget_exhausted
+        last_error: str | None = None
+
+        # 04a
+        row_a, mapped_a = await _enrich_04a_one(
+            item,
+            staging_folder=staging_folder,
+            zotero_client=zotero_client,
+            openalex_client=openalex_client,
+            dry_run=dry_run,
+        )
+        if row_a.status in _ENRICHED_STATUSES or row_a.status == "dry_run":
+            return row_a, mapped_a, None
+        if row_a.status == "failed":
+            return row_a, None, row_a.error
+        last_error = row_a.error
+
+        # 04b
+        row_b, mapped_b = await _enrich_04b_one(
+            item,
+            staging_folder=staging_folder,
+            zotero_client=zotero_client,
+            openalex_client=openalex_client,
+            dry_run=dry_run,
+        )
+        if row_b.status in _ENRICHED_STATUSES or row_b.status == "dry_run":
+            return row_b, mapped_b, None
+        if row_b.status == "failed":
+            return row_b, None, row_b.error
+        last_error = row_b.error or last_error
+
+        # 04c
+        row_c, mapped_c = await _enrich_04c_one(
+            item,
+            staging_folder=staging_folder,
+            zotero_client=zotero_client,
+            semantic_scholar_client=semantic_scholar_client,
+            dry_run=dry_run,
+        )
+        if row_c.status in _ENRICHED_STATUSES or row_c.status == "dry_run":
+            return row_c, mapped_c, None
+        if row_c.status == "failed":
+            return row_c, None, row_c.error
+        last_error = row_c.error or last_error
+
+        # 04d (skip if budget already tripped earlier in the run)
+        if not budget_exhausted and openai_client is not None:
+            try:
+                row_d, mapped_d = await _enrich_04d_one(
+                    item,
+                    staging_folder=staging_folder,
+                    zotero_client=zotero_client,
+                    openai_client=openai_client,
+                    dry_run=dry_run,
+                )
+            except BudgetExceededError as exc:
+                log.warning("stage_04d.budget_exceeded", error=str(exc))
+                budget_exhausted = True
+                last_error = f"budget_exceeded:{exc}"
+            else:
+                if row_d.status in _ENRICHED_STATUSES or row_d.status == "dry_run":
+                    return row_d, mapped_d, None
+                if row_d.status == "failed":
+                    return row_d, None, row_d.error
+                last_error = row_d.error or last_error
+
+        # 04e (quarantine)
+        row_e, snippet = await _enrich_04e_one(
+            item,
+            staging_folder=staging_folder,
+            zotero_client=zotero_client,
+            quarantine_collection_key=quarantine_collection_key,
+            last_error=last_error,
+            dry_run=dry_run,
+        )
+        if row_e.status == "quarantined_04e":
+            quarantine_rows.append((row_e, snippet))
+        return row_e, None, last_error
 
     with Session(engine) as session:
         if not dry_run:
@@ -1012,7 +1608,45 @@ async def _run_enrich_async(
                         semantic_scholar_client=semantic_scholar_client,
                         dry_run=dry_run,
                     )
-                else:  # pragma: no cover — 04d/04e filtered upstream.
+                elif substage == "04d":
+                    assert openai_client is not None  # needs_llm branch built it
+                    try:
+                        row, mapped = await _enrich_04d_one(
+                            item,
+                            staging_folder=staging_folder,
+                            zotero_client=zotero_client,
+                            openai_client=openai_client,
+                            dry_run=dry_run,
+                        )
+                    except BudgetExceededError as exc:
+                        log.warning("stage_04d.budget_exceeded", error=str(exc))
+                        budget_exhausted = True
+                        row = EnrichRow(
+                            sha256=item.id,
+                            source_path=item.source_path,
+                            zotero_item_key_before=item.zotero_item_key,
+                            zotero_item_key_after=None,
+                            substage_resolved=None,
+                            new_doi=None,
+                            status="budget_exceeded",
+                            error=str(exc),
+                        )
+                        mapped = None
+                elif substage == "04e":
+                    row, snippet = await _enrich_04e_one(
+                        item,
+                        staging_folder=staging_folder,
+                        zotero_client=zotero_client,
+                        quarantine_collection_key=quarantine_collection_key,
+                        last_error=item.last_error,
+                        dry_run=dry_run,
+                    )
+                    mapped = None
+                    if row.status == "quarantined_04e":
+                        quarantine_rows.append((row, snippet))
+                elif substage == "all":
+                    row, mapped, _last = await _run_per_item_cascade(item)
+                else:  # pragma: no cover — typer blocks the unknown values upstream
                     raise NotImplementedError(
                         f"Unreachable substage {substage} inside dispatcher."
                     )
@@ -1030,11 +1664,23 @@ async def _run_enrich_async(
                         item.last_error = None
                         item.updated_at = now()
                     run.items_processed += 1
+                elif row.status == "quarantined_04e":
+                    if not dry_run:
+                        item.in_quarantine = True
+                        item.stage_completed = max(item.stage_completed, _STAGE)
+                        item.last_error = row.error
+                        item.updated_at = now()
+                    run.items_processed += 1
                 elif row.status == "dry_run":
                     pass
-                elif row.status in ("no_progress", "skipped_generic_title"):
-                    # No state change — item waits for the next substage.
-                    pass
+                elif row.status in (
+                    "no_progress",
+                    "skipped_generic_title",
+                    "budget_exceeded",
+                ):
+                    if not dry_run and row.error:
+                        item.last_error = row.error
+                        item.updated_at = now()
                 elif row.status == "failed":
                     if not dry_run:
                         item.last_error = row.error
@@ -1058,8 +1704,16 @@ async def _run_enrich_async(
         items_failed = run.items_failed
 
     reports_folder = ensure_dir(settings.paths.reports_folder)
-    csv_path = _csv_path(reports_folder, dry_run=dry_run, now=now())
+    csv_now = now()
+    csv_path = _csv_path(reports_folder, dry_run=dry_run, now=csv_now)
     _write_csv(csv_path, rows)
+
+    quarantine_csv_path: Path | None = None
+    if quarantine_rows:
+        quarantine_csv_path = _quarantine_csv_path(
+            reports_folder, dry_run=dry_run, now=csv_now
+        )
+        _write_quarantine_csv(quarantine_csv_path, quarantine_rows)
 
     result = EnrichResult(
         run_id=run_id,
@@ -1070,6 +1724,8 @@ async def _run_enrich_async(
         items_enriched_04a=sum(1 for r in rows if r.status == "enriched_04a"),
         items_enriched_04b=sum(1 for r in rows if r.status == "enriched_04b"),
         items_enriched_04c=sum(1 for r in rows if r.status == "enriched_04c"),
+        items_enriched_04d=sum(1 for r in rows if r.status == "enriched_04d"),
+        items_quarantined=sum(1 for r in rows if r.status == "quarantined_04e"),
         items_no_progress=sum(1 for r in rows if r.status == "no_progress"),
         items_skipped=sum(
             1 for r in rows if r.status == "skipped_already_enriched"
@@ -1077,6 +1733,7 @@ async def _run_enrich_async(
         items_skipped_generic_title=sum(
             1 for r in rows if r.status == "skipped_generic_title"
         ),
+        quarantine_csv_path=quarantine_csv_path,
     )
     log.info(
         "stage_finished",
@@ -1085,9 +1742,12 @@ async def _run_enrich_async(
         enriched_04a=result.items_enriched_04a,
         enriched_04b=result.items_enriched_04b,
         enriched_04c=result.items_enriched_04c,
+        enriched_04d=result.items_enriched_04d,
+        quarantined=result.items_quarantined,
         no_progress=result.items_no_progress,
         skipped_generic_title=result.items_skipped_generic_title,
         csv=str(csv_path),
+        quarantine_csv=str(quarantine_csv_path) if quarantine_csv_path else None,
     )
     return result
 
@@ -1097,6 +1757,8 @@ __all__ = [
     "EnrichRow",
     "EnrichStatus",
     "EnrichSubstage",
+    "LLMExtractedMetadata",
+    "map_llm_extraction_to_zotero",
     "map_semantic_scholar_to_zotero",
     "run_enrich",
 ]

--- a/tests/test_s1/test_stage_04.py
+++ b/tests/test_s1/test_stage_04.py
@@ -1,34 +1,44 @@
-"""Tests for :mod:`zotai.s1.stage_04_enrich` — substages 04a, 04b, 04c.
+"""Tests for :mod:`zotai.s1.stage_04_enrich` — substages 04a-04e + cascade.
 
 Structure mirrors ``test_stage_03.py``: a fake ``ZoteroClient`` records
-every call; fake ``OpenAlexClient`` / ``SemanticScholarClient`` return
-scripted responses. Tests drive :func:`run_enrich` (sync wrapper) with
-the substage under test.
+every call; fake ``OpenAlexClient`` / ``SemanticScholarClient`` /
+``OpenAIClient`` return scripted responses. Tests drive :func:`run_enrich`
+(sync wrapper) with the substage under test.
 
 Covered substages:
 
 - **04a** — identifier regex + OpenAlex DOI retry (from PR 1/3).
 - **04b** — OpenAlex fuzzy title match (PR 2/3).
 - **04c** — Semantic Scholar fuzzy title match (PR 2/3).
+- **04d** — LLM JSON extraction via ``gpt-4o-mini`` (PR 3/3).
+- **04e** — Quarantine: tag + collection + separate report CSV (PR 3/3).
+- **all** — Per-item cascade through every substage with budget awareness (PR 3/3).
 """
 
 from __future__ import annotations
 
+import json
 from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 
 from sqlmodel import Session, select
 
+from zotai.api.openai_client import BudgetExceededError
 from zotai.config import PathSettings, Settings, ZoteroSettings
-from zotai.s1.stage_04_enrich import map_semantic_scholar_to_zotero, run_enrich
+from zotai.s1.stage_04_enrich import (
+    LLMExtractedMetadata,
+    map_llm_extraction_to_zotero,
+    map_semantic_scholar_to_zotero,
+    run_enrich,
+)
 from zotai.state import Item, init_s1, make_s1_engine
 
 # ─── Fakes ─────────────────────────────────────────────────────────────────
 
 
 class FakeZoteroClient:
-    """Minimal in-memory stand-in for ``ZoteroClient``. Covers the 04a surface."""
+    """Minimal in-memory stand-in for ``ZoteroClient``. Covers 04a-04e surface."""
 
     def __init__(
         self,
@@ -36,16 +46,21 @@ class FakeZoteroClient:
         existing: list[dict[str, Any]] | None = None,
         existing_children: dict[str, list[dict[str, Any]]] | None = None,
         orphans: dict[str, dict[str, Any]] | None = None,
+        existing_collections: list[dict[str, Any]] | None = None,
     ) -> None:
         self._existing = existing or []
         self._existing_children = existing_children or {}
         self._orphans = orphans or {}
+        self._collections: list[dict[str, Any]] = list(existing_collections or [])
         self.dry_run = False
         self.created_items: list[dict[str, Any]] = []
         self.items_calls: list[dict[str, Any]] = []
         self.children_calls: list[str] = []
         self.item_fetch_calls: list[str] = []
         self.updated_items: list[dict[str, Any]] = []
+        self.created_collections: list[dict[str, Any]] = []
+        self.addto_collection_calls: list[tuple[str, str]] = []
+        self.add_tags_calls: list[tuple[str, list[str]]] = []
         self._next = 0
 
     def _key(self, prefix: str) -> str:
@@ -71,7 +86,8 @@ class FakeZoteroClient:
     def item(self, item_key: str) -> dict[str, Any]:
         self.item_fetch_calls.append(item_key)
         if item_key in self._orphans:
-            return {"data": self._orphans[item_key]}
+            # pyzotero's shape: top-level ``key`` mirrored inside ``data``.
+            return {"key": item_key, "data": self._orphans[item_key]}
         return {"data": {}}
 
     def create_items(self, payloads: list[dict[str, Any]]) -> dict[str, Any]:
@@ -84,6 +100,33 @@ class FakeZoteroClient:
 
     def update_item(self, item: dict[str, Any]) -> bool:
         self.updated_items.append(item)
+        return True
+
+    def collections(self, **kwargs: Any) -> list[dict[str, Any]]:
+        return list(self._collections)
+
+    def create_collections(
+        self, payload: list[dict[str, Any]]
+    ) -> dict[str, Any]:
+        success: dict[str, str] = {}
+        for idx, entry in enumerate(payload):
+            key = self._key("COLL")
+            created = {"key": key, "data": {"key": key, "name": entry["name"]}}
+            self._collections.append(created)
+            self.created_collections.append(created)
+            success[str(idx)] = key
+        return {"success": success, "unchanged": {}, "failed": {}}
+
+    def addto_collection(
+        self, collection_key: str, item: dict[str, Any]
+    ) -> bool:
+        item_key = item.get("key") or ""
+        self.addto_collection_calls.append((collection_key, item_key))
+        return True
+
+    def add_tags(self, item: dict[str, Any], tags: list[str]) -> bool:
+        item_key = item.get("key") or ""
+        self.add_tags_calls.append((item_key, list(tags)))
         return True
 
 
@@ -108,6 +151,60 @@ class FakeOpenAlexClient:
     ) -> list[dict[str, Any]]:
         self.search_calls.append((title, per_page))
         return self._search_responses.get(title, [])
+
+
+class FakeOpenAIClient:
+    """Mimics ``OpenAIClient.extract_metadata`` — returns queued responses.
+
+    Each queued entry is either a JSON-string body (wrapped into a minimal
+    response object on demand), a ``BudgetExceededError`` instance (raised),
+    or an arbitrary exception (raised) so tests can exercise retry + error
+    paths.
+    """
+
+    def __init__(self, queue: list[str | Exception] | None = None) -> None:
+        self._queue: list[str | Exception] = list(queue or [])
+        self.extract_calls: list[str] = []
+
+    async def extract_metadata(
+        self, *, text: str, model: str = "gpt-4o-mini"
+    ) -> Any:
+        self.extract_calls.append(text)
+        if not self._queue:
+            raise AssertionError("extract_metadata called more times than queued")
+        nxt = self._queue.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return _fake_usage_record(nxt, model=model)
+
+
+def _fake_usage_record(content: str, *, model: str) -> Any:
+    """Build an object that duck-types what ``_parse_llm_response`` reads."""
+
+    class _Message:
+        def __init__(self, c: str) -> None:
+            self.content = c
+
+    class _Choice:
+        def __init__(self, c: str) -> None:
+            self.message = _Message(c)
+
+    class _Response:
+        def __init__(self, c: str) -> None:
+            self.choices = [_Choice(c)]
+            self.usage = type(
+                "U", (), {"prompt_tokens": 100, "completion_tokens": 50}
+            )()
+
+    class _Usage:
+        def __init__(self, resp: Any) -> None:
+            self.response = resp
+            self.model = model
+            self.prompt_tokens = 100
+            self.completion_tokens = 50
+            self.cost_usd = 0.0
+
+    return _Usage(_Response(content))
 
 
 class FakeSemanticScholarClient:
@@ -1006,24 +1103,575 @@ def test_map_ss_builds_payload_minimal() -> None:
     assert len(payload["creators"]) == 2
 
 
-# ─── Substage not yet implemented: 04d raises (04e also blocked) ─────────
+# ─── 04d: happy path — JSON extraction → Zotero parent ──────────────────
 
 
-def test_04d_not_implemented_raises(tmp_path: Path) -> None:
+def _llm_json(
+    *,
+    title: str = "A discovered paper",
+    year: int = 2024,
+    item_type: str = "journalArticle",
+    doi: str | None = "10.1000/llm-found",
+    venue: str = "Journal of LLMs",
+    abstract: str = "Abstract discovered by the LLM.",
+    authors: list[dict[str, str]] | None = None,
+) -> str:
+    """Helper: valid JSON body the LLM is expected to emit for 04d."""
+    body: dict[str, Any] = {
+        "title": title,
+        "authors": authors
+        if authors is not None
+        else [
+            {"first": "Jane", "last": "Doe"},
+            {"first": "John", "last": "Smith"},
+        ],
+        "year": year,
+        "item_type": item_type,
+        "venue": venue,
+        "abstract": abstract,
+    }
+    if doi is not None:
+        body["doi"] = doi
+    return json.dumps(body)
+
+
+def test_04d_extracts_and_creates_parent(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
     settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "d1.pdf")
+    orphan_key = "ORPHAN30"
+    _seed_orphan(
+        settings,
+        sha="A" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_text_pages(
+        monkeypatch,
+        {pdf.name: ["Page 1 text about something", "Page 2 continues"]},
+    )
+
+    zot = FakeZoteroClient(
+        orphans={orphan_key: {"key": orphan_key, "itemType": "attachment"}}
+    )
+    oa_client = FakeOpenAIClient(queue=[_llm_json()])
+
+    result = run_enrich(
+        substage="04d",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openai_client=oa_client,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04d == 1
+    assert len(zot.created_items) == 1
+    payload = zot.created_items[0]["payload"]
+    assert payload["title"] == "A discovered paper"
+    assert payload["DOI"] == "10.1000/llm-found"
+    assert payload["itemType"] == "journalArticle"
+    assert len(zot.updated_items) == 1
+    assert zot.updated_items[0]["parentItem"] == zot.created_items[0]["key"]
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.stage_completed == 4
+    assert item.import_route == "A"
+    assert item.detected_doi == "10.1000/llm-found"
+
+
+# ─── 04d: malformed JSON → retry once → succeed on second attempt ────────
+
+
+def test_04d_retries_once_on_malformed_json(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "d2.pdf")
+    _seed_orphan(
+        settings,
+        sha="B" * 64,
+        source_path=pdf,
+        zotero_item_key="ORPHAN31",
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: ["Paper text", ""]})
+
+    zot = FakeZoteroClient(orphans={"ORPHAN31": {"key": "ORPHAN31"}})
+    # First response is malformed; second is valid.
+    oa_client = FakeOpenAIClient(queue=["not json at all {{{", _llm_json()])
+
+    result = run_enrich(
+        substage="04d",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openai_client=oa_client,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04d == 1
+    assert len(oa_client.extract_calls) == 2, "Second attempt should have fired"
+
+
+# ─── 04d: both attempts invalid → no_progress ────────────────────────────
+
+
+def test_04d_exhausts_retries_no_progress(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "d3.pdf")
+    _seed_orphan(
+        settings,
+        sha="C" * 64,
+        source_path=pdf,
+        zotero_item_key="ORPHAN32",
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: ["text", ""]})
+
+    zot = FakeZoteroClient()
+    oa_client = FakeOpenAIClient(queue=["garbage", "still garbage"])
+
+    result = run_enrich(
+        substage="04d",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openai_client=oa_client,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_no_progress == 1
+    assert result.items_enriched_04d == 0
+    assert [r.error for r in result.rows] == ["llm_json_invalid"]
+    assert len(zot.created_items) == 0
+
+
+# ─── 04d: budget exceeded → row records budget_exceeded status ───────────
+
+
+def test_04d_budget_exceeded_marks_status(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "d4.pdf")
+    _seed_orphan(
+        settings,
+        sha="D" * 64,
+        source_path=pdf,
+        zotero_item_key="ORPHAN33",
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: ["text", ""]})
+
+    zot = FakeZoteroClient()
+    oa_client = FakeOpenAIClient(
+        queue=[BudgetExceededError("spent=$2.5, budget=$2.0")]
+    )
+
+    result = run_enrich(
+        substage="04d",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openai_client=oa_client,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert [r.status for r in result.rows] == ["budget_exceeded"]
+    assert result.items_enriched_04d == 0
+    # Item is not marked as failed — budget exhaustion is recoverable on
+    # the next run with a higher cap.
+    assert result.items_failed == 0
+
+
+# ─── 04d: quality gate (bad item_type) → no_progress ─────────────────────
+
+
+def test_04d_invalid_item_type_is_no_progress(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "d5.pdf")
+    _seed_orphan(
+        settings,
+        sha="E" * 64,
+        source_path=pdf,
+        zotero_item_key="ORPHAN34",
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: ["text", ""]})
+
+    zot = FakeZoteroClient()
+    oa_client = FakeOpenAIClient(
+        queue=[_llm_json(item_type="tweet")]  # not in the allow-list
+    )
+
+    result = run_enrich(
+        substage="04d",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openai_client=oa_client,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_no_progress == 1
+    assert [r.error for r in result.rows] == ["quality_gate_failed"]
+
+
+# ─── 04e: happy path — quarantine creates collection, tags, writes CSV ──
+
+
+def test_04e_quarantines_and_writes_report(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "e1.pdf")
+    orphan_key = "ORPHAN40"
+    _seed_orphan(
+        settings,
+        sha="F" * 64,
+        source_path=pdf,
+        zotero_item_key=orphan_key,
+    )
+    # Give 04e something to put into the text_snippet column.
+    _patch_extract_text_pages(
+        monkeypatch,
+        {pdf.name: ["Some first page text that should appear in the snippet.", ""]},
+    )
+
+    zot = FakeZoteroClient(
+        orphans={orphan_key: {"key": orphan_key, "itemType": "attachment"}}
+    )
+
+    result = run_enrich(
+        substage="04e",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_quarantined == 1
+    # Collection was created on-demand (no pre-existing Quarantine).
+    assert len(zot.created_collections) == 1
+    assert zot.created_collections[0]["data"]["name"] == "Quarantine"
+    # Item was tagged + added to the collection.
+    assert zot.add_tags_calls == [(orphan_key, ["needs-manual-review"])]
+    assert zot.addto_collection_calls == [
+        (zot.created_collections[0]["key"], orphan_key)
+    ]
+    # quarantine_report.csv was written with the snippet.
+    assert result.quarantine_csv_path is not None
+    assert result.quarantine_csv_path.exists()
+    content = result.quarantine_csv_path.read_text(encoding="utf-8")
+    assert "Some first page text" in content
+
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.in_quarantine is True
+    assert item.stage_completed == 4
+
+
+# ─── 04e: reuses an already-existing Quarantine collection ───────────────
+
+
+def test_04e_reuses_existing_quarantine_collection(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "e2.pdf")
+    _seed_orphan(
+        settings,
+        sha="G" * 64,
+        source_path=pdf,
+        zotero_item_key="ORPHAN41",
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: ["txt", ""]})
+
+    zot = FakeZoteroClient(
+        orphans={"ORPHAN41": {"key": "ORPHAN41"}},
+        existing_collections=[
+            {"key": "PREEXISTING_Q", "data": {"key": "PREEXISTING_Q", "name": "Quarantine"}}
+        ],
+    )
+
+    result = run_enrich(
+        substage="04e",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_quarantined == 1
+    assert len(zot.created_collections) == 0, "Should not re-create Quarantine"
+    assert zot.addto_collection_calls == [("PREEXISTING_Q", "ORPHAN41")]
+
+
+# ─── Cascade 'all': 04a hits → never calls 04b/04c/04d ───────────────────
+
+
+def test_cascade_all_stops_at_first_success(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "all1.pdf")
+    orphan_key = "ORPHAN50"
+    new_doi = "10.1000/cascade-hit-04a"
+    _seed_orphan(
+        settings,
+        sha="H" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_text_pages(
+        monkeypatch, {pdf.name: [f"DOI {new_doi}", "", ""]}
+    )
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    oa = FakeOpenAlexClient({new_doi: _good_openalex_work(new_doi)})
+    ss = FakeSemanticScholarClient()
+    llm = FakeOpenAIClient()  # no queue — would raise if called
+
+    result = run_enrich(
+        substage="all",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        semantic_scholar_client=ss,  # type: ignore[arg-type]
+        openai_client=llm,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04a == 1
+    assert result.items_enriched_04b == 0
+    assert result.items_enriched_04c == 0
+    assert result.items_enriched_04d == 0
+    assert result.items_quarantined == 0
+    assert ss.search_calls == [], "Semantic Scholar must not be called"
+    assert llm.extract_calls == [], "LLM must not be called when 04a succeeded"
+
+
+# ─── Cascade 'all': all free substages miss → 04d picks it up ────────────
+
+
+def test_cascade_all_falls_through_to_04d(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "all2.pdf")
+    orphan_key = "ORPHAN51"
+    title = "A recalcitrant paper title"
+    _seed_orphan(
+        settings,
+        sha="I" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key=orphan_key,
+    )
+    # No identifiers in the text → 04a misses.
+    _patch_extract_text_pages(
+        monkeypatch, {pdf.name: ["Body without ids", "More body", ""]}
+    )
+    # 04b/04c both use extract_probable_title and get no fuzzy match.
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    # Neither OpenAlex search nor Semantic Scholar return a fuzzy-match-able title.
+    oa = FakeOpenAlexClient(
+        search_responses={
+            title: [_good_openalex_work("10.1000/x", title="Totally different")]
+        }
+    )
+    ss = FakeSemanticScholarClient(
+        search_responses={title: [_ss_paper("Unrelated")]}
+    )
+    llm = FakeOpenAIClient(queue=[_llm_json(title=title, doi="10.1000/llm-saved")])
+
+    result = run_enrich(
+        substage="all",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        semantic_scholar_client=ss,  # type: ignore[arg-type]
+        openai_client=llm,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04d == 1
+    assert result.items_quarantined == 0
+    assert ss.search_calls == [(title, 5, "title,authors,year,venue,abstract,externalIds")]
+
+
+# ─── Cascade 'all': everything fails → 04e quarantines ───────────────────
+
+
+def test_cascade_all_quarantines_on_exhaustion(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    pdf = _write_pdf(tmp_path / "pdfs" / "all3.pdf")
+    orphan_key = "ORPHAN52"
+    title = "Another hopeless paper"
+    _seed_orphan(
+        settings,
+        sha="J" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_text_pages(
+        monkeypatch, {pdf.name: ["No ids at all", "Nothing", ""]}
+    )
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    oa = FakeOpenAlexClient(search_responses={title: []})
+    ss = FakeSemanticScholarClient(search_responses={title: []})
+    # LLM emits a payload the quality gate rejects → falls through to 04e.
+    llm = FakeOpenAIClient(
+        queue=["garbage", "still garbage"]  # retry exhausts
+    )
+
+    result = run_enrich(
+        substage="all",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        semantic_scholar_client=ss,  # type: ignore[arg-type]
+        openai_client=llm,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_quarantined == 1
+    assert result.items_enriched_04a == 0
+    assert result.items_enriched_04d == 0
+    assert result.quarantine_csv_path is not None
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.in_quarantine is True
+
+
+# ─── Cascade 'all': budget exceeded on first item routes rest to 04e ─────
+
+
+def test_cascade_all_budget_tripped_skips_llm_for_rest(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path)
+    # Two items that both need to reach 04d.
+    pdf1 = _write_pdf(tmp_path / "pdfs" / "b1.pdf")
+    pdf2 = _write_pdf(tmp_path / "pdfs" / "b2.pdf")
+    _seed_orphan(settings, sha="K" * 64, source_path=pdf1, zotero_item_key="ORPH_B1")
+    _seed_orphan(settings, sha="L" * 64, source_path=pdf2, zotero_item_key="ORPH_B2")
+    _patch_extract_text_pages(
+        monkeypatch, {pdf1.name: ["p1"], pdf2.name: ["p2"]}
+    )
+    _patch_extract_probable_title(
+        monkeypatch, {pdf1.name: "Title one", pdf2.name: "Title two"}
+    )
+
+    zot = FakeZoteroClient(
+        orphans={
+            "ORPH_B1": {"key": "ORPH_B1"},
+            "ORPH_B2": {"key": "ORPH_B2"},
+        }
+    )
+    oa = FakeOpenAlexClient(
+        search_responses={"Title one": [], "Title two": []}
+    )
+    ss = FakeSemanticScholarClient(
+        search_responses={"Title one": [], "Title two": []}
+    )
+    # Budget trips on the first call; the second item must route to 04e
+    # without any LLM call.
+    llm = FakeOpenAIClient(
+        queue=[BudgetExceededError("over budget")]
+    )
+
+    result = run_enrich(
+        substage="all",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        semantic_scholar_client=ss,  # type: ignore[arg-type]
+        openai_client=llm,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_quarantined == 2
+    assert len(llm.extract_calls) == 1, "Second item must skip the LLM"
+
+
+# ─── map_llm_extraction_to_zotero direct checks ─────────────────────────
+
+
+def test_map_llm_requires_title_and_authors() -> None:
+    # Missing title.
+    assert (
+        map_llm_extraction_to_zotero(
+            LLMExtractedMetadata.model_validate(
+                {
+                    "title": "",
+                    "authors": [{"first": "J", "last": "D"}],
+                    "item_type": "journalArticle",
+                }
+            )
+        )
+        is None
+    )
+    # Missing authors.
+    assert (
+        map_llm_extraction_to_zotero(
+            LLMExtractedMetadata.model_validate(
+                {"title": "T", "authors": [], "item_type": "journalArticle"}
+            )
+        )
+        is None
+    )
+
+
+def test_map_llm_rejects_unknown_item_type() -> None:
+    extracted = LLMExtractedMetadata.model_validate(
+        {
+            "title": "Good",
+            "authors": [{"first": "J", "last": "D"}],
+            "item_type": "newsletter",  # off the allow-list
+        }
+    )
+    assert map_llm_extraction_to_zotero(extracted) is None
+
+
+def test_map_llm_builds_zotero_payload() -> None:
+    extracted = LLMExtractedMetadata.model_validate(
+        {
+            "title": "Good paper",
+            "authors": [{"first": "Jane", "last": "Doe"}],
+            "year": 2022,
+            "item_type": "preprint",
+            "venue": "arXiv",
+            "doi": "10.1000/x",
+            "abstract": "abc",
+        }
+    )
+    payload = map_llm_extraction_to_zotero(extracted)
+    assert payload is not None
+    assert payload["title"] == "Good paper"
+    assert payload["itemType"] == "preprint"
+    assert payload["DOI"] == "10.1000/x"
+    assert payload["date"] == "2022"
+
+
+# ─── Smoke: 04d without OPENAI_API_KEY raises StageAbortedError ──────────
+
+
+def test_04d_without_api_key_raises_stage_aborted(tmp_path: Path) -> None:
+    from zotai.s1.handler import StageAbortedError
+
+    settings = _settings(tmp_path)  # empty openai.api_key
     try:
         run_enrich(substage="04d", settings=settings)
-    except NotImplementedError as exc:
-        assert "04d" in str(exc)
+    except StageAbortedError as exc:
+        assert "OPENAI_API_KEY" in str(exc)
     else:  # pragma: no cover
-        raise AssertionError("expected NotImplementedError")
-
-
-def test_04e_not_implemented_raises(tmp_path: Path) -> None:
-    settings = _settings(tmp_path)
-    try:
-        run_enrich(substage="04e", settings=settings)
-    except NotImplementedError as exc:
-        assert "04e" in str(exc)
-    else:  # pragma: no cover
-        raise AssertionError("expected NotImplementedError")
+        raise AssertionError("expected StageAbortedError")


### PR DESCRIPTION
**Stacked on #50.** Closes #6. This is the last of three PRs for Stage 04.

## Summary

Completes the Stage 04 enrichment cascade with the LLM and quarantine paths, plus the per-item orchestrator that walks `04a → 04b → 04c → 04d → 04e` until one succeeds.

- **04d — LLM extraction** (\`gpt-4o-mini\`). First two pages → JSON → validated by a new \`LLMExtractedMetadata\` Pydantic schema with retry-once on malformed JSON → mapped by \`map_llm_extraction_to_zotero\` with quality gate on title + authors + allow-listed \`item_type\` (plan_01 §3.04d). Budget enforcement lives in \`OpenAIClient\` (\`MAX_COST_USD_STAGE_04\`, overridable per-run via \`--max-cost\`). \`BudgetExceededError\` is caught in the orchestrator so tripping the cap routes remaining items directly to 04e without further LLM calls.
- **04e — Quarantine** (ADR 008). Idempotent \`_ensure_quarantine_collection\` uses two new \`ZoteroClient\` wrappers (\`create_collections\` / \`addto_collection\`). \`_enrich_04e_one\` tags the orphan with \`needs-manual-review\`, adds it to the collection, flips \`Item.in_quarantine\`, and writes a purpose-built \`reports/quarantine_report_<ts>.csv\` with columns \`sha256, source_path, text_snippet, reason\` — the triage surface plan_01 §3.04e prescribes.
- **Cascade orchestrator \`--substage all\`.** Per-item loop with early-exit on first success; a nonlocal \`budget_exhausted\` flag skips the LLM for remaining items after the cap trips.
- **Shared helper** \`_create_parent_and_reparent\` (extracted in #50) now serves 04a, 04b, 04c, 04d uniformly — one ADR 014 dedup path, one reparent path.
- **CLI** \`zotai s1 enrich --substage {04a|04b|04c|04d|04e|all}\` with working \`--max-cost\`. The \"not yet implemented\" banner is gone.
- **\`EnrichStatus\`** adds \`enriched_04d\`, \`quarantined_04e\`, \`budget_exceeded\`. **\`EnrichResult\`** adds \`items_enriched_04d\`, \`items_quarantined\`, \`quarantine_csv_path\`.
- **ADRs** \`005-gpt-4o-mini-tagging-extraction.md\` (retrospective rationale for the default LLM across Stages 01, 04d, 05) and \`008-quarantine-in-s1.md\` (rationale for the completeness-vs-quality tradeoff resolved by 04e). Closes the two plan_00 §5 entries that were pending since PR #26.

## Test plan

- [x] \`pytest tests/test_s1/test_stage_04.py\` — **34 passed** (was 21; +13 new tests)
- [x] \`pytest\` full suite — **158 passed** (was 145)
- [x] \`mypy --strict\` on modified files — clean
- [x] \`ruff check\` on modified files — clean
- [x] CLI smoke: \`zotai s1 enrich --help\` now lists every substage + \`all\`; \`--substage 04d\` without \`OPENAI_API_KEY\` aborts cleanly via \`StageAbortedError\`
- [ ] End-to-end real run on a staging Zotero library after Stage 03 seeds Route-C items (manual, post-merge)

### New tests

| # | Test | Focus |
|---|---|---|
| 1 | \`test_04d_extracts_and_creates_parent\` | Happy path: JSON → payload → create parent → reparent → DB state |
| 2 | \`test_04d_retries_once_on_malformed_json\` | Retry-once semantics |
| 3 | \`test_04d_exhausts_retries_no_progress\` | Both attempts invalid → \`no_progress\` with \`error=\"llm_json_invalid\"\` |
| 4 | \`test_04d_budget_exceeded_marks_status\` | Budget error routes to \`status=\"budget_exceeded\"\`, not \"failed\" |
| 5 | \`test_04d_invalid_item_type_is_no_progress\` | Off-allow-list \`item_type\` → quality gate fail |
| 6 | \`test_04e_quarantines_and_writes_report\` | Collection created, item tagged, added, CSV written with snippet |
| 7 | \`test_04e_reuses_existing_quarantine_collection\` | Idempotent lookup |
| 8 | \`test_cascade_all_stops_at_first_success\` | 04a hits → SS and LLM never called |
| 9 | \`test_cascade_all_falls_through_to_04d\` | All free substages miss → 04d picks it up |
| 10 | \`test_cascade_all_quarantines_on_exhaustion\` | Everything fails → 04e |
| 11 | \`test_cascade_all_budget_tripped_skips_llm_for_rest\` | Budget tripped on item 1 → item 2 skips LLM, quarantines directly |
| 12-14 | \`test_map_llm_*\` | Direct mapper coverage: quality gate, item_type allow-list, payload shape |
| 15 | \`test_04d_without_api_key_raises_stage_aborted\` | Fail-loud when \`OPENAI_API_KEY\` missing |

## Related

- Issue **#6** (Phase 5 — Stage 04)
- **ADR 005** — \`gpt-4o-mini\` for tagging/extraction (this PR)
- **ADR 008** — Quarantine in S1 (this PR)
- ADR 014 — Stage 03 dedup skip-attach (reused via shared helper)
- \`docs/plan_01_subsystem1.md\` §3 Etapa 04 (substages 04d, 04e)
- \`docs/plan_00_overview.md\` §5 (rows ADR 005 and ADR 008, both previously pending)