### PR TITLE
feat(s1): stage 05 tagging — LLM against TEMA/METODO taxonomy (#7)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,39 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **S1 Stage 05 — tagging** (#7, closes the Stage 05 / Phase 6 issue):
+  `zotai.s1.stage_05_tag.run_tag` walks items with `stage_completed >= 4
+  AND in_quarantine=False AND zotero_item_key IS NOT NULL AND tags_json
+  IS NULL` (the last clause dropped by `--re-tag`), builds a metadata
+  dict from `Item.metadata_json`, and asks `OpenAIClient.tag_paper` to
+  return `{"tema": [...], "metodo": [...]}`. JSON validation goes
+  through a Pydantic schema with a retry-once on malformed output;
+  after the retry the item is flagged `llm_failed` and left without
+  tags. Strict taxonomy validation: ids not present in
+  `config/taxonomy.yaml` are dropped (not fatal) and surfaced in the
+  CSV's `tema_rejected` / `metodo_rejected` columns so the researcher
+  can spot hallucinations or taxonomy gaps. **Two modes**: `--preview`
+  writes the CSV only (no Zotero / no DB writes); `--apply` calls
+  `ZoteroClient.add_tags`, persists `Item.tags_json`, and advances
+  `stage_completed` to 5. The global `--dry-run` short-circuits writes
+  in either mode. **Taxonomy sanity gate**: the stage refuses to run
+  against `config/taxonomy.yaml` when `status: template` unless
+  `--allow-template-taxonomy` is passed (for deliberate integration
+  testing on the shipped template). Budget: `MAX_COST_USD_STAGE_05`
+  (default $1.00, typical ~$0.40 for 1000 items) with
+  `--max-cost` override. `BudgetExceededError` aborts the stage via
+  `StageAbortedError` with partial state preserved (already-tagged
+  items stay tagged; re-run with a higher cap picks up from where it
+  left off). New module: `src/zotai/s1/stage_05_tag.py`. New CLI:
+  `zotai s1 tag --preview|--apply [--re-tag] [--max-cost N]
+  [--allow-template-taxonomy]`. New tests: `tests/test_s1/test_stage_05.py`
+  with 17 cases covering taxonomy loader errors, template refusal +
+  override, preview / apply / dry-run semantics, strict validation,
+  retry-once on malformed JSON, eligibility (quarantined / already-
+  tagged / no-metadata skips), `--re-tag`, budget exceeded with
+  partial commit. Full suite: 175 passed (was 158). `mypy --strict`
+  clean on the modified files.
+
 - **S1 Stage 04 — substages 04d + 04e + cascade orchestrator `--substage all`**
   (#6, third of three PRs for Stage 04; closes #6):
   - **04d — LLM extraction** (`gpt-4o-mini`). `zotai.s1.stage_04_enrich._enrich_04d_one`

--- a/src/zotai/cli.py
+++ b/src/zotai/cli.py
@@ -338,14 +338,85 @@ def s1_enrich(
 
 @s1_app.command("tag")
 def s1_tag(
-    preview: Annotated[bool, typer.Option("--preview")] = False,
-    apply: Annotated[bool, typer.Option("--apply")] = False,
-    re_tag: Annotated[bool, typer.Option("--re-tag")] = False,
-    max_cost: Annotated[float | None, typer.Option("--max-cost")] = None,
+    ctx: typer.Context,
+    preview: Annotated[
+        bool,
+        typer.Option(
+            "--preview",
+            help="Write tag proposals to reports/tag_report_<ts>.csv without touching Zotero.",
+        ),
+    ] = False,
+    apply: Annotated[
+        bool,
+        typer.Option(
+            "--apply",
+            help="Apply the tags to Zotero and advance stage_completed to 5.",
+        ),
+    ] = False,
+    re_tag: Annotated[
+        bool,
+        typer.Option(
+            "--re-tag",
+            help="Re-tag items that already have tags (default skips them).",
+        ),
+    ] = False,
+    max_cost: Annotated[
+        float | None,
+        typer.Option(
+            "--max-cost",
+            help="Override MAX_COST_USD_STAGE_05 for this invocation.",
+        ),
+    ] = None,
+    allow_template_taxonomy: Annotated[
+        bool,
+        typer.Option(
+            "--allow-template-taxonomy",
+            help=(
+                "Proceed even when config/taxonomy.yaml is marked "
+                "status=template. Useful for integration tests on the "
+                "default taxonomy before the researcher customizes it; "
+                "do NOT set on a real run."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Stage 05 — LLM tagging against the TEMA/METODO taxonomy."""
-    _ = preview, apply, re_tag, max_cost
-    _not_implemented("s1 tag", 6, 7)
+    from zotai.config import Settings
+    from zotai.s1.handler import StageAbortedError
+    from zotai.s1.stage_05_tag import run_tag
+
+    settings = Settings()
+    dry_run = bool(ctx.obj.get("dry_run", False)) or settings.behavior.dry_run
+
+    if preview == apply:
+        typer.secho(
+            "Pass exactly one of --preview or --apply.",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(code=2)
+
+    try:
+        result = run_tag(
+            preview=preview,
+            apply=apply,
+            re_tag=re_tag,
+            dry_run=dry_run,
+            max_cost=max_cost,
+            allow_template_taxonomy=allow_template_taxonomy,
+            settings=settings,
+        )
+    except StageAbortedError as exc:
+        typer.secho(f"Stage aborted: {exc}", err=True, fg=typer.colors.RED)
+        raise typer.Exit(code=2) from exc
+
+    typer.echo(
+        f"processed={result.items_processed} failed={result.items_failed} "
+        f"tagged={result.items_tagged} previewed={result.items_previewed} "
+        f"no_metadata={result.items_no_metadata} "
+        f"llm_failed={result.items_llm_failed} "
+        f"cost=${result.cost_usd:.4f} csv={result.csv_path}"
+    )
 
 
 @s1_app.command("validate")

--- a/src/zotai/s1/stage_05_tag.py
+++ b/src/zotai/s1/stage_05_tag.py
@@ -1,0 +1,754 @@
+"""Stage 05 — LLM tagging against the TEMA / METODO taxonomy (plan_01 §3 Etapa 05).
+
+Input: every item with ``stage_completed >= 4 AND in_quarantine=False AND
+zotero_item_key IS NOT NULL``. Output: ``Item.tags_json`` persisted and
+(in ``--apply`` mode) the tags attached to the Zotero item.
+
+Per-item flow:
+
+1. Build a metadata dict from ``Item.metadata_json`` (the Zotero payload
+   written by Stage 03 Route-A or Stage 04 enrichment).
+2. Ask ``OpenAIClient.tag_paper`` to return a JSON object of the shape
+   ``{"tema": [...], "metodo": [...]}``. Retry once on malformed JSON;
+   after the retry, the item is recorded with ``status="llm_failed"``
+   and no tags are written.
+3. Strict-validate each returned id against the active taxonomy. Unknown
+   ids are dropped (not fatal) and surfaced in the CSV so the researcher
+   can spot LLM hallucinations or taxonomy gaps.
+4. In ``--apply``, call ``ZoteroClient.add_tags`` and persist
+   ``Item.tags_json``; advance ``stage_completed`` to 5. In ``--preview``
+   (or global ``--dry-run``), the CSV is written but Zotero and the DB
+   stay untouched.
+
+Budget: ``MAX_COST_USD_STAGE_05`` (default $1.00 — typical spend on 1000
+items at ``~$0.0004/paper`` is ~$0.40). Overridable per-run with
+``--max-cost``. ``BudgetExceededError`` aborts the stage cleanly; items
+already processed keep their tags.
+
+Taxonomy file sanity gate: ``config/taxonomy.yaml`` carries a
+``status: template | customized`` marker. The stage refuses to run
+against ``status: template`` unless the caller passes
+``--allow-template-taxonomy`` — plan_01 §3.05 forbids accidentally
+populating a library with placeholder tags.
+"""
+
+from __future__ import annotations
+
+import asyncio
+import csv
+import json
+from collections.abc import Awaitable, Callable, Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from pathlib import Path
+from typing import Any, Final, Literal
+
+import yaml
+from pydantic import BaseModel, Field, ValidationError
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, select
+
+from zotai.api.openai_client import BudgetExceededError, OpenAIClient
+from zotai.api.zotero import ZoteroClient
+from zotai.config import Settings
+from zotai.s1.handler import StageAbortedError
+from zotai.state import Item, Run, init_s1, make_s1_engine
+from zotai.utils.fs import ensure_dir
+from zotai.utils.logging import bind, get_logger
+
+log = get_logger(__name__)
+
+_STAGE: Final[int] = 5
+_PREREQ_STAGE: Final[int] = 4
+# Retry the LLM call once if the first response fails JSON / schema
+# validation; after that the item is recorded as ``llm_failed`` and
+# left without tags.
+_LLM_MAX_RETRIES: Final[int] = 1
+
+_CSV_COLUMNS: Final[tuple[str, ...]] = (
+    "sha256",
+    "zotero_item_key",
+    "title",
+    "tema_applied",
+    "metodo_applied",
+    "tema_rejected",
+    "metodo_rejected",
+    "cost_usd",
+    "status",
+    "error",
+)
+
+TagStatus = Literal[
+    "tagged",
+    "preview",
+    "no_metadata",
+    "no_valid_tags",
+    "llm_failed",
+    "dry_run",
+    "skipped_already_tagged",
+]
+
+
+# ─── Taxonomy loading ────────────────────────────────────────────────────
+
+
+class TaxonomyEntry(BaseModel):
+    """One row under ``tema:`` or ``metodo:`` in ``config/taxonomy.yaml``."""
+
+    id: str
+    description: str = ""
+    synonyms: list[str] = Field(default_factory=list)
+
+
+class Taxonomy(BaseModel):
+    """Parsed ``config/taxonomy.yaml``.
+
+    ``status`` is the sanity gate described in plan_01 §3.05 and in the
+    header comment of the yaml file. ``tema`` / ``metodo`` are plain
+    lists so the downstream ``OpenAIClient.tag_paper`` helper can read
+    ``entry.id`` directly.
+    """
+
+    version: int = 1
+    status: Literal["template", "customized"] = "template"
+    tema: list[TaxonomyEntry] = Field(default_factory=list)
+    metodo: list[TaxonomyEntry] = Field(default_factory=list)
+
+    @property
+    def tema_ids(self) -> set[str]:
+        return {entry.id for entry in self.tema}
+
+    @property
+    def metodo_ids(self) -> set[str]:
+        return {entry.id for entry in self.metodo}
+
+    def as_payload_dict(self) -> dict[str, list[dict[str, Any]]]:
+        """Shape accepted by ``OpenAIClient.tag_paper``."""
+        return {
+            "tema": [entry.model_dump() for entry in self.tema],
+            "metodo": [entry.model_dump() for entry in self.metodo],
+        }
+
+
+def load_taxonomy(path: Path) -> Taxonomy:
+    """Parse + validate the taxonomy YAML at ``path``.
+
+    Raises ``StageAbortedError`` on unreadable / invalid files so the
+    caller can surface a clear message instead of a bare validation
+    traceback.
+    """
+    try:
+        raw = yaml.safe_load(path.read_text(encoding="utf-8"))
+    except FileNotFoundError as exc:
+        raise StageAbortedError(
+            f"Taxonomy file not found: {path}. Create it from the "
+            "template at config/taxonomy.yaml and set status=customized "
+            "before running `zotai s1 tag`."
+        ) from exc
+    except yaml.YAMLError as exc:
+        raise StageAbortedError(f"Taxonomy YAML parse error in {path}: {exc}") from exc
+    if not isinstance(raw, dict):
+        raise StageAbortedError(
+            f"Taxonomy file {path} must be a mapping at the top level; "
+            f"got {type(raw).__name__}."
+        )
+    try:
+        return Taxonomy.model_validate(raw)
+    except ValidationError as exc:
+        raise StageAbortedError(f"Taxonomy schema error in {path}: {exc}") from exc
+
+
+# ─── Result types ────────────────────────────────────────────────────────
+
+
+@dataclass(frozen=True)
+class TagRow:
+    """One row in ``reports/tag_report_<ts>.csv``."""
+
+    sha256: str
+    zotero_item_key: str | None
+    title: str
+    tema_applied: list[str]
+    metodo_applied: list[str]
+    tema_rejected: list[str]
+    metodo_rejected: list[str]
+    cost_usd: float
+    status: TagStatus
+    error: str | None
+
+
+@dataclass(frozen=True)
+class TagResult:
+    """Aggregate outcome of one ``run_tag`` call."""
+
+    run_id: int | None
+    rows: list[TagRow]
+    csv_path: Path
+    items_processed: int
+    items_failed: int
+    items_tagged: int
+    items_previewed: int
+    items_no_metadata: int
+    items_llm_failed: int
+    cost_usd: float
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def _csv_path(reports_dir: Path, *, dry_run: bool, now: datetime) -> Path:
+    suffix = "_dryrun" if dry_run else ""
+    timestamp = now.strftime("%Y%m%d_%H%M%S")
+    return reports_dir / f"tag_report_{timestamp}{suffix}.csv"
+
+
+def _write_csv(path: Path, rows: Iterable[TagRow]) -> None:
+    with path.open("w", encoding="utf-8", newline="") as handle:
+        writer = csv.DictWriter(handle, fieldnames=list(_CSV_COLUMNS))
+        writer.writeheader()
+        for row in rows:
+            writer.writerow(
+                {
+                    "sha256": row.sha256,
+                    "zotero_item_key": row.zotero_item_key or "",
+                    "title": row.title,
+                    "tema_applied": "|".join(row.tema_applied),
+                    "metodo_applied": "|".join(row.metodo_applied),
+                    "tema_rejected": "|".join(row.tema_rejected),
+                    "metodo_rejected": "|".join(row.metodo_rejected),
+                    "cost_usd": f"{row.cost_usd:.6f}",
+                    "status": row.status,
+                    "error": row.error or "",
+                }
+            )
+
+
+# ─── LLM response parsing ────────────────────────────────────────────────
+
+
+class _LLMTagResponse(BaseModel):
+    tema: list[str] = Field(default_factory=list)
+    metodo: list[str] = Field(default_factory=list)
+
+
+def _parse_llm_response(usage: Any) -> _LLMTagResponse | None:
+    """Parse ``UsageRecord.response`` into the tag schema, or ``None`` on failure."""
+    response = getattr(usage, "response", None)
+    choices = getattr(response, "choices", None) or []
+    if not choices:
+        return None
+    message = getattr(choices[0], "message", None)
+    content = getattr(message, "content", None) if message is not None else None
+    if not isinstance(content, str) or not content:
+        return None
+    try:
+        raw = json.loads(content)
+    except json.JSONDecodeError:
+        return None
+    if not isinstance(raw, dict):
+        return None
+    try:
+        return _LLMTagResponse.model_validate(raw)
+    except ValidationError:
+        return None
+
+
+def _validate_tags(
+    parsed: _LLMTagResponse, taxonomy: Taxonomy
+) -> tuple[list[str], list[str], list[str], list[str]]:
+    """Split the LLM response into accepted + rejected tag ids.
+
+    Returns ``(tema_applied, metodo_applied, tema_rejected, metodo_rejected)``
+    in taxonomy-declaration order for determinism, deduped, with
+    unknown ids surfaced under the rejected lists so the caller can log
+    them.
+    """
+    tema_ids = taxonomy.tema_ids
+    metodo_ids = taxonomy.metodo_ids
+    tema_seen: set[str] = set()
+    metodo_seen: set[str] = set()
+    tema_applied: list[str] = []
+    metodo_applied: list[str] = []
+    tema_rejected: list[str] = []
+    metodo_rejected: list[str] = []
+    for raw_tag in parsed.tema:
+        if not isinstance(raw_tag, str):
+            continue
+        tag = raw_tag.strip()
+        if not tag or tag in tema_seen:
+            continue
+        tema_seen.add(tag)
+        if tag in tema_ids:
+            tema_applied.append(tag)
+        else:
+            tema_rejected.append(tag)
+    for raw_tag in parsed.metodo:
+        if not isinstance(raw_tag, str):
+            continue
+        tag = raw_tag.strip()
+        if not tag or tag in metodo_seen:
+            continue
+        metodo_seen.add(tag)
+        if tag in metodo_ids:
+            metodo_applied.append(tag)
+        else:
+            metodo_rejected.append(tag)
+    return tema_applied, metodo_applied, tema_rejected, metodo_rejected
+
+
+# ─── Per-item tagging ────────────────────────────────────────────────────
+
+
+async def _tag_one(
+    item: Item,
+    *,
+    taxonomy: Taxonomy,
+    openai_client: OpenAIClient,
+    model: str,
+) -> tuple[TagRow, list[str], list[str], float]:
+    """Tag a single item. Returns ``(row, tema_applied, metodo_applied, cost)``.
+
+    ``BudgetExceededError`` is not caught — the caller short-circuits the
+    whole run when the cap trips, so partial state stays consistent.
+    """
+    metadata_json = item.metadata_json
+    if not metadata_json:
+        return (
+            TagRow(
+                sha256=item.id,
+                zotero_item_key=item.zotero_item_key,
+                title="",
+                tema_applied=[],
+                metodo_applied=[],
+                tema_rejected=[],
+                metodo_rejected=[],
+                cost_usd=0.0,
+                status="no_metadata",
+                error="item.metadata_json is empty",
+            ),
+            [],
+            [],
+            0.0,
+        )
+
+    try:
+        metadata = json.loads(metadata_json)
+    except json.JSONDecodeError as exc:
+        return (
+            TagRow(
+                sha256=item.id,
+                zotero_item_key=item.zotero_item_key,
+                title="",
+                tema_applied=[],
+                metodo_applied=[],
+                tema_rejected=[],
+                metodo_rejected=[],
+                cost_usd=0.0,
+                status="llm_failed",
+                error=f"metadata_json_decode:{exc}",
+            ),
+            [],
+            [],
+            0.0,
+        )
+    title = str(metadata.get("title") or "")
+
+    parsed: _LLMTagResponse | None = None
+    last_error: str | None = None
+    total_cost = 0.0
+    for _attempt in range(_LLM_MAX_RETRIES + 1):
+        try:
+            usage = await openai_client.tag_paper(
+                metadata=metadata,
+                taxonomy=taxonomy.as_payload_dict(),
+                model=model,
+            )
+        except BudgetExceededError:
+            raise
+        except Exception as exc:
+            last_error = f"openai_error:{type(exc).__name__}:{exc}"
+            continue
+        total_cost += float(getattr(usage, "cost_usd", 0.0) or 0.0)
+        parsed = _parse_llm_response(usage)
+        if parsed is not None:
+            break
+        last_error = "llm_json_invalid"
+
+    if parsed is None:
+        return (
+            TagRow(
+                sha256=item.id,
+                zotero_item_key=item.zotero_item_key,
+                title=title,
+                tema_applied=[],
+                metodo_applied=[],
+                tema_rejected=[],
+                metodo_rejected=[],
+                cost_usd=total_cost,
+                status="llm_failed",
+                error=last_error or "llm_no_response",
+            ),
+            [],
+            [],
+            total_cost,
+        )
+
+    tema_applied, metodo_applied, tema_rejected, metodo_rejected = _validate_tags(
+        parsed, taxonomy
+    )
+    if not tema_applied and not metodo_applied:
+        return (
+            TagRow(
+                sha256=item.id,
+                zotero_item_key=item.zotero_item_key,
+                title=title,
+                tema_applied=[],
+                metodo_applied=[],
+                tema_rejected=tema_rejected,
+                metodo_rejected=metodo_rejected,
+                cost_usd=total_cost,
+                status="no_valid_tags",
+                error=None,
+            ),
+            [],
+            [],
+            total_cost,
+        )
+
+    return (
+        TagRow(
+            sha256=item.id,
+            zotero_item_key=item.zotero_item_key,
+            title=title,
+            tema_applied=tema_applied,
+            metodo_applied=metodo_applied,
+            tema_rejected=tema_rejected,
+            metodo_rejected=metodo_rejected,
+            cost_usd=total_cost,
+            status="tagged",  # caller adjusts to preview / dry_run later
+            error=None,
+        ),
+        tema_applied,
+        metodo_applied,
+        total_cost,
+    )
+
+
+# ─── Eligible-items query ────────────────────────────────────────────────
+
+
+def _select_eligible(session: Session, *, re_tag: bool) -> list[Item]:
+    """Items that Stage 05 should process.
+
+    Default: ``stage_completed >= 4 AND !in_quarantine AND
+    zotero_item_key IS NOT NULL AND tags_json IS NULL`` (i.e. not yet
+    tagged). ``re_tag=True`` drops the ``tags_json IS NULL`` clause so
+    the caller can re-tag the corpus after a taxonomy edit.
+    """
+    stmt = (
+        select(Item)
+        .where(Item.stage_completed >= _PREREQ_STAGE)
+        .where(Item.in_quarantine == False)  # noqa: E712
+        .where(Item.zotero_item_key.is_not(None))  # type: ignore[union-attr]
+    )
+    if not re_tag:
+        stmt = stmt.where(Item.tags_json.is_(None))  # type: ignore[union-attr]
+    return list(session.exec(stmt))
+
+
+# ─── Public entry points ─────────────────────────────────────────────────
+
+
+def run_tag(
+    *,
+    preview: bool = False,
+    apply: bool = False,
+    re_tag: bool = False,
+    dry_run: bool = False,
+    max_cost: float | None = None,
+    allow_template_taxonomy: bool = False,
+    settings: Settings | None = None,
+    engine: Engine | None = None,
+    openai_client: OpenAIClient | None = None,
+    zotero_client: ZoteroClient | None = None,
+    taxonomy_path: Path | None = None,
+    now: Callable[[], datetime] = _utc_now,
+    sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
+) -> TagResult:
+    """Run Stage 05 tagging.
+
+    Exactly one of ``preview`` / ``apply`` must be True (the CLI enforces
+    this; callers passing both get an error). ``dry_run`` short-circuits
+    writes regardless of mode, matching the global ``--dry-run`` flag
+    semantics used by the other S1 stages.
+
+    ``allow_template_taxonomy=True`` bypasses the ``status: template``
+    refusal — intended for tests and deliberate testing runs; never set
+    it by default.
+    """
+    if preview == apply:
+        raise StageAbortedError(
+            "Pass exactly one of --preview or --apply. Preview writes the "
+            "CSV only; apply also patches Zotero and advances the pipeline."
+        )
+    return asyncio.run(
+        _run_tag_async(
+            preview=preview,
+            apply=apply,
+            re_tag=re_tag,
+            dry_run=dry_run,
+            max_cost=max_cost,
+            allow_template_taxonomy=allow_template_taxonomy,
+            settings=settings,
+            engine=engine,
+            openai_client=openai_client,
+            zotero_client=zotero_client,
+            taxonomy_path=taxonomy_path,
+            now=now,
+            sleep=sleep,
+        )
+    )
+
+
+async def _run_tag_async(
+    *,
+    preview: bool,
+    apply: bool,
+    re_tag: bool,
+    dry_run: bool,
+    max_cost: float | None,
+    allow_template_taxonomy: bool,
+    settings: Settings | None,
+    engine: Engine | None,
+    openai_client: OpenAIClient | None,
+    zotero_client: ZoteroClient | None,
+    taxonomy_path: Path | None,
+    now: Callable[[], datetime],
+    sleep: Callable[[float], Awaitable[None]],
+) -> TagResult:
+    _ = sleep  # reserved for rate-pacing when we move to async batches
+    settings = settings or Settings()
+    if engine is None:
+        engine = make_s1_engine(str(settings.paths.state_db))
+        init_s1(engine)
+
+    # Taxonomy first — fail early on a bad config.
+    if taxonomy_path is None:
+        taxonomy_path = _default_taxonomy_path()
+    taxonomy = load_taxonomy(taxonomy_path)
+    if taxonomy.status != "customized" and not allow_template_taxonomy:
+        raise StageAbortedError(
+            f"Taxonomy at {taxonomy_path} is marked status=template. "
+            "Customize it per docs/plan_taxonomy.md §8 and set "
+            "status=customized, or pass --allow-template-taxonomy for "
+            "a deliberate testing run. Applying template tags to a real "
+            "library corrupts the researcher's classification."
+        )
+
+    if openai_client is None:
+        api_key = settings.openai.api_key.get_secret_value()
+        if not api_key:
+            raise StageAbortedError(
+                "Stage 05 requires OPENAI_API_KEY. Set it in .env or pass "
+                "openai_client explicitly."
+            )
+        budget = (
+            max_cost
+            if max_cost is not None
+            else settings.budgets.max_cost_usd_stage_05
+        )
+        openai_client = OpenAIClient(api_key=api_key, budget_usd=budget)
+
+    write_to_zotero = apply and not dry_run
+    if zotero_client is None:
+        zotero_client = ZoteroClient(
+            library_id=settings.zotero.library_id,
+            library_type=settings.zotero.library_type,
+            api_key=settings.zotero.api_key.get_secret_value(),
+            local=settings.zotero.local_api,
+            local_api_host=settings.zotero.local_api_host or None,
+            dry_run=not write_to_zotero,
+        )
+
+    model = settings.openai.model_tag
+    run = Run(stage=_STAGE, status="running", started_at=now())
+    rows: list[TagRow] = []
+    total_cost = 0.0
+    stopped_early = False
+
+    bind(stage=_STAGE, dry_run=dry_run, mode="apply" if apply else "preview")
+    log.info(
+        "stage_started",
+        mode="apply" if apply else "preview",
+        dry_run=dry_run,
+        re_tag=re_tag,
+    )
+
+    with Session(engine) as session:
+        if write_to_zotero:
+            session.add(run)
+            session.flush()
+
+        try:
+            items = _select_eligible(session, re_tag=re_tag)
+            log.info("stage_05.eligible_items", count=len(items))
+
+            for item in items:
+                try:
+                    core_row, tema_applied, metodo_applied, cost = await _tag_one(
+                        item,
+                        taxonomy=taxonomy,
+                        openai_client=openai_client,
+                        model=model,
+                    )
+                except BudgetExceededError as exc:
+                    log.warning("stage_05.budget_exceeded", error=str(exc))
+                    stopped_early = True
+                    break
+                total_cost += cost
+
+                if core_row.status == "no_metadata":
+                    rows.append(core_row)
+                    continue
+                if core_row.status in ("llm_failed", "no_valid_tags"):
+                    rows.append(core_row)
+                    if write_to_zotero:
+                        item.last_error = core_row.error or core_row.status
+                        item.updated_at = now()
+                    run.items_failed += 1
+                    continue
+
+                # Tagged successfully from the LLM's perspective.
+                final_status: TagStatus
+                if dry_run:
+                    final_status = "dry_run"
+                elif preview:
+                    final_status = "preview"
+                else:
+                    final_status = "tagged"
+                final_row = TagRow(
+                    sha256=core_row.sha256,
+                    zotero_item_key=core_row.zotero_item_key,
+                    title=core_row.title,
+                    tema_applied=tema_applied,
+                    metodo_applied=metodo_applied,
+                    tema_rejected=core_row.tema_rejected,
+                    metodo_rejected=core_row.metodo_rejected,
+                    cost_usd=core_row.cost_usd,
+                    status=final_status,
+                    error=None,
+                )
+                rows.append(final_row)
+
+                if write_to_zotero and item.zotero_item_key:
+                    try:
+                        zotero_client.add_tags(
+                            {"key": item.zotero_item_key},
+                            tema_applied + metodo_applied,
+                        )
+                    except Exception as exc:
+                        log.warning(
+                            "stage_05.add_tags_failed",
+                            sha256=item.id,
+                            error=str(exc),
+                        )
+                        final_row = TagRow(
+                            sha256=final_row.sha256,
+                            zotero_item_key=final_row.zotero_item_key,
+                            title=final_row.title,
+                            tema_applied=final_row.tema_applied,
+                            metodo_applied=final_row.metodo_applied,
+                            tema_rejected=final_row.tema_rejected,
+                            metodo_rejected=final_row.metodo_rejected,
+                            cost_usd=final_row.cost_usd,
+                            status="llm_failed",
+                            error=f"add_tags:{type(exc).__name__}:{exc}",
+                        )
+                        rows[-1] = final_row
+                        run.items_failed += 1
+                        continue
+                    item.tags_json = json.dumps(
+                        {"tema": tema_applied, "metodo": metodo_applied}
+                    )
+                    item.stage_completed = max(item.stage_completed, _STAGE)
+                    item.last_error = None
+                    item.updated_at = now()
+                run.items_processed += 1
+
+            if stopped_early:
+                run.status = "aborted"
+            else:
+                run.status = "succeeded"
+        except StageAbortedError:
+            run.status = "aborted"
+            raise
+        except Exception:
+            run.status = "failed"
+            raise
+        finally:
+            run.finished_at = now()
+            run.cost_usd = total_cost
+            if write_to_zotero:
+                session.commit()
+
+        run_id = run.id
+        items_processed = run.items_processed
+        items_failed = run.items_failed
+
+    reports_folder = ensure_dir(settings.paths.reports_folder)
+    csv_path = _csv_path(reports_folder, dry_run=dry_run or preview, now=now())
+    _write_csv(csv_path, rows)
+
+    result = TagResult(
+        run_id=run_id,
+        rows=rows,
+        csv_path=csv_path,
+        items_processed=items_processed,
+        items_failed=items_failed,
+        items_tagged=sum(1 for r in rows if r.status == "tagged"),
+        items_previewed=sum(1 for r in rows if r.status == "preview"),
+        items_no_metadata=sum(1 for r in rows if r.status == "no_metadata"),
+        items_llm_failed=sum(1 for r in rows if r.status == "llm_failed"),
+        cost_usd=total_cost,
+    )
+    log.info(
+        "stage_finished",
+        tagged=result.items_tagged,
+        previewed=result.items_previewed,
+        no_metadata=result.items_no_metadata,
+        llm_failed=result.items_llm_failed,
+        cost_usd=round(result.cost_usd, 6),
+        csv=str(csv_path),
+        stopped_early=stopped_early,
+    )
+    if stopped_early:
+        raise StageAbortedError(
+            "Stage 05 aborted: LLM budget exceeded. Partial tags have "
+            "been written; re-run with --max-cost to bump the cap and "
+            "pick up where we left off."
+        )
+    return result
+
+
+def _default_taxonomy_path() -> Path:
+    """Resolve ``config/taxonomy.yaml`` relative to the working directory.
+
+    The Docker layout mounts ``./config`` at ``/app/config``; local dev
+    runs from the repo root where ``config/taxonomy.yaml`` exists too.
+    """
+    container_path = Path("/app/config/taxonomy.yaml")
+    if container_path.exists():
+        return container_path
+    return Path("config/taxonomy.yaml").resolve()
+
+
+__all__ = [
+    "TagResult",
+    "TagRow",
+    "TagStatus",
+    "Taxonomy",
+    "TaxonomyEntry",
+    "load_taxonomy",
+    "run_tag",
+]

--- a/tests/test_s1/test_stage_05.py
+++ b/tests/test_s1/test_stage_05.py
@@ -1,0 +1,544 @@
+"""Tests for :mod:`zotai.s1.stage_05_tag`.
+
+A fake ``OpenAIClient`` feeds scripted JSON responses (or
+``BudgetExceededError`` instances) to ``tag_paper``; a fake
+``ZoteroClient`` records every ``add_tags`` call. The taxonomy is
+loaded from an in-tmp YAML file so we can flip ``status: template``
+vs. ``status: customized`` per test.
+"""
+
+from __future__ import annotations
+
+import json
+from pathlib import Path
+from typing import Any
+
+import pytest
+import yaml
+from sqlmodel import Session, select
+
+from zotai.api.openai_client import BudgetExceededError
+from zotai.config import BudgetSettings, OpenAISettings, PathSettings, Settings, ZoteroSettings
+from zotai.s1.handler import StageAbortedError
+from zotai.s1.stage_05_tag import (
+    Taxonomy,
+    load_taxonomy,
+    run_tag,
+)
+from zotai.state import Item, init_s1, make_s1_engine
+
+# ─── Fakes ────────────────────────────────────────────────────────────────
+
+
+class FakeOpenAIClient:
+    def __init__(self, queue: list[str | Exception] | None = None) -> None:
+        self._queue: list[str | Exception] = list(queue or [])
+        self.tag_calls: list[dict[str, Any]] = []
+
+    async def tag_paper(
+        self,
+        *,
+        metadata: dict[str, Any],
+        taxonomy: dict[str, list[dict[str, Any]]],
+        model: str = "gpt-4o-mini",
+    ) -> Any:
+        self.tag_calls.append({"metadata": metadata, "taxonomy": taxonomy, "model": model})
+        if not self._queue:
+            raise AssertionError("tag_paper called more times than queued")
+        nxt = self._queue.pop(0)
+        if isinstance(nxt, Exception):
+            raise nxt
+        return _fake_usage(nxt, model)
+
+
+def _fake_usage(content: str, model: str) -> Any:
+    class _Msg:
+        def __init__(self, c: str) -> None:
+            self.content = c
+
+    class _Choice:
+        def __init__(self, c: str) -> None:
+            self.message = _Msg(c)
+
+    class _Response:
+        def __init__(self, c: str) -> None:
+            self.choices = [_Choice(c)]
+            self.usage = type(
+                "U", (), {"prompt_tokens": 50, "completion_tokens": 20}
+            )()
+
+    class _Usage:
+        def __init__(self, r: Any) -> None:
+            self.response = r
+            self.model = model
+            self.prompt_tokens = 50
+            self.completion_tokens = 20
+            self.cost_usd = 0.0005
+
+    return _Usage(_Response(content))
+
+
+class FakeZoteroClient:
+    def __init__(self) -> None:
+        self.dry_run = False
+        self.add_tags_calls: list[tuple[str, list[str]]] = []
+        self.should_raise: Exception | None = None
+
+    def add_tags(self, item: dict[str, Any], tags: list[str]) -> bool:
+        if self.should_raise is not None:
+            raise self.should_raise
+        self.add_tags_calls.append((str(item.get("key") or ""), list(tags)))
+        return True
+
+
+# ─── Fixtures ─────────────────────────────────────────────────────────────
+
+
+_MIN_TAXONOMY = {
+    "version": 1,
+    "status": "customized",
+    "tema": [
+        {"id": "macro-fiscal", "description": "Fiscal", "synonyms": ["fiscal"]},
+        {"id": "mercado-laboral", "description": "Labor", "synonyms": ["labor"]},
+        {"id": "informalidad", "description": "Informality", "synonyms": []},
+    ],
+    "metodo": [
+        {"id": "empirico-obs", "description": "Observational", "synonyms": []},
+        {"id": "empirico-rct", "description": "RCT", "synonyms": []},
+    ],
+}
+
+
+def _write_taxonomy(path: Path, *, status: str = "customized") -> Path:
+    data = dict(_MIN_TAXONOMY)
+    data["status"] = status
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    return path
+
+
+def _settings(tmp_path: Path) -> Settings:
+    return Settings(
+        paths=PathSettings(
+            state_db=tmp_path / "state.db",
+            reports_folder=tmp_path / "reports",
+            staging_folder=tmp_path / "staging",
+            pdf_source_folders=[],
+        ),
+        zotero=ZoteroSettings(library_id="123", library_type="user", local_api=True),
+        openai=OpenAISettings(),
+        budgets=BudgetSettings(max_cost_usd_stage_05=0.10),
+    )
+
+
+def _seed_item(
+    settings: Settings,
+    *,
+    sha: str,
+    zotero_key: str,
+    metadata: dict[str, Any] | None,
+    stage_completed: int = 4,
+    in_quarantine: bool = False,
+    tags_json: str | None = None,
+) -> None:
+    engine = make_s1_engine(str(settings.paths.state_db))
+    init_s1(engine)
+    with Session(engine) as session:
+        session.add(
+            Item(
+                id=sha,
+                source_path=f"/data/{sha}.pdf",
+                size_bytes=4096,
+                has_text=True,
+                classification="academic",
+                stage_completed=stage_completed,
+                import_route="A",
+                zotero_item_key=zotero_key,
+                in_quarantine=in_quarantine,
+                metadata_json=json.dumps(metadata) if metadata is not None else None,
+                tags_json=tags_json,
+            )
+        )
+        session.commit()
+
+
+# ─── Taxonomy loader ─────────────────────────────────────────────────────
+
+
+def test_load_taxonomy_template_is_accepted_by_loader(tmp_path: Path) -> None:
+    """The loader itself doesn't gate on status — the stage does.
+
+    Enables tests / tools that inspect taxonomy structure to run on the
+    shipped template without flipping the marker.
+    """
+    path = _write_taxonomy(tmp_path / "taxonomy.yaml", status="template")
+    tax = load_taxonomy(path)
+    assert isinstance(tax, Taxonomy)
+    assert tax.status == "template"
+    assert "macro-fiscal" in tax.tema_ids
+
+
+def test_load_taxonomy_raises_on_missing_file(tmp_path: Path) -> None:
+    with pytest.raises(StageAbortedError, match="not found"):
+        load_taxonomy(tmp_path / "nope.yaml")
+
+
+def test_load_taxonomy_raises_on_bad_yaml(tmp_path: Path) -> None:
+    bad = tmp_path / "bad.yaml"
+    bad.write_text(": : :\n", encoding="utf-8")
+    with pytest.raises(StageAbortedError, match="parse error"):
+        load_taxonomy(bad)
+
+
+def test_load_taxonomy_raises_on_unknown_status(tmp_path: Path) -> None:
+    path = tmp_path / "taxo.yaml"
+    data = dict(_MIN_TAXONOMY)
+    data["status"] = "draft"  # not in the Literal
+    path.write_text(yaml.safe_dump(data), encoding="utf-8")
+    with pytest.raises(StageAbortedError, match="schema error"):
+        load_taxonomy(path)
+
+
+# ─── Stage 05: template refusal + override ───────────────────────────────
+
+
+def test_stage_refuses_template_without_override(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    path = _write_taxonomy(tmp_path / "taxo.yaml", status="template")
+    with pytest.raises(StageAbortedError, match="status=template"):
+        run_tag(
+            preview=True,
+            apply=False,
+            settings=settings,
+            taxonomy_path=path,
+            openai_client=FakeOpenAIClient(queue=[]),
+            zotero_client=FakeZoteroClient(),  # type: ignore[arg-type]
+        )
+
+
+def test_stage_preview_runs_with_template_override(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    path = _write_taxonomy(tmp_path / "taxo.yaml", status="template")
+    _seed_item(
+        settings,
+        sha="a" * 64,
+        zotero_key="ZKEY01",
+        metadata={"title": "Fiscal multipliers"},
+    )
+    llm = FakeOpenAIClient(
+        queue=[json.dumps({"tema": ["macro-fiscal"], "metodo": ["empirico-obs"]})]
+    )
+    zot = FakeZoteroClient()
+    result = run_tag(
+        preview=True,
+        apply=False,
+        allow_template_taxonomy=True,
+        settings=settings,
+        taxonomy_path=path,
+        openai_client=llm,  # type: ignore[arg-type]
+        zotero_client=zot,  # type: ignore[arg-type]
+    )
+    assert result.items_previewed == 1
+    # Preview mode: CSV exists, Zotero untouched, DB unchanged.
+    assert result.csv_path.exists()
+    assert zot.add_tags_calls == []
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.tags_json is None
+    assert item.stage_completed == 4
+
+
+# ─── Stage 05: apply happy path ──────────────────────────────────────────
+
+
+def test_stage_apply_tags_item_in_zotero_and_db(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    path = _write_taxonomy(tmp_path / "taxo.yaml", status="customized")
+    _seed_item(
+        settings,
+        sha="b" * 64,
+        zotero_key="ZKEY02",
+        metadata={"title": "Informal economy in LATAM"},
+    )
+    llm = FakeOpenAIClient(
+        queue=[
+            json.dumps(
+                {"tema": ["informalidad", "mercado-laboral"], "metodo": ["empirico-obs"]}
+            )
+        ]
+    )
+    zot = FakeZoteroClient()
+    result = run_tag(
+        preview=False,
+        apply=True,
+        settings=settings,
+        taxonomy_path=path,
+        openai_client=llm,  # type: ignore[arg-type]
+        zotero_client=zot,  # type: ignore[arg-type]
+    )
+    assert result.items_tagged == 1
+    assert zot.add_tags_calls == [
+        ("ZKEY02", ["informalidad", "mercado-laboral", "empirico-obs"])
+    ]
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.stage_completed == 5
+    assert item.tags_json is not None
+    persisted = json.loads(item.tags_json)
+    assert persisted["tema"] == ["informalidad", "mercado-laboral"]
+    assert persisted["metodo"] == ["empirico-obs"]
+
+
+# ─── Stage 05: dry-run short-circuits writes ─────────────────────────────
+
+
+def test_stage_apply_with_dry_run_writes_nothing(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    path = _write_taxonomy(tmp_path / "taxo.yaml", status="customized")
+    _seed_item(settings, sha="c" * 64, zotero_key="ZKEY03", metadata={"title": "X"})
+    llm = FakeOpenAIClient(
+        queue=[json.dumps({"tema": ["macro-fiscal"], "metodo": ["empirico-obs"]})]
+    )
+    zot = FakeZoteroClient()
+    result = run_tag(
+        preview=False,
+        apply=True,
+        dry_run=True,
+        settings=settings,
+        taxonomy_path=path,
+        openai_client=llm,  # type: ignore[arg-type]
+        zotero_client=zot,  # type: ignore[arg-type]
+    )
+    assert [r.status for r in result.rows] == ["dry_run"]
+    assert zot.add_tags_calls == []
+    assert "_dryrun" in result.csv_path.name
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        item = session.exec(select(Item)).one()
+    assert item.stage_completed == 4
+    assert item.tags_json is None
+
+
+# ─── Stage 05: strict validation drops unknown ids ───────────────────────
+
+
+def test_stage_drops_unknown_tags(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    path = _write_taxonomy(tmp_path / "taxo.yaml", status="customized")
+    _seed_item(settings, sha="d" * 64, zotero_key="ZKEY04", metadata={"title": "X"})
+    llm = FakeOpenAIClient(
+        queue=[
+            json.dumps(
+                {
+                    "tema": ["macro-fiscal", "hallucinated-tag"],
+                    "metodo": ["empirico-obs", "another-ghost"],
+                }
+            )
+        ]
+    )
+    zot = FakeZoteroClient()
+    result = run_tag(
+        preview=False,
+        apply=True,
+        settings=settings,
+        taxonomy_path=path,
+        openai_client=llm,  # type: ignore[arg-type]
+        zotero_client=zot,  # type: ignore[arg-type]
+    )
+    assert result.items_tagged == 1
+    # Only the taxonomy-matching tags reached Zotero.
+    assert zot.add_tags_calls == [("ZKEY04", ["macro-fiscal", "empirico-obs"])]
+    # Rejected ids still land in the CSV so the user can spot them.
+    assert result.rows[0].tema_rejected == ["hallucinated-tag"]
+    assert result.rows[0].metodo_rejected == ["another-ghost"]
+
+
+# ─── Stage 05: malformed JSON → retry once ───────────────────────────────
+
+
+def test_stage_retries_once_on_malformed_json(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    path = _write_taxonomy(tmp_path / "taxo.yaml", status="customized")
+    _seed_item(settings, sha="e" * 64, zotero_key="ZKEY05", metadata={"title": "X"})
+    llm = FakeOpenAIClient(
+        queue=[
+            "garbage {{ not json",
+            json.dumps({"tema": ["macro-fiscal"], "metodo": ["empirico-rct"]}),
+        ]
+    )
+    zot = FakeZoteroClient()
+    result = run_tag(
+        preview=False,
+        apply=True,
+        settings=settings,
+        taxonomy_path=path,
+        openai_client=llm,  # type: ignore[arg-type]
+        zotero_client=zot,  # type: ignore[arg-type]
+    )
+    assert result.items_tagged == 1
+    assert len(llm.tag_calls) == 2, "Second attempt should have fired"
+
+
+def test_stage_llm_failure_after_retries(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    path = _write_taxonomy(tmp_path / "taxo.yaml", status="customized")
+    _seed_item(settings, sha="f" * 64, zotero_key="ZKEY06", metadata={"title": "X"})
+    llm = FakeOpenAIClient(queue=["bad", "also bad"])
+    zot = FakeZoteroClient()
+    result = run_tag(
+        preview=False,
+        apply=True,
+        settings=settings,
+        taxonomy_path=path,
+        openai_client=llm,  # type: ignore[arg-type]
+        zotero_client=zot,  # type: ignore[arg-type]
+    )
+    assert result.items_llm_failed == 1
+    assert result.items_tagged == 0
+    assert zot.add_tags_calls == []
+
+
+# ─── Stage 05: eligibility filters ───────────────────────────────────────
+
+
+def test_stage_skips_quarantined_items(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    path = _write_taxonomy(tmp_path / "taxo.yaml", status="customized")
+    _seed_item(
+        settings,
+        sha="g" * 64,
+        zotero_key="ZKEY07",
+        metadata={"title": "Quarantined paper"},
+        in_quarantine=True,
+    )
+    llm = FakeOpenAIClient()  # no queue
+    zot = FakeZoteroClient()
+    result = run_tag(
+        preview=True,
+        apply=False,
+        settings=settings,
+        taxonomy_path=path,
+        openai_client=llm,  # type: ignore[arg-type]
+        zotero_client=zot,  # type: ignore[arg-type]
+    )
+    assert result.items_processed == 0
+    assert len(result.rows) == 0
+    assert llm.tag_calls == []
+
+
+def test_stage_skips_already_tagged_without_re_tag_flag(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    path = _write_taxonomy(tmp_path / "taxo.yaml", status="customized")
+    _seed_item(
+        settings,
+        sha="h" * 64,
+        zotero_key="ZKEY08",
+        metadata={"title": "Already tagged"},
+        tags_json=json.dumps({"tema": ["x"], "metodo": ["y"]}),
+    )
+    llm = FakeOpenAIClient()  # no queue
+    zot = FakeZoteroClient()
+    result = run_tag(
+        preview=True,
+        apply=False,
+        settings=settings,
+        taxonomy_path=path,
+        openai_client=llm,  # type: ignore[arg-type]
+        zotero_client=zot,  # type: ignore[arg-type]
+    )
+    assert result.items_processed == 0
+    assert llm.tag_calls == []
+
+
+def test_stage_re_tag_includes_already_tagged(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    path = _write_taxonomy(tmp_path / "taxo.yaml", status="customized")
+    _seed_item(
+        settings,
+        sha="i" * 64,
+        zotero_key="ZKEY09",
+        metadata={"title": "Already tagged"},
+        tags_json=json.dumps({"tema": ["old"], "metodo": ["old"]}),
+    )
+    llm = FakeOpenAIClient(
+        queue=[json.dumps({"tema": ["macro-fiscal"], "metodo": ["empirico-obs"]})]
+    )
+    zot = FakeZoteroClient()
+    result = run_tag(
+        preview=False,
+        apply=True,
+        re_tag=True,
+        settings=settings,
+        taxonomy_path=path,
+        openai_client=llm,  # type: ignore[arg-type]
+        zotero_client=zot,  # type: ignore[arg-type]
+    )
+    assert result.items_tagged == 1
+
+
+# ─── Stage 05: no metadata short-circuit ─────────────────────────────────
+
+
+def test_stage_skips_items_without_metadata(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    path = _write_taxonomy(tmp_path / "taxo.yaml", status="customized")
+    _seed_item(settings, sha="j" * 64, zotero_key="ZKEY10", metadata=None)
+    llm = FakeOpenAIClient()
+    zot = FakeZoteroClient()
+    result = run_tag(
+        preview=False,
+        apply=True,
+        settings=settings,
+        taxonomy_path=path,
+        openai_client=llm,  # type: ignore[arg-type]
+        zotero_client=zot,  # type: ignore[arg-type]
+    )
+    assert result.items_no_metadata == 1
+    assert llm.tag_calls == []
+    assert zot.add_tags_calls == []
+
+
+# ─── Stage 05: budget exceeded aborts cleanly ────────────────────────────
+
+
+def test_stage_budget_exceeded_aborts_with_partial_state(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    path = _write_taxonomy(tmp_path / "taxo.yaml", status="customized")
+    # Two eligible items; the second trips the budget.
+    _seed_item(settings, sha="k" * 64, zotero_key="ZKEY11", metadata={"title": "A"})
+    _seed_item(settings, sha="l" * 64, zotero_key="ZKEY12", metadata={"title": "B"})
+    llm = FakeOpenAIClient(
+        queue=[
+            json.dumps({"tema": ["macro-fiscal"], "metodo": ["empirico-obs"]}),
+            BudgetExceededError("cap tripped"),
+        ]
+    )
+    zot = FakeZoteroClient()
+    with pytest.raises(StageAbortedError, match="budget exceeded"):
+        run_tag(
+            preview=False,
+            apply=True,
+            settings=settings,
+            taxonomy_path=path,
+            openai_client=llm,  # type: ignore[arg-type]
+            zotero_client=zot,  # type: ignore[arg-type]
+        )
+    # First item was committed before the second tripped; enforced by the
+    # commit-in-finally pattern so partial state is durable.
+    engine = make_s1_engine(str(settings.paths.state_db))
+    with Session(engine) as session:
+        items = {item.id: item for item in session.exec(select(Item))}
+    assert items["k" * 64].stage_completed == 5
+    assert items["k" * 64].tags_json is not None
+    assert items["l" * 64].stage_completed == 4
+    assert items["l" * 64].tags_json is None
+
+
+# ─── Stage 05: --preview and --apply together is rejected ────────────────
+
+
+def test_stage_rejects_both_preview_and_apply(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    with pytest.raises(StageAbortedError, match="exactly one"):
+        run_tag(preview=True, apply=True, settings=settings)


### PR DESCRIPTION
Closes #7.

## Summary

- \`zotai.s1.stage_05_tag.run_tag\` drives Stage 05: eligible items are tagged by \`OpenAIClient.tag_paper\` against the TEMA / METODO taxonomy loaded from \`config/taxonomy.yaml\`.
- **Pydantic-validated JSON** with retry-once on malformed output; after the retry the item is flagged \`llm_failed\` and left without tags.
- **Strict taxonomy validation** — ids not present in the taxonomy are dropped (not fatal) and surfaced in the CSV's \`tema_rejected\` / \`metodo_rejected\` columns so the researcher can spot hallucinations or taxonomy gaps.
- **Two modes**: \`--preview\` writes the CSV only (no Zotero / no DB writes); \`--apply\` calls \`ZoteroClient.add_tags\`, persists \`Item.tags_json\`, advances \`stage_completed\` to 5. Global \`--dry-run\` short-circuits writes in either mode.
- **Taxonomy sanity gate** — refuses to run while \`config/taxonomy.yaml\` has \`status: template\` unless \`--allow-template-taxonomy\` is passed. Protects against accidentally populating a real library with placeholder tags.
- **Budget**: \`MAX_COST_USD_STAGE_05\` (default \$1.00) with \`--max-cost\` override. \`BudgetExceededError\` aborts via \`StageAbortedError\` with partial state preserved — re-run with a higher cap picks up where we left off.

## Files

- **New**: \`src/zotai/s1/stage_05_tag.py\`, \`tests/test_s1/test_stage_05.py\`
- **Changed**: \`src/zotai/cli.py\` (\`s1 tag\` stub → real), \`CHANGELOG.md\`

## CLI

\`\`\`bash
zotai s1 tag --preview          # recommended first run
zotai s1 tag --apply
zotai s1 tag --apply --re-tag   # re-process already-tagged items
zotai s1 tag --preview --allow-template-taxonomy  # testing without customizing taxonomy
\`\`\`

## Test plan

- [x] \`pytest tests/test_s1/test_stage_05.py\` — 17 passed
- [x] \`pytest\` full suite — **175 passed** (was 158; +17)
- [x] \`mypy --strict src/zotai/s1/stage_05_tag.py src/zotai/cli.py\` — clean
- [x] \`ruff check\` on modified files — clean
- [ ] End-to-end \`--preview\` on a real Zotero library after the taxonomy is customized (manual, post-merge)

### Test coverage

1. Taxonomy loader: accepts template status for inspection; raises on missing / bad YAML / unknown status.
2. Stage: refuses \`status=template\` without \`--allow-template-taxonomy\`; runs when overridden.
3. \`--apply\` happy path: tags flow to Zotero + \`Item.tags_json\` + \`stage_completed=5\`.
4. \`--apply --dry-run\` writes only the CSV with \`_dryrun\` suffix.
5. Strict validation: unknown ids are dropped and surfaced in rejected columns.
6. Retry-once on malformed JSON; \`llm_failed\` after exhausted retries.
7. Eligibility: skips quarantined and already-tagged items; \`--re-tag\` includes them.
8. No metadata → \`no_metadata\` short-circuit (no LLM call).
9. Budget exceeded mid-batch aborts with partial commit (first item tagged, second pending).
10. \`--preview\` + \`--apply\` together is rejected.

## Related

- Issue #7 (Phase 6 — Stage 05 Tagging)
- ADR 005 (gpt-4o-mini for tagging/extraction) — this is the first production call path that closes that loop
- \`docs/plan_01_subsystem1.md\` §3 Etapa 05
- \`docs/plan_taxonomy.md\` (taxonomy design + domain-adapt guide)
- \`config/taxonomy.yaml\` (template — customize before \`--apply\` on real library)

## Next

Phase 7 (#8) — Stage 06 validation report. Reads all the counters Stage 05 just made meaningful.