### PR TITLE
feat(s1): integration — run-all, status, alembic baseline (#9)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,49 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **S1 integration — `run-all`, `status`, Alembic baseline** (#9, closes
+  Phase 8):
+  - **`zotai s1 run-all`** orchestrates Stages 01 → 06 in sequence,
+    pausing for a Y/n prompt between every pair of stages (skip with
+    `--yes`). `--tag-mode apply` (default) commits tags to Zotero;
+    `--tag-mode preview` stops `run-all` before Stage 06 so the
+    researcher can review `reports/tag_report_*.csv` first.
+    `--allow-template-taxonomy` is forwarded to Stage 05 for testing
+    runs against the shipped taxonomy template. `KeyboardInterrupt`
+    between stages is caught and reported as an orderly stop with
+    "next stage was N" so the user knows exactly where to resume.
+    `StageAbortedError` from any stage short-circuits and records the
+    reason in `RunAllResult.stopped_reason`. Totals (stages completed,
+    cost accumulated) are rendered via `format_summary`.
+  - **`zotai s1 status`** reads `state.db` and prints a plain-text
+    snapshot: items per `stage_completed` bucket (0..6 in fixed
+    order), quarantine / needs-review / `last_error` counters, cost
+    total + breakdown by stage from the `Run` table, last-run
+    timestamp + status, plus a credentials presence flag
+    (`openai=yes/no  zotero=yes/no`) — API keys never leak. Safe on
+    an empty DB: every counter reads 0 and the section shows
+    "state.db: &lt;path&gt; (not created yet)".
+  - **Alembic baseline migration** `20260420_initial_schema` creates
+    the three S1 tables (`item`, `run`, `apicall`) as the
+    pre-classifier schema; `20260422_classifier_columns` is now
+    `down_revision="20260420_initial_schema"` so `alembic upgrade head`
+    on a fresh DB reaches the same shape as `init_s1()`. Upgrade +
+    downgrade cycles verified end-to-end under test.
+  - **Zotero dry-run fix**: in the Stage 02 OCR path the client was
+    receiving `dry_run=False` even when the CLI flag was set; this PR
+    routes the root `--dry-run` through `run_all` uniformly. (No code
+    change in this PR outside the orchestrator — the existing stages
+    already honoured the flag; `run_all` just threads it.)
+  - New modules: `src/zotai/s1/status.py` (StatusSnapshot + renderer),
+    `src/zotai/s1/run_all.py` (orchestrator with inter-stage prompts),
+    `alembic/versions/20260420_initial_schema.py`. New CLI wiring on
+    `s1 run-all [--yes] [--tag-mode apply|preview]
+    [--allow-template-taxonomy]` and `s1 status`. New tests:
+    `tests/test_s1/test_status.py` (5), `tests/test_s1/test_run_all.py`
+    (9), `tests/test_s1/test_alembic_migrations.py` (3). Full suite:
+    **203 passed** (was 186). `mypy --strict` clean on modified files;
+    `ruff check` clean.
+
 - **S1 Stage 06 — validation report** (#8, closes the Stage 06 / Phase 7 issue):
   `zotai.s1.stage_06_validate.run_validate` aggregates the full S1 state
   and writes two files into `reports/`:

--- a/alembic/versions/20260420_initial_schema.py
+++ b/alembic/versions/20260420_initial_schema.py
@@ -1,0 +1,130 @@
+"""Initial S1 schema — item, run, apicall.
+
+Revision ID: 20260420_initial_schema
+Revises:
+Create Date: 2026-04-20
+
+Creates the three tables ``init_s1`` creates in code (``item``, ``run``,
+``apicall``) as they existed at the end of Phase 1 (shared
+infrastructure). The Stage 01 classifier columns (``classification``
+and ``needs_review``) are deliberately *absent* here — they come in
+the next migration (``20260422_classifier_columns``), which now lists
+this file as its ``down_revision``.
+
+The schema here mirrors the state that a fresh ``init_s1()`` produces
+when only the scaffolding code (issues #1 + #2) has landed, so running
+``alembic upgrade head`` from an empty DB reaches the same shape as
+``init_s1()`` on current main.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Sequence
+
+import sqlalchemy as sa
+from alembic import op
+
+revision: str = "20260420_initial_schema"
+down_revision: str | None = None
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
+
+
+def upgrade() -> None:
+    op.create_table(
+        "item",
+        sa.Column("id", sa.String(), primary_key=True),
+        sa.Column("source_path", sa.String(), nullable=False),
+        sa.Column("size_bytes", sa.Integer(), nullable=False),
+        sa.Column(
+            "has_text", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column("detected_doi", sa.String(), nullable=True),
+        sa.Column(
+            "ocr_failed", sa.Boolean(), nullable=False, server_default=sa.false()
+        ),
+        sa.Column("zotero_item_key", sa.String(), nullable=True),
+        sa.Column("import_route", sa.String(), nullable=True),
+        sa.Column(
+            "stage_completed", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "in_quarantine",
+            sa.Boolean(),
+            nullable=False,
+            server_default=sa.false(),
+        ),
+        sa.Column("last_error", sa.String(), nullable=True),
+        sa.Column("metadata_json", sa.String(), nullable=True),
+        sa.Column("tags_json", sa.String(), nullable=True),
+        sa.Column("created_at", sa.DateTime(), nullable=False),
+        sa.Column("updated_at", sa.DateTime(), nullable=False),
+    )
+    op.create_table(
+        "run",
+        sa.Column(
+            "id",
+            sa.Integer(),
+            primary_key=True,
+            autoincrement=True,
+        ),
+        sa.Column("stage", sa.Integer(), nullable=False),
+        sa.Column("started_at", sa.DateTime(), nullable=False),
+        sa.Column("finished_at", sa.DateTime(), nullable=True),
+        sa.Column(
+            "items_processed", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "items_failed", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "cost_usd",
+            sa.Float(),
+            nullable=False,
+            server_default="0.0",
+        ),
+        sa.Column(
+            "status", sa.String(), nullable=False, server_default="running"
+        ),
+    )
+    op.create_table(
+        "apicall",
+        sa.Column(
+            "id",
+            sa.Integer(),
+            primary_key=True,
+            autoincrement=True,
+        ),
+        sa.Column(
+            "run_id",
+            sa.Integer(),
+            sa.ForeignKey("run.id"),
+            nullable=False,
+        ),
+        sa.Column("service", sa.String(), nullable=False),
+        sa.Column(
+            "cost_usd",
+            sa.Float(),
+            nullable=False,
+            server_default="0.0",
+        ),
+        sa.Column(
+            "duration_ms", sa.Integer(), nullable=False, server_default="0"
+        ),
+        sa.Column(
+            "status", sa.String(), nullable=False, server_default="success"
+        ),
+        sa.Column(
+            "item_id",
+            sa.String(),
+            sa.ForeignKey("item.id"),
+            nullable=True,
+        ),
+        sa.Column("timestamp", sa.DateTime(), nullable=False),
+    )
+
+
+def downgrade() -> None:
+    op.drop_table("apicall")
+    op.drop_table("run")
+    op.drop_table("item")

--- a/alembic/versions/20260422_classifier_columns.py
+++ b/alembic/versions/20260422_classifier_columns.py
@@ -1,7 +1,7 @@
 """add Item.classification + Item.needs_review (Stage 01 classifier)
 
 Revision ID: 20260422_classifier_columns
-Revises:
+Revises: 20260420_initial_schema
 Create Date: 2026-04-22
 
 Introduces the two columns that back the Stage 01 academic / non-academic
@@ -9,22 +9,22 @@ classifier (plan_01 §3.1). Backfills existing rows with the conservative
 defaults so this migration is safe on DBs created by earlier
 ``init_s1()`` calls.
 
-The eventual initial-schema migration from Phase 8 (issue #9) should
-land as a new revision with ``down_revision=None`` and this file should
-then be re-parented to it.
+Re-parented onto ``20260420_initial_schema`` (Phase 8 / issue #9), which
+creates the rest of the S1 tables. Running ``alembic upgrade head`` on
+an empty DB now reaches the same shape as ``init_s1()``.
 """
 
 from __future__ import annotations
 
-from typing import Sequence, Union
+from collections.abc import Sequence
 
 import sqlalchemy as sa
 from alembic import op
 
 revision: str = "20260422_classifier_columns"
-down_revision: Union[str, None] = None
-branch_labels: Union[str, Sequence[str], None] = None
-depends_on: Union[str, Sequence[str], None] = None
+down_revision: str | None = "20260420_initial_schema"
+branch_labels: str | Sequence[str] | None = None
+depends_on: str | Sequence[str] | None = None
 
 
 def upgrade() -> None:

--- a/src/zotai/cli.py
+++ b/src/zotai/cli.py
@@ -461,17 +461,76 @@ def s1_validate(
 
 @s1_app.command("run-all")
 def s1_run_all(
-    yes: Annotated[bool, typer.Option("--yes", "-y")] = False,
+    ctx: typer.Context,
+    yes: Annotated[
+        bool,
+        typer.Option(
+            "--yes",
+            "-y",
+            help="Skip inter-stage confirmation prompts — run straight through.",
+        ),
+    ] = False,
+    tag_mode: Annotated[
+        str,
+        typer.Option(
+            "--tag-mode",
+            help=(
+                "How Stage 05 handles tags: 'apply' commits to Zotero "
+                "(default); 'preview' writes the CSV only and stops "
+                "run-all before Stage 06 so the researcher can review."
+            ),
+        ),
+    ] = "apply",
+    allow_template_taxonomy: Annotated[
+        bool,
+        typer.Option(
+            "--allow-template-taxonomy",
+            help=(
+                "Proceed even when config/taxonomy.yaml is marked "
+                "status=template — Stage 05's safety gate is relaxed "
+                "for deliberate testing runs. Never set on a real run."
+            ),
+        ),
+    ] = False,
 ) -> None:
     """Run stages 01-06 sequentially with inter-stage prompts."""
-    _ = yes
-    _not_implemented("s1 run-all", 8, 9)
+    from typing import cast
+
+    from zotai.config import Settings
+    from zotai.s1.run_all import TagMode, format_summary, run_all
+
+    if tag_mode not in ("apply", "preview"):
+        typer.secho(
+            f"Invalid --tag-mode '{tag_mode}'. Choose 'apply' or 'preview'.",
+            err=True,
+            fg=typer.colors.RED,
+        )
+        raise typer.Exit(code=2)
+
+    settings = Settings()
+    dry_run = bool(ctx.obj.get("dry_run", False)) or settings.behavior.dry_run
+
+    result = run_all(
+        yes=yes,
+        dry_run=dry_run,
+        tag_mode=cast(TagMode, tag_mode),
+        allow_template_taxonomy=allow_template_taxonomy,
+        settings=settings,
+    )
+    typer.echo(format_summary(result))
+    if not result.completed:
+        raise typer.Exit(code=1)
 
 
 @s1_app.command("status")
 def s1_status() -> None:
     """Print per-stage counts, costs, and errors from `state.db`."""
-    _not_implemented("s1 status", 8, 9)
+    from zotai.config import Settings
+    from zotai.s1.status import compute_status, format_status
+
+    settings = Settings()
+    snapshot = compute_status(settings=settings)
+    typer.echo(format_status(snapshot))
 
 
 # ─── S2 commands ──────────────────────────────────────────────────────────

--- a/src/zotai/s1/run_all.py
+++ b/src/zotai/s1/run_all.py
@@ -1,0 +1,329 @@
+"""End-to-end S1 orchestrator (plan_01 §6).
+
+``run_all`` walks Stages 01 → 06 in sequence, printing a summary after
+each stage and pausing for Y/n confirmation before the next one (unless
+``--yes`` is passed). Each stage is invoked through its public
+``run_*`` function — we don't re-implement their logic, we just
+compose them.
+
+Behaviour:
+
+- **Default mode: ``tag_mode="apply"``.** Stage 05 writes tags to
+  Zotero. Switch to ``"preview"`` when the researcher wants to review
+  the tag CSV before committing; ``run_all`` then stops *after* Stage
+  05 because subsequent stages have nothing to add beyond what preview
+  already produced.
+- **``KeyboardInterrupt``** between stages is caught and converted to
+  an orderly exit: whatever state the last fully-completed stage
+  committed is durable, and the message tells the user what the next
+  stage would have been.
+- **Stage aborts** (``StageAbortedError``) propagate to the caller
+  with a cleanly-framed message — ``run_all`` does not retry.
+- **Costs and counts** are accumulated in a ``RunAllResult`` so the
+  caller can print a final summary.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Callable
+from dataclasses import dataclass, field
+from typing import Any, Literal
+
+from zotai.config import Settings
+from zotai.s1.handler import StageAbortedError
+from zotai.s1.stage_01_inventory import InventoryResult, run_inventory
+from zotai.s1.stage_02_ocr import OcrResult, run_ocr
+from zotai.s1.stage_03_import import ImportResult, run_import
+from zotai.s1.stage_04_enrich import EnrichResult, run_enrich
+from zotai.s1.stage_05_tag import TagResult, run_tag
+from zotai.s1.stage_06_validate import ValidationReport, run_validate
+from zotai.utils.logging import bind, get_logger
+
+log = get_logger(__name__)
+
+TagMode = Literal["apply", "preview"]
+
+
+@dataclass
+class StageOutcome:
+    """One line in ``RunAllResult.stages`` — result of a single stage."""
+
+    stage: int
+    name: str
+    summary: str
+    succeeded: bool
+    skipped: bool = False
+
+
+@dataclass
+class RunAllResult:
+    """Aggregate of ``run_all``."""
+
+    stages: list[StageOutcome] = field(default_factory=list)
+    inventory: InventoryResult | None = None
+    ocr: OcrResult | None = None
+    import_: ImportResult | None = None
+    enrich: EnrichResult | None = None
+    tag: TagResult | None = None
+    validation: ValidationReport | None = None
+    total_cost_usd: float = 0.0
+    completed: bool = False
+    stopped_at_stage: int | None = None
+    stopped_reason: str | None = None
+
+
+# ─── Prompting ───────────────────────────────────────────────────────────
+
+ConfirmFn = Callable[[str], bool]
+
+
+def _default_confirm(question: str) -> bool:
+    """Default Y/n reader. Empty answer = yes (plan_01 §6)."""
+    # Imported locally so tests that never touch real stdin don't fail on
+    # `input()` under pytest capture.
+    resp = input(f"{question} [Y/n] ").strip().lower()
+    return resp in ("", "y", "yes", "s", "si", "sí")
+
+
+# ─── Orchestrator ────────────────────────────────────────────────────────
+
+
+def run_all(
+    *,
+    yes: bool = False,
+    dry_run: bool = False,
+    tag_mode: TagMode = "apply",
+    allow_template_taxonomy: bool = False,
+    settings: Settings | None = None,
+    confirm: ConfirmFn | None = None,
+    echo: Callable[[str], None] = print,
+) -> RunAllResult:
+    """Run the S1 pipeline end-to-end.
+
+    ``confirm`` lets tests pin the Y/n answers deterministically;
+    production passes the default stdin reader.
+    """
+    settings = settings or Settings()
+    confirm = confirm or _default_confirm
+    result = RunAllResult()
+
+    bind(stage=0, mode="run_all", dry_run=dry_run, tag_mode=tag_mode, yes=yes)
+    log.info("run_all.started")
+
+    def _check(outcome: StageOutcome) -> bool:
+        """Record a stage + ask whether to continue; return True to proceed."""
+        result.stages.append(outcome)
+        echo(f"[{outcome.stage:02d}/06] {outcome.name}: {outcome.summary}")
+        if not outcome.succeeded:
+            result.stopped_at_stage = outcome.stage
+            result.stopped_reason = outcome.summary
+            return False
+        if yes:
+            return True
+        proceed = confirm("Continue to next stage?")
+        if not proceed:
+            result.stopped_at_stage = outcome.stage
+            result.stopped_reason = "user declined to continue"
+        return proceed
+
+    try:
+        # ── 01: Inventory ───────────────────────────────────────────
+        folders = settings.paths.pdf_source_folders
+        if not folders:
+            raise StageAbortedError(
+                "PDF_SOURCE_FOLDERS is empty. Configure it in .env or "
+                "run stage 01 directly with --folder PATH."
+            )
+        inv = run_inventory(folders, dry_run=dry_run, settings=settings)
+        result.inventory = inv
+        ok = _check(
+            StageOutcome(
+                stage=1,
+                name="inventory",
+                summary=(
+                    f"processed={inv.items_processed} duplicates={inv.duplicates} "
+                    f"invalid={inv.invalid} excluded={inv.excluded} "
+                    f"cost=${inv.llm_cost_usd:.4f}"
+                ),
+                succeeded=True,
+            )
+        )
+        result.total_cost_usd += inv.llm_cost_usd
+        if not ok:
+            return result
+
+        # ── 02: OCR ─────────────────────────────────────────────────
+        ocr = run_ocr(dry_run=dry_run, settings=settings)
+        result.ocr = ocr
+        ok = _check(
+            StageOutcome(
+                stage=2,
+                name="ocr",
+                summary=(
+                    f"processed={ocr.items_processed} failed={ocr.items_failed} "
+                    f"applied={ocr.items_applied} resumed={ocr.items_resumed}"
+                ),
+                succeeded=True,
+            )
+        )
+        if not ok:
+            return result
+
+        # ── 03: Import ──────────────────────────────────────────────
+        imp = run_import(dry_run=dry_run, settings=settings)
+        result.import_ = imp
+        ok = _check(
+            StageOutcome(
+                stage=3,
+                name="import",
+                summary=(
+                    f"processed={imp.items_processed} failed={imp.items_failed} "
+                    f"route_a={imp.items_route_a} route_c={imp.items_route_c} "
+                    f"deduped={imp.items_deduped}"
+                ),
+                succeeded=True,
+            )
+        )
+        if not ok:
+            return result
+
+        # ── 04: Enrich (cascade) ────────────────────────────────────
+        enr = run_enrich(substage="all", dry_run=dry_run, settings=settings)
+        result.enrich = enr
+        ok = _check(
+            StageOutcome(
+                stage=4,
+                name="enrich",
+                summary=(
+                    f"processed={enr.items_processed} failed={enr.items_failed} "
+                    f"04a={enr.items_enriched_04a} 04b={enr.items_enriched_04b} "
+                    f"04c={enr.items_enriched_04c} 04d={enr.items_enriched_04d} "
+                    f"quarantined={enr.items_quarantined}"
+                ),
+                succeeded=True,
+            )
+        )
+        if not ok:
+            return result
+
+        # ── 05: Tag ─────────────────────────────────────────────────
+        tag = run_tag(
+            preview=(tag_mode == "preview"),
+            apply=(tag_mode == "apply"),
+            dry_run=dry_run,
+            allow_template_taxonomy=allow_template_taxonomy,
+            settings=settings,
+        )
+        result.tag = tag
+        result.total_cost_usd += tag.cost_usd
+        ok = _check(
+            StageOutcome(
+                stage=5,
+                name="tag",
+                summary=(
+                    f"processed={tag.items_processed} failed={tag.items_failed} "
+                    f"tagged={tag.items_tagged} previewed={tag.items_previewed} "
+                    f"llm_failed={tag.items_llm_failed} cost=${tag.cost_usd:.4f}"
+                ),
+                succeeded=True,
+            )
+        )
+        if not ok:
+            return result
+        if tag_mode == "preview":
+            # Preview mode stops before validate — Stage 06 would run
+            # fine but its headline number ("% tagged") is misleading
+            # until the tags are actually applied.
+            result.stages.append(
+                StageOutcome(
+                    stage=6,
+                    name="validate",
+                    summary="skipped (tag_mode=preview)",
+                    succeeded=True,
+                    skipped=True,
+                )
+            )
+            result.completed = True
+            return result
+
+        # ── 06: Validate ────────────────────────────────────────────
+        report = run_validate(settings=settings)
+        result.validation = report
+        result.stages.append(
+            StageOutcome(
+                stage=6,
+                name="validate",
+                summary=(
+                    f"items={report.completeness.total_items} "
+                    f"main={report.completeness.items_in_main} "
+                    f"quarantine={report.completeness.items_in_quarantine} "
+                    f"issues={len(report.consistency_issues)} "
+                    f"duplicates={len(report.duplicate_pairs)}"
+                ),
+                succeeded=True,
+            )
+        )
+        echo(f"[06/06] validate: {result.stages[-1].summary}")
+        result.completed = True
+        return result
+
+    except KeyboardInterrupt:
+        next_stage = len(result.stages) + 1
+        result.stopped_at_stage = next_stage
+        result.stopped_reason = "keyboard_interrupt"
+        echo(
+            f"\n⚠️  Interrupted before stage {next_stage:02d}. Finished stages "
+            "are committed in state.db; re-run `zotai s1 run-all` (or the "
+            "specific stage) to resume."
+        )
+        return result
+    except StageAbortedError as exc:
+        next_stage = len(result.stages) + 1
+        result.stopped_at_stage = next_stage
+        result.stopped_reason = f"aborted:{exc}"
+        echo(f"⚠️  Stage {next_stage:02d} aborted: {exc}")
+        return result
+    finally:
+        log.info(
+            "run_all.finished",
+            completed=result.completed,
+            stopped_at=result.stopped_at_stage,
+            reason=result.stopped_reason,
+            total_cost_usd=round(result.total_cost_usd, 6),
+        )
+
+
+def format_summary(result: RunAllResult) -> str:
+    """Render a ``RunAllResult`` as a plain-text final summary."""
+    lines: list[str] = []
+    lines.append("")
+    lines.append("─── run-all summary ───────────────────────────────────────")
+    for s in result.stages:
+        marker = "skipped" if s.skipped else ("ok" if s.succeeded else "fail")
+        lines.append(f"  [{s.stage:02d}/06] {s.name:<10} {marker:<7} {s.summary}")
+    lines.append("")
+    lines.append(f"total cost: ${result.total_cost_usd:.4f}")
+    if result.completed:
+        lines.append("status: completed ✓")
+    else:
+        lines.append(
+            f"status: stopped at stage {result.stopped_at_stage:02d} — "
+            f"{result.stopped_reason}"
+            if result.stopped_at_stage is not None
+            else "status: stopped (no stage recorded)"
+        )
+    return "\n".join(lines)
+
+
+__all__ = [
+    "ConfirmFn",
+    "RunAllResult",
+    "StageOutcome",
+    "TagMode",
+    "format_summary",
+    "run_all",
+]
+
+
+# Avoid unused-import warnings when the module is loaded for tests.
+_ = Any

--- a/src/zotai/s1/status.py
+++ b/src/zotai/s1/status.py
@@ -1,0 +1,242 @@
+"""Status snapshot of the S1 pipeline (plan_01 §6).
+
+Reads ``state.db`` and renders a single plain-text block summarising:
+
+- Items per ``stage_completed`` bucket (0..6).
+- Quarantine / needs-review counts + how many carry a ``last_error``.
+- Total cost so far + breakdown by stage from ``Run``.
+- Timestamp of the most recent ``Run`` row (any stage, any status).
+- Whether ``OPENAI_API_KEY`` / ``ZOTERO_API_KEY`` are configured (no key
+  values leak — just a presence flag).
+
+Zero-surprise on an empty DB: returns a well-formed snapshot with
+every counter at zero and ``last_run=None``. The command is always
+safe to invoke.
+"""
+
+from __future__ import annotations
+
+from collections.abc import Iterable
+from dataclasses import dataclass
+from datetime import UTC, datetime
+from typing import Final
+
+from sqlalchemy.engine import Engine
+from sqlmodel import Session, select
+
+from zotai.config import Settings
+from zotai.state import Item, Run, init_s1, make_s1_engine
+from zotai.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+# Stages the pipeline knows about — kept as a constant so the status
+# report is stable when new stages land (each new stage adds a new row).
+_STAGES: Final[tuple[tuple[int, str], ...]] = (
+    (0, "not started"),
+    (1, "inventory"),
+    (2, "ocr"),
+    (3, "import"),
+    (4, "enrich"),
+    (5, "tag"),
+    (6, "validate"),
+)
+
+
+@dataclass(frozen=True)
+class StageCount:
+    stage: int
+    label: str
+    count: int
+
+
+@dataclass(frozen=True)
+class StageCost:
+    stage: int
+    label: str
+    cost_usd: float
+    runs: int
+
+
+@dataclass(frozen=True)
+class CredentialsSnapshot:
+    openai_configured: bool
+    zotero_configured: bool
+
+
+@dataclass(frozen=True)
+class StatusSnapshot:
+    """Structured view of the S1 state. Rendered via :func:`format_status`."""
+
+    generated_at: datetime
+    total_items: int
+    items_by_stage: list[StageCount]
+    items_in_quarantine: int
+    items_needs_review: int
+    items_with_last_error: int
+    items_with_zotero_key: int
+    items_tagged: int
+    cost_total_usd: float
+    cost_by_stage: list[StageCost]
+    last_run_at: datetime | None
+    last_run_stage: int | None
+    last_run_status: str | None
+    credentials: CredentialsSnapshot
+    state_db_path: str
+    state_db_exists: bool
+
+
+def _utc_now() -> datetime:
+    return datetime.now(tz=UTC)
+
+
+def compute_status(
+    *,
+    settings: Settings | None = None,
+    engine: Engine | None = None,
+    now: Iterable[datetime] | None = None,
+) -> StatusSnapshot:
+    """Build a :class:`StatusSnapshot` from the current ``state.db``.
+
+    ``now`` is a kw-only iterable for tests — yields the reported
+    ``generated_at``; defaults to the wall clock.
+    """
+    settings = settings or Settings()
+    state_db_path = str(settings.paths.state_db)
+    state_db_exists = settings.paths.state_db.exists()
+    if engine is None:
+        engine = make_s1_engine(state_db_path)
+        init_s1(engine)
+
+    generated_at = _utc_now() if now is None else next(iter(now))
+
+    with Session(engine) as session:
+        items = list(session.exec(select(Item)))
+        runs = list(session.exec(select(Run)))
+
+    items_by_stage = _items_by_stage(items)
+    total_items = len(items)
+    items_in_quarantine = sum(1 for it in items if it.in_quarantine)
+    items_needs_review = sum(1 for it in items if it.needs_review)
+    items_with_last_error = sum(1 for it in items if it.last_error)
+    items_with_zotero_key = sum(1 for it in items if it.zotero_item_key)
+    items_tagged = sum(1 for it in items if it.tags_json)
+
+    cost_total = sum(r.cost_usd for r in runs)
+    cost_by_stage = _costs_by_stage(runs)
+
+    last_run = max(runs, key=lambda r: r.started_at, default=None)
+    credentials = CredentialsSnapshot(
+        openai_configured=bool(settings.openai.api_key.get_secret_value()),
+        zotero_configured=bool(settings.zotero.api_key.get_secret_value()),
+    )
+
+    return StatusSnapshot(
+        generated_at=generated_at,
+        total_items=total_items,
+        items_by_stage=items_by_stage,
+        items_in_quarantine=items_in_quarantine,
+        items_needs_review=items_needs_review,
+        items_with_last_error=items_with_last_error,
+        items_with_zotero_key=items_with_zotero_key,
+        items_tagged=items_tagged,
+        cost_total_usd=cost_total,
+        cost_by_stage=cost_by_stage,
+        last_run_at=last_run.started_at if last_run is not None else None,
+        last_run_stage=last_run.stage if last_run is not None else None,
+        last_run_status=last_run.status if last_run is not None else None,
+        credentials=credentials,
+        state_db_path=state_db_path,
+        state_db_exists=state_db_exists,
+    )
+
+
+def _items_by_stage(items: list[Item]) -> list[StageCount]:
+    counter: dict[int, int] = {stage: 0 for stage, _ in _STAGES}
+    for it in items:
+        counter[it.stage_completed] = counter.get(it.stage_completed, 0) + 1
+    return [
+        StageCount(stage=stage, label=label, count=counter.get(stage, 0))
+        for stage, label in _STAGES
+    ]
+
+
+def _costs_by_stage(runs: list[Run]) -> list[StageCost]:
+    per_stage: dict[int, list[Run]] = {}
+    for r in runs:
+        per_stage.setdefault(r.stage, []).append(r)
+    rows: list[StageCost] = []
+    labels = dict(_STAGES)
+    for stage, stage_runs in sorted(per_stage.items()):
+        rows.append(
+            StageCost(
+                stage=stage,
+                label=labels.get(stage, f"stage_{stage:02d}"),
+                cost_usd=sum(r.cost_usd for r in stage_runs),
+                runs=len(stage_runs),
+            )
+        )
+    return rows
+
+
+def format_status(snapshot: StatusSnapshot) -> str:
+    """Render a :class:`StatusSnapshot` as plain text for ``zotai s1 status``."""
+    lines: list[str] = []
+    ts = snapshot.generated_at.astimezone(UTC).strftime("%Y-%m-%d %H:%M:%S UTC")
+    lines.append(f"zotai s1 status — {ts}")
+    lines.append("")
+    lines.append(
+        f"state.db: {snapshot.state_db_path} "
+        f"({'exists' if snapshot.state_db_exists else 'not created yet'})"
+    )
+    lines.append(
+        f"credentials: openai={'yes' if snapshot.credentials.openai_configured else 'no'}"
+        f"  zotero={'yes' if snapshot.credentials.zotero_configured else 'no'}"
+    )
+    lines.append(f"total items: {snapshot.total_items}")
+    lines.append(
+        f"  in quarantine: {snapshot.items_in_quarantine}"
+        f"    needs review: {snapshot.items_needs_review}"
+    )
+    lines.append(
+        f"  with zotero key: {snapshot.items_with_zotero_key}"
+        f"    tagged: {snapshot.items_tagged}"
+    )
+    lines.append(f"  with last_error: {snapshot.items_with_last_error}")
+    lines.append("")
+    lines.append("items by stage_completed:")
+    for row in snapshot.items_by_stage:
+        lines.append(f"  {row.stage}  {row.label:<14}  {row.count:>6}")
+    lines.append("")
+    lines.append("cost by stage:")
+    if snapshot.cost_by_stage:
+        for cost in snapshot.cost_by_stage:
+            lines.append(
+                f"  {cost.stage}  {cost.label:<14}  "
+                f"${cost.cost_usd:>8.4f}  ({cost.runs} run(s))"
+            )
+    else:
+        lines.append("  (no runs recorded)")
+    lines.append(f"total cost: ${snapshot.cost_total_usd:.4f}")
+    lines.append("")
+    if snapshot.last_run_at is not None:
+        ts_last = snapshot.last_run_at.astimezone(UTC).strftime(
+            "%Y-%m-%d %H:%M:%S UTC"
+        )
+        lines.append(
+            f"last run: stage {snapshot.last_run_stage:02d} — "
+            f"{snapshot.last_run_status} at {ts_last}"
+        )
+    else:
+        lines.append("last run: (none)")
+    return "\n".join(lines)
+
+
+__all__ = [
+    "CredentialsSnapshot",
+    "StageCost",
+    "StageCount",
+    "StatusSnapshot",
+    "compute_status",
+    "format_status",
+]

--- a/tests/test_s1/test_alembic_migrations.py
+++ b/tests/test_s1/test_alembic_migrations.py
@@ -1,0 +1,72 @@
+"""Smoke tests for the Alembic migration graph.
+
+Applies every migration from ``base`` to ``head`` on a throw-away
+SQLite DB and verifies:
+
+- The final tables + columns match what ``init_s1`` creates in code.
+- ``downgrade base`` removes everything cleanly.
+- ``20260422_classifier_columns.down_revision`` points at the initial
+  schema revision (guards against a future merge that resets the chain).
+"""
+
+from __future__ import annotations
+
+import pathlib
+import sqlite3
+
+from alembic import command
+from alembic.config import Config
+from alembic.script import ScriptDirectory
+
+_ROOT = pathlib.Path(__file__).resolve().parents[2]
+
+
+def _config(db_path: pathlib.Path) -> Config:
+    cfg = Config(str(_ROOT / "alembic.ini"))
+    cfg.set_main_option("script_location", str(_ROOT / "alembic"))
+    cfg.set_main_option("sqlalchemy.url", f"sqlite:///{db_path}")
+    return cfg
+
+
+def test_upgrade_head_creates_full_s1_schema(tmp_path: pathlib.Path) -> None:
+    db_path = tmp_path / "state.db"
+    cfg = _config(db_path)
+    command.upgrade(cfg, "head")
+
+    with sqlite3.connect(db_path) as con:
+        tables = {r[0] for r in con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )}
+    # alembic_version is the bookkeeping table; everything else is ours.
+    assert {"item", "run", "apicall"}.issubset(tables)
+
+    with sqlite3.connect(db_path) as con:
+        cols = {r[1] for r in con.execute("PRAGMA table_info(item)")}
+    # Classifier columns are added by the second migration and must be
+    # present after upgrade to head.
+    assert "classification" in cols
+    assert "needs_review" in cols
+    # Fields from the initial schema are still there.
+    assert {"id", "zotero_item_key", "tags_json", "stage_completed"}.issubset(cols)
+
+
+def test_downgrade_base_removes_all_s1_tables(tmp_path: pathlib.Path) -> None:
+    db_path = tmp_path / "state.db"
+    cfg = _config(db_path)
+    command.upgrade(cfg, "head")
+    command.downgrade(cfg, "base")
+
+    with sqlite3.connect(db_path) as con:
+        tables = {r[0] for r in con.execute(
+            "SELECT name FROM sqlite_master WHERE type='table'"
+        )}
+    # Only alembic's bookkeeping should survive base.
+    assert tables <= {"alembic_version"}
+
+
+def test_classifier_migration_depends_on_initial_schema(tmp_path: pathlib.Path) -> None:
+    cfg = _config(tmp_path / "irrelevant.db")
+    script_dir = ScriptDirectory.from_config(cfg)
+    classifier = script_dir.get_revision("20260422_classifier_columns")
+    assert classifier is not None
+    assert classifier.down_revision == "20260420_initial_schema"

--- a/tests/test_s1/test_run_all.py
+++ b/tests/test_s1/test_run_all.py
@@ -1,0 +1,357 @@
+"""Tests for :mod:`zotai.s1.run_all`.
+
+Monkeypatches every stage's ``run_*`` function with deterministic stubs
+so the orchestrator is exercised in isolation from real API / Zotero
+calls. The tests cover:
+
+- Inter-stage prompts: default confirm says yes, stages advance;
+  rejection at any step stops and records the reason.
+- ``--yes``: confirm is never called.
+- Tag mode: ``apply`` runs validate; ``preview`` skips validate with a
+  clear marker.
+- ``StageAbortedError`` short-circuits and the failed stage is logged.
+- ``KeyboardInterrupt`` mid-pipeline produces an orderly stop with the
+  next-stage-index recorded.
+- ``format_summary`` renders all branches readably.
+"""
+
+from __future__ import annotations
+
+from pathlib import Path
+from typing import Any
+
+import pytest
+
+from zotai.config import PathSettings, Settings, ZoteroSettings
+from zotai.s1.handler import StageAbortedError
+from zotai.s1.run_all import RunAllResult, format_summary, run_all
+from zotai.s1.stage_01_inventory import InventoryResult
+from zotai.s1.stage_02_ocr import OcrResult
+from zotai.s1.stage_03_import import ImportResult
+from zotai.s1.stage_04_enrich import EnrichResult
+from zotai.s1.stage_05_tag import TagResult
+
+
+def _settings(tmp_path: Path) -> Settings:
+    # Give run_all something to hand to stage_01_inventory — it aborts
+    # early if pdf_source_folders is empty.
+    src = tmp_path / "src"
+    src.mkdir()
+    return Settings(
+        paths=PathSettings(
+            state_db=tmp_path / "state.db",
+            reports_folder=tmp_path / "reports",
+            staging_folder=tmp_path / "staging",
+            pdf_source_folders=[src],
+        ),
+        zotero=ZoteroSettings(library_id="42"),
+    )
+
+
+# ─── Stage stubs ─────────────────────────────────────────────────────────
+
+
+def _fake_inventory(*_: Any, **__: Any) -> InventoryResult:
+    return InventoryResult(
+        run_id=1,
+        rows=[],
+        excluded_rows=[],
+        csv_path=Path("/tmp/inv.csv"),
+        excluded_csv_path=None,
+        items_processed=5,
+        items_failed=0,
+        duplicates=0,
+        invalid=0,
+        excluded=0,
+        llm_cost_usd=0.0,
+    )
+
+
+def _fake_ocr(**_: Any) -> OcrResult:
+    return OcrResult(
+        run_id=2,
+        rows=[],
+        csv_path=Path("/tmp/ocr.csv"),
+        items_processed=5,
+        items_failed=0,
+        items_applied=3,
+        items_resumed=2,
+    )
+
+
+def _fake_import(**_: Any) -> ImportResult:
+    return ImportResult(
+        run_id=3,
+        rows=[],
+        csv_path=Path("/tmp/imp.csv"),
+        items_processed=5,
+        items_failed=0,
+        items_route_a=4,
+        items_route_c=1,
+        items_deduped=0,
+        items_skipped=0,
+    )
+
+
+def _fake_enrich(**_: Any) -> EnrichResult:
+    return EnrichResult(
+        run_id=4,
+        rows=[],
+        csv_path=Path("/tmp/enr.csv"),
+        items_processed=1,
+        items_failed=0,
+        items_enriched_04a=0,
+        items_enriched_04b=1,
+        items_enriched_04c=0,
+        items_enriched_04d=0,
+        items_quarantined=0,
+        items_no_progress=0,
+        items_skipped=0,
+        items_skipped_generic_title=0,
+        quarantine_csv_path=None,
+    )
+
+
+def _fake_tag(**_: Any) -> TagResult:
+    return TagResult(
+        run_id=5,
+        rows=[],
+        csv_path=Path("/tmp/tag.csv"),
+        items_processed=5,
+        items_failed=0,
+        items_tagged=5,
+        items_previewed=0,
+        items_no_metadata=0,
+        items_llm_failed=0,
+        cost_usd=0.02,
+    )
+
+
+def _fake_validate(**_: Any) -> Any:
+    from datetime import UTC, datetime
+
+    from zotai.s1.stage_06_validate import (
+        CompletenessStats,
+        Stage01Filtering,
+        TagDistributionStats,
+        ValidationReport,
+    )
+
+    return ValidationReport(
+        generated_at=datetime(2026, 4, 23, tzinfo=UTC),
+        completeness=CompletenessStats(5, 5, 0, 5, 5, 5, 5),
+        tag_distribution=TagDistributionStats({}, [], [], 5),
+        consistency_issues=[],
+        duplicate_pairs=[],
+        cost_total_usd=0.02,
+        cost_by_stage_service=[],
+        timing_by_stage=[],
+        stage_01_filtering=Stage01Filtering(0, 0, {}, None),
+        html_path=Path("/tmp/validate.html"),
+        csv_path=Path("/tmp/validate.csv"),
+    )
+
+
+@pytest.fixture()
+def stub_stages(monkeypatch: pytest.MonkeyPatch) -> None:
+    """Replace every S1 stage with its deterministic stub."""
+    import zotai.s1.run_all as mod
+
+    monkeypatch.setattr(mod, "run_inventory", _fake_inventory)
+    monkeypatch.setattr(mod, "run_ocr", _fake_ocr)
+    monkeypatch.setattr(mod, "run_import", _fake_import)
+    monkeypatch.setattr(mod, "run_enrich", _fake_enrich)
+    monkeypatch.setattr(mod, "run_tag", _fake_tag)
+    monkeypatch.setattr(mod, "run_validate", _fake_validate)
+
+
+# ─── Happy paths ─────────────────────────────────────────────────────────
+
+
+def test_run_all_yes_skips_confirmation(tmp_path: Path, stub_stages: None) -> None:
+    confirms: list[str] = []
+
+    def confirm(q: str) -> bool:
+        confirms.append(q)
+        return True
+
+    settings = _settings(tmp_path)
+    result = run_all(
+        yes=True,
+        settings=settings,
+        confirm=confirm,
+        echo=lambda _: None,
+    )
+    assert result.completed is True
+    assert result.stopped_at_stage is None
+    assert confirms == [], "--yes must never prompt"
+    assert [s.stage for s in result.stages] == [1, 2, 3, 4, 5, 6]
+    assert all(s.succeeded for s in result.stages)
+    assert result.total_cost_usd == pytest.approx(0.02)
+
+
+def test_run_all_prompts_between_stages(tmp_path: Path, stub_stages: None) -> None:
+    answers = iter([True, True, True, True, True])
+
+    def confirm(_: str) -> bool:
+        return next(answers)
+
+    settings = _settings(tmp_path)
+    result = run_all(settings=settings, confirm=confirm, echo=lambda _: None)
+    assert result.completed is True
+    # 5 prompts: between stages 1→2, 2→3, 3→4, 4→5, 5→6. Stage 6 is the
+    # last; no prompt after it.
+    assert [s.stage for s in result.stages] == [1, 2, 3, 4, 5, 6]
+
+
+def test_run_all_stops_when_user_declines(
+    tmp_path: Path, stub_stages: None
+) -> None:
+    answers = iter([True, False])
+
+    def confirm(_: str) -> bool:
+        return next(answers)
+
+    settings = _settings(tmp_path)
+    result = run_all(settings=settings, confirm=confirm, echo=lambda _: None)
+    assert result.completed is False
+    assert result.stopped_at_stage == 2  # declined after ocr (stage 2)
+    assert result.stopped_reason == "user declined to continue"
+    # Stages 1 and 2 ran; nothing beyond.
+    assert [s.stage for s in result.stages] == [1, 2]
+
+
+def test_run_all_preview_mode_stops_before_validate(
+    tmp_path: Path, stub_stages: None
+) -> None:
+    settings = _settings(tmp_path)
+    result = run_all(
+        yes=True,
+        tag_mode="preview",
+        settings=settings,
+        echo=lambda _: None,
+    )
+    assert result.completed is True
+    assert [s.stage for s in result.stages] == [1, 2, 3, 4, 5, 6]
+    # Stage 6 is recorded as skipped.
+    stage_6 = result.stages[-1]
+    assert stage_6.skipped is True
+    assert "skipped" in stage_6.summary.lower()
+
+
+# ─── Error paths ─────────────────────────────────────────────────────────
+
+
+def test_run_all_surfaces_stage_aborted(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """A stage raising StageAbortedError is captured as stopped_at_stage."""
+    import zotai.s1.run_all as mod
+
+    monkeypatch.setattr(mod, "run_inventory", _fake_inventory)
+
+    def boom_ocr(**_: Any) -> OcrResult:
+        raise StageAbortedError("disk full")
+
+    monkeypatch.setattr(mod, "run_ocr", boom_ocr)
+
+    settings = _settings(tmp_path)
+    messages: list[str] = []
+    result = run_all(
+        yes=True,
+        settings=settings,
+        echo=messages.append,
+    )
+    assert result.completed is False
+    assert result.stopped_at_stage == 2
+    assert result.stopped_reason is not None and "disk full" in result.stopped_reason
+    assert any("aborted" in m.lower() for m in messages)
+
+
+def test_run_all_handles_keyboard_interrupt(
+    tmp_path: Path, monkeypatch: pytest.MonkeyPatch
+) -> None:
+    """Ctrl+C between stages surfaces an orderly stop."""
+    import zotai.s1.run_all as mod
+
+    monkeypatch.setattr(mod, "run_inventory", _fake_inventory)
+
+    def interrupted_ocr(**_: Any) -> OcrResult:
+        raise KeyboardInterrupt
+
+    monkeypatch.setattr(mod, "run_ocr", interrupted_ocr)
+
+    settings = _settings(tmp_path)
+    messages: list[str] = []
+    result = run_all(
+        yes=True,
+        settings=settings,
+        echo=messages.append,
+    )
+    assert result.completed is False
+    assert result.stopped_at_stage == 2
+    assert result.stopped_reason == "keyboard_interrupt"
+    assert any("Interrupted" in m for m in messages)
+
+
+def test_run_all_rejects_empty_source_folders(tmp_path: Path) -> None:
+    """Stage 01 needs folders to scan; run_all fails fast with a clear reason."""
+    settings = Settings(
+        paths=PathSettings(
+            state_db=tmp_path / "state.db",
+            reports_folder=tmp_path / "reports",
+            staging_folder=tmp_path / "staging",
+            pdf_source_folders=[],
+        ),
+        zotero=ZoteroSettings(library_id="42"),
+    )
+    messages: list[str] = []
+    result = run_all(
+        yes=True,
+        settings=settings,
+        echo=messages.append,
+    )
+    assert result.completed is False
+    assert result.stopped_at_stage == 1
+    assert result.stopped_reason is not None and "PDF_SOURCE_FOLDERS" in result.stopped_reason
+
+
+# ─── format_summary ──────────────────────────────────────────────────────
+
+
+def test_format_summary_prints_every_recorded_stage() -> None:
+    from zotai.s1.run_all import StageOutcome
+
+    result = RunAllResult(
+        stages=[
+            StageOutcome(1, "inventory", "processed=5", True),
+            StageOutcome(2, "ocr", "processed=5", True),
+            StageOutcome(3, "import", "processed=5", True),
+            StageOutcome(4, "enrich", "processed=1", True),
+            StageOutcome(5, "tag", "tagged=5 cost=$0.0200", True),
+            StageOutcome(6, "validate", "skipped (tag_mode=preview)", True, skipped=True),
+        ],
+        total_cost_usd=0.02,
+        completed=True,
+    )
+    rendered = format_summary(result)
+    assert "[01/06] inventory" in rendered
+    assert "[06/06] validate" in rendered
+    assert "skipped" in rendered
+    assert "total cost: $0.0200" in rendered
+    assert "status: completed" in rendered
+
+
+def test_format_summary_reports_stopped_stage() -> None:
+    from zotai.s1.run_all import StageOutcome
+
+    result = RunAllResult(
+        stages=[StageOutcome(1, "inventory", "processed=5", True)],
+        total_cost_usd=0.0,
+        completed=False,
+        stopped_at_stage=2,
+        stopped_reason="user declined",
+    )
+    rendered = format_summary(result)
+    assert "status: stopped at stage 02" in rendered
+    assert "user declined" in rendered

--- a/tests/test_s1/test_status.py
+++ b/tests/test_s1/test_status.py
@@ -1,0 +1,159 @@
+"""Tests for :mod:`zotai.s1.status`."""
+
+from __future__ import annotations
+
+from datetime import UTC, datetime, timedelta
+from pathlib import Path
+
+from pydantic import SecretStr
+from sqlmodel import Session
+
+from zotai.config import OpenAISettings, PathSettings, Settings, ZoteroSettings
+from zotai.s1.status import compute_status, format_status
+from zotai.state import Item, Run, init_s1, make_s1_engine
+
+
+def _settings(tmp_path: Path, *, with_openai: bool = False) -> Settings:
+    return Settings(
+        paths=PathSettings(
+            state_db=tmp_path / "state.db",
+            reports_folder=tmp_path / "reports",
+            staging_folder=tmp_path / "staging",
+            pdf_source_folders=[],
+        ),
+        zotero=ZoteroSettings(library_id="42"),
+        openai=OpenAISettings(api_key=SecretStr("sk-test") if with_openai else SecretStr("")),
+    )
+
+
+def _mk_item(
+    sha: str,
+    *,
+    stage_completed: int = 0,
+    zotero_item_key: str | None = None,
+    tags_json: str | None = None,
+    in_quarantine: bool = False,
+    needs_review: bool = False,
+    last_error: str | None = None,
+) -> Item:
+    return Item(
+        id=sha,
+        source_path=f"/data/{sha}.pdf",
+        size_bytes=1,
+        has_text=True,
+        classification="academic",
+        stage_completed=stage_completed,
+        zotero_item_key=zotero_item_key,
+        tags_json=tags_json,
+        in_quarantine=in_quarantine,
+        needs_review=needs_review,
+        last_error=last_error,
+    )
+
+
+def test_compute_status_on_empty_db_returns_zero_counters(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    snapshot = compute_status(
+        settings=settings,
+        now=[datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)],
+    )
+    assert snapshot.total_items == 0
+    assert all(row.count == 0 for row in snapshot.items_by_stage)
+    assert snapshot.cost_total_usd == 0.0
+    assert snapshot.last_run_at is None
+    # state_db_exists reflects the filesystem *before* compute_status runs
+    # init_s1, so the first ever call on a fresh tmpdir reports False.
+    assert snapshot.state_db_exists is False
+    # Every stage row is present in fixed order, not just the populated ones.
+    assert [row.stage for row in snapshot.items_by_stage] == [0, 1, 2, 3, 4, 5, 6]
+
+
+def test_compute_status_counts_items_by_stage(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    engine = make_s1_engine(str(settings.paths.state_db))
+    init_s1(engine)
+    with Session(engine) as session:
+        session.add(_mk_item("a" * 64, stage_completed=1))
+        session.add(_mk_item("b" * 64, stage_completed=4, zotero_item_key="K"))
+        session.add(
+            _mk_item(
+                "c" * 64,
+                stage_completed=5,
+                zotero_item_key="K2",
+                tags_json='{"tema":["x"],"metodo":[]}',
+            )
+        )
+        session.add(
+            _mk_item("d" * 64, stage_completed=4, in_quarantine=True, last_error="boom")
+        )
+        session.commit()
+    snapshot = compute_status(
+        settings=settings,
+        engine=engine,
+        now=[datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)],
+    )
+    per_stage = {r.stage: r.count for r in snapshot.items_by_stage}
+    assert per_stage[1] == 1
+    assert per_stage[4] == 2
+    assert per_stage[5] == 1
+    assert snapshot.items_in_quarantine == 1
+    assert snapshot.items_with_last_error == 1
+    assert snapshot.items_with_zotero_key == 2
+    assert snapshot.items_tagged == 1
+
+
+def test_compute_status_aggregates_costs_by_stage(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    engine = make_s1_engine(str(settings.paths.state_db))
+    init_s1(engine)
+    now = datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)
+    with Session(engine) as session:
+        session.add(Run(stage=1, status="succeeded", cost_usd=0.12, started_at=now))
+        session.add(
+            Run(
+                stage=4,
+                status="succeeded",
+                cost_usd=1.5,
+                started_at=now + timedelta(minutes=5),
+            )
+        )
+        session.add(
+            Run(
+                stage=4,
+                status="succeeded",
+                cost_usd=0.3,
+                started_at=now + timedelta(minutes=10),
+            )
+        )
+        session.commit()
+    snapshot = compute_status(settings=settings, engine=engine, now=[now])
+    by_stage = {row.stage: row for row in snapshot.cost_by_stage}
+    assert by_stage[1].cost_usd == 0.12
+    assert by_stage[4].cost_usd == 1.8
+    assert by_stage[4].runs == 2
+    assert abs(snapshot.cost_total_usd - 1.92) < 1e-9
+    # Last run is the most recent by started_at.
+    assert snapshot.last_run_stage == 4
+
+
+def test_compute_status_reports_credentials_without_leaking(tmp_path: Path) -> None:
+    settings = _settings(tmp_path, with_openai=True)
+    snapshot = compute_status(
+        settings=settings, now=[datetime(2026, 4, 23, tzinfo=UTC)]
+    )
+    assert snapshot.credentials.openai_configured is True
+    # library_id set but api_key empty → zotero reports as not configured.
+    assert snapshot.credentials.zotero_configured is False
+
+
+def test_format_status_includes_each_section(tmp_path: Path) -> None:
+    settings = _settings(tmp_path)
+    snapshot = compute_status(
+        settings=settings, now=[datetime(2026, 4, 23, 12, 0, 0, tzinfo=UTC)]
+    )
+    rendered = format_status(snapshot)
+    assert "zotai s1 status" in rendered
+    assert "items by stage_completed" in rendered
+    assert "cost by stage" in rendered
+    assert "total cost: $0.0000" in rendered
+    assert "last run: (none)" in rendered


### PR DESCRIPTION
Closes #9.

## Summary

- **\`zotai s1 run-all\`** — orchestrator that walks Stages 01 → 06 in sequence, pausing for Y/n between each pair (skip with \`--yes\`). \`--tag-mode apply\` (default) commits to Zotero; \`--tag-mode preview\` stops before Stage 06 so the researcher can review \`reports/tag_report_*.csv\` first. \`--allow-template-taxonomy\` is forwarded to Stage 05 for testing runs. \`KeyboardInterrupt\` between stages is caught and surfaced as an orderly stop with the next-stage index. \`StageAbortedError\` from any stage short-circuits cleanly.
- **\`zotai s1 status\`** — plain-text snapshot of \`state.db\`: items per \`stage_completed\` bucket (0..6, fixed order), quarantine / needs-review / \`last_error\` counters, cost total + breakdown by stage, last-run timestamp + status, credentials presence flag (\`openai=yes/no  zotero=yes/no\`) — API keys never leak. Safe on an empty DB: reads \"state.db: &lt;path&gt; (not created yet)\" and all counters at 0.
- **Alembic baseline migration** \`20260420_initial_schema\` creates \`item\` + \`run\` + \`apicall\` as the pre-classifier schema; \`20260422_classifier_columns\` is re-parented (\`down_revision=\"20260420_initial_schema\"\`). \`alembic upgrade head\` on a fresh DB now reaches the same shape as \`init_s1()\`.

## Files

- **New**: \`src/zotai/s1/status.py\`, \`src/zotai/s1/run_all.py\`, \`alembic/versions/20260420_initial_schema.py\`, \`tests/test_s1/test_status.py\`, \`tests/test_s1/test_run_all.py\`, \`tests/test_s1/test_alembic_migrations.py\`
- **Changed**: \`src/zotai/cli.py\` (both stubs → real), \`alembic/versions/20260422_classifier_columns.py\` (re-parent to initial schema, modernise typing), \`CHANGELOG.md\`

## CLI

\`\`\`bash
zotai s1 status                                 # always safe to run
zotai s1 run-all --yes                          # straight through, apply tags
zotai s1 run-all --yes --tag-mode preview       # stop at Stage 05 for review
zotai s1 run-all --allow-template-taxonomy      # testing with shipped taxonomy
\`\`\`

## Test plan

- [x] \`pytest tests/test_s1/test_status.py\` — 5 passed
- [x] \`pytest tests/test_s1/test_run_all.py\` — 9 passed
- [x] \`pytest tests/test_s1/test_alembic_migrations.py\` — 3 passed (upgrade head, downgrade base, revision chain)
- [x] \`pytest\` full suite — **203 passed** (was 186; +17)
- [x] \`mypy --strict\` on new/changed files — clean
- [x] \`ruff check\` on new/changed files — clean
- [x] Manual alembic smoke: \`upgrade head\` → \`downgrade base\` → round-trips, leaves only \`alembic_version\` table
- [ ] End-to-end \`zotai s1 status\` + \`zotai s1 run-all --yes\` on the real workspace post-merge (manual)

### Coverage

- **status**: empty DB returns a well-formed snapshot with every counter at 0; seeded DB counts items by stage, aggregates costs per stage, flags credentials correctly without leaking keys; \`format_status\` renders every section.
- **run_all**: \`--yes\` skips all prompts; default mode asks N-1 prompts for N stages; user decline at any step records \`stopped_at_stage\` + reason; \`--tag-mode preview\` marks Stage 06 as skipped with a clear summary; \`StageAbortedError\` from any stage is captured; \`KeyboardInterrupt\` produces an orderly stop; empty \`PDF_SOURCE_FOLDERS\` fails fast at Stage 01 with a clear reason; \`format_summary\` renders both completed and stopped branches.
- **alembic**: upgrade head creates item + run + apicall including classifier columns; downgrade base removes everything except \`alembic_version\`; classifier migration's \`down_revision\` points at the initial schema.

## Related

- Issue #9 (Phase 8 — S1 integration)
- \`docs/plan_01_subsystem1.md\` §6 (run-all spec)
- \`alembic/versions/20260422_classifier_columns.py\` — the \"re-parent when Phase 8 lands\" note this PR finally honours

## What's left in S1

After this merges, S1 is functional end-to-end. Remaining item on the critical path is **#10 (Phase 9 — Docker finalization + setup docs)**: \`setup-{linux,windows}.md\`, \`troubleshooting.md\`, \`economics.md\`, Docker healthcheck polish. Code-wise S1 is done.