### PR TITLE
docs: docker finalization + setup guides + pipeline wrappers (#10)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -9,6 +9,36 @@ and this project adheres to [Semantic Versioning](https://semver.org/spec/v2.0.0
 
 ### Added
 
+- **Docker finalization + setup docs + pipeline wrappers** (#10, closes
+  Phase 9):
+  - `scripts/run-pipeline.sh` (Linux / macOS, bash) and
+    `scripts/run-pipeline.ps1` (Windows, PowerShell) — thin wrappers
+    around `docker compose --profile onboarding run --rm onboarding
+    zotai s1 run-all`, forwarding any extra args verbatim. Fail-fast
+    if `.env` is missing with a clear pointer to `.env.example`.
+  - `docs/setup-linux.md` — per-OS guide: Docker Engine install,
+    Zotero local API, `.env` minimum, first run, `cron` recipe for
+    S2 worker (ADR 012), cross-references to ADR 013 for networking.
+  - `docs/setup-windows.md` — WSL2 + Docker Desktop + `host.docker.internal`
+    gotcha, PowerShell execution policy, Task Scheduler recipe for the
+    S2 worker alternative.
+  - `docs/troubleshooting.md` — seven categories: Docker, Zotero
+    connectivity, OCR, >20 MB PDFs (referencing the tracking issue
+    #39), budget exceeded mid-run, interrupted runs + resume, and
+    how to start any triage from `zotai s1 status` + `zotai s1
+    validate --open-report`.
+  - `docs/economics.md` — per-stage cost estimates (Jan 2026 OpenAI
+    prices), how the hard caps in `.env` enforce them, LATAM-heavy
+    corpus adjustments, optimization tips.
+  - `README.md` quickstart updated — commands match what Phase 8
+    actually exposes (`--profile onboarding`, `--rm`, `run-pipeline.*`
+    wrappers, `--tag-mode`, `--allow-template-taxonomy`). Status
+    table now reflects S1 as functional end-to-end.
+  - No Dockerfile / docker-compose.yml changes — both already finalised
+    by earlier PRs (#37 bridge networking, #42 ChromaDB :rw mount).
+    The compose file header and ADR cross-references remain accurate.
+  - No test file changes — full suite still at **203 passed**.
+
 - **S1 integration — `run-all`, `status`, Alembic baseline** (#9, closes
   Phase 8):
   - **`zotai s1 run-all`** orchestrates Stages 01 → 06 in sequence,

--- a/README.md
+++ b/README.md
@@ -67,30 +67,44 @@ Ver `docs/plan_01_subsystem1.md` §3.1 para el detalle del clasificador.
 
 | Subsistema | Estado | Plan |
 |---|---|---|
-| S1 – Retroactive | 🟢 En implementación (Stages 01 inventory+classifier, 02 OCR, 03 import mergeados; próximo Stage 04 enrich [#6](https://github.com/igalkej/auto_zotero/issues/6)) | `docs/plan_01_subsystem1.md` |
+| S1 – Retroactive | 🟢 Funcional end-to-end (Stages 01-06 + `run-all` + `status` + Docker + setup docs). Taxonomía pendiente de customizar por cada investigador antes de aplicar tags reales. | `docs/plan_01_subsystem1.md` |
 | S3 – MCP access | 🟡 Spec, pendiente implementación ([#11](https://github.com/igalkej/auto_zotero/issues/11)) | `docs/plan_03_subsystem3.md` |
 | S2 – Prospective | 🟡 Spec, pendiente implementación ([#12](https://github.com/igalkej/auto_zotero/issues/12)–[#15](https://github.com/igalkej/auto_zotero/issues/15)) | `docs/plan_02_subsystem2.md` |
 
 ---
 
-## Quickstart (cuando esté implementado)
+## Quickstart
 
 ```bash
-git clone <repo>
+git clone https://github.com/igalkej/auto_zotero.git zotero-ai-toolkit
 cd zotero-ai-toolkit
 cp .env.example .env
-# editar .env con tus credenciales: ZOTERO_API_KEY, OPENAI_API_KEY, PDF_SOURCE_FOLDERS
+# editar .env con tus credenciales: ZOTERO_API_KEY, ZOTERO_LIBRARY_ID,
+# OPENAI_API_KEY, PDF_SOURCE_FOLDERS, USER_EMAIL
 
-# Arrancar S1 (carga inicial)
-docker compose run onboarding zotai s1 run-all
+# Status — siempre seguro; no escribe nada.
+docker compose --profile onboarding run --rm onboarding zotai s1 status
 
-# Configurar S3 (MCP para Claude Desktop) - guía manual
-# ver docs/s3-setup.md  (pendiente — Phase 10, #11)
+# Pipeline completo S1 (interactivo, prompts entre etapas).
+./scripts/run-pipeline.sh          # Linux / macOS
+.\scripts\run-pipeline.ps1         # Windows / PowerShell
 
-# Arrancar S2 (dashboard + worker)
+# Variantes útiles:
+./scripts/run-pipeline.sh --yes                       # sin prompts
+./scripts/run-pipeline.sh --yes --tag-mode preview    # stop antes de Stage 06
+./scripts/run-pipeline.sh --allow-template-taxonomy   # testing sin customizar taxonomía
+
+# Configurar S3 (MCP para Claude Desktop) — guía manual
+# ver docs/s3-setup.md (pendiente — Phase 10, #11)
+
+# Arrancar S2 dashboard + worker (pendiente — Phases 11-14, #12-#15)
 docker compose up dashboard
 # abrir http://localhost:8000
 ```
+
+Setup guiado por OS: [`docs/setup-linux.md`](docs/setup-linux.md) /
+[`docs/setup-windows.md`](docs/setup-windows.md). Problemas comunes:
+[`docs/troubleshooting.md`](docs/troubleshooting.md).
 
 ---
 

--- a/docs/economics.md
+++ b/docs/economics.md
@@ -1,0 +1,175 @@
+# Economics
+
+Costos esperados del pipeline por etapa, qué los controla, y cómo los
+hard caps en `.env` los refuerzan. Números de enero 2026; actualizar
+al cambio de precios de OpenAI.
+
+---
+
+## 1. Resumen — corpus típico (1000 PDFs, 70 % anglo / 30 % LATAM)
+
+| Concepto | Estimado | Hard cap (default) | Env var |
+|---|---|---|---|
+| **Stage 01** — LLM gate (clasificador académico) | ~$0.12 | $1.00 | `MAX_COST_USD_STAGE_01` |
+| **Stage 02** — OCR | $0 | — | — (tesseract local, sin costo marginal) |
+| **Stage 03** — Import vía OpenAlex | $0 | — | — (API gratis) |
+| **Stage 04a-c** — Cascade gratis | $0 | — | — (APIs gratis + rate limits) |
+| **Stage 04d** — LLM extraction | ~$0.40 | $2.00 | `MAX_COST_USD_STAGE_04` |
+| **Stage 05** — Tagging LLM | ~$0.40 | $1.00 | `MAX_COST_USD_STAGE_05` |
+| **Stage 06** — Validation | $0 | — | — (read-only) |
+| **S2 backfill inicial** — embeddings sobre la biblioteca completa | ~$1.50 | $3.00 | `S2_MAX_COST_USD_BACKFILL` |
+| **S2 worker** — scoring mensual | ~$2.00/mes | $5.00/mes | `S2_MAX_COST_USD_MONTHLY` |
+| **Total S1 típico** | **~$1.00** | $10.00 | `MAX_COST_USD_TOTAL` |
+
+**S1 one-shot típico: menos de $1**. El cap duro del total (`MAX_COST_USD_TOTAL=10.00`)
+es deliberadamente laxo para absorber corpora atípicos sin abortar; los
+caps por etapa son los que efectivamente rigen.
+
+---
+
+## 2. Detalle por etapa
+
+### Stage 01 — LLM gate
+
+Sólo los PDFs **ambiguos** (no claramente académicos ni claramente
+descarte) llegan al LLM. Las tres ramas del clasificador (plan_01
+§3.1):
+
+1. **Accept automático** (zero cost) — DOI / arXiv / ISBN / keywords
+   académicos en páginas 1-3. Suele resolver 70-80 % del corpus.
+2. **Reject automático** (zero cost) — ≤ 2 páginas + keywords de
+   facturación / documento personal. Suele resolver 5-10 %.
+3. **LLM gate** — el resto. `gpt-4o-mini` con prompt de ~500 chars
+   + 1 retry. ~$0.0004 por PDF.
+
+Para 1000 PDFs con ~20 % ambiguos: 200 × $0.0004 = **$0.08**. En
+corpus LATAM-heavy (más variedad) hasta **$0.20**. Cap default:
+$1.00.
+
+### Stage 02 — OCR
+
+Tesseract local vía `ocrmypdf`. Costo = tiempo CPU (≈ 10-30s/PDF
+dependiendo del escaneo; paralelizable con `OCR_PARALLEL_PROCESSES`).
+No hay costo de API.
+
+### Stage 03 — Import
+
+OpenAlex es gratuito con `USER_EMAIL` en el User-Agent (el "polite
+pool", 100 req/s vs 10). Zotero local API es gratis. Costo = $0.
+
+### Stage 04a-c — Cascade gratis
+
+- **04a**: regex + OpenAlex por DOI. Gratis.
+- **04b**: OpenAlex por búsqueda de título. Gratis.
+- **04c**: Semantic Scholar por búsqueda de título. Gratis (rate limit
+  100 req / 5 min sin key, 1 req/s con key).
+
+Estas tres ramas suelen resolver 80-90 % del fallthrough de Stage 03
+en corpus anglo-dominantes. Para LATAM-heavy cae a 40-60 %, lo que
+empuja más items a Stage 04d.
+
+### Stage 04d — LLM extraction
+
+Sólo los items que sobrevivieron 04a-c van al LLM. `gpt-4o-mini` con
+primeras 2 páginas + prompt estructurado + 1 retry. ~$0.0004 por item.
+
+**Estimación anglo-dominante**: 10-20 % del corpus × 1000 PDFs ×
+$0.0004 = **$0.04-0.08**.
+
+**Estimación LATAM-heavy** (plan_01 §3 Etapa 04 "Aviso"): 40 % del
+corpus × 1000 × $0.0004 = **$0.16**, pero con ruido de retries
+malformados y papers largos puede llegar a **$1.00**. Subí el cap a
+`MAX_COST_USD_STAGE_04=4.00` si tu corpus es LATAM-pesado.
+
+Cuando el cap trip, el orchestrator de `run-all` rutea los items
+restantes directo a 04e (quarantine) — no vuelve a llamar al LLM.
+Ver `docs/troubleshooting.md` §5 para recuperar items
+quarantinados después de subir el cap.
+
+### Stage 05 — Tagging
+
+Un call al LLM por ítem elegible (con metadata + no quarantinado +
+aún sin tags). ~$0.0004 por ítem.
+
+**Estimación**: 1000 items × $0.0004 = **$0.40**. Cap default $1.00.
+
+`--preview` mode escribe el CSV sin tocar Zotero ni cobrar por tags
+que descartás. Buena práctica: `--preview` primero, revisar el CSV,
+después `--apply`.
+
+### Stage 06 — Validation
+
+Read-only. No API calls. $0.
+
+---
+
+## 3. S2 (prospective capture — pendiente de implementación)
+
+### Backfill inicial (`zotai s2 backfill-index`)
+
+Un embedding por ítem de la biblioteca. `text-embedding-3-large` a
+$0.00013 por 1K tokens. Un abstract medio es ~250 tokens ~
+$0.000033 por ítem.
+
+**Estimación**: 1500 items × $0.000033 = **$0.05**. Pero la ADR 015
+cap default es `S2_MAX_COST_USD_BACKFILL=3.00` para absorber retries
++ re-embeds cuando el texto fulltext está disponible.
+
+### Worker mensual
+
+Cada candidate cuesta ~$0.0005 en embeddings + scoring. 30
+candidates × 4 ciclos × 30 días = **~$1.80/mes**. Cap default
+`S2_MAX_COST_USD_MONTHLY=5.00`.
+
+---
+
+## 4. Cómo se enforcen los caps
+
+`zotai.api.openai_client.OpenAIClient` mantiene un ledger de `spent_usd`
+que se incrementa después de cada call exitoso. Antes de cada call,
+`_check_budget()` tira `BudgetExceededError` si `spent + projected >
+budget`.
+
+- **Stage 01**: el cap es un override del call-site: el clasificador
+  construye su propio `OpenAIClient(budget_usd=max_cost or MAX_COST_USD_STAGE_01)`.
+- **Stage 04d**: idem.
+- **Stage 05**: idem.
+
+Los caps son por-stage, no acumulativos entre stages. El cap total
+`MAX_COST_USD_TOTAL` no se enforza automáticamente en v1 — es más
+que nada un budget mental. Si querés enforce real del total, bajá
+los caps individuales.
+
+---
+
+## 5. Claude Desktop (S3)
+
+Claude Pro es $20/mes — requerido para usar el MCP server. No hay
+costo marginal por query (Anthropic lo incluye en la suscripción).
+
+---
+
+## 6. Optimizar costos
+
+- Correr Stage 01 con `--skip-llm-gate` si tenés confianza en que tu
+  corpus está limpio de no-académicos (ahorra los ~$0.12 del gate).
+- Correr Stage 04d con `--substage 04d` aislado después de 04a-c
+  cuando querés monitorear el gasto del LLM específicamente.
+- `--preview` antes de `--apply` en Stage 05 — el costo es el mismo
+  (un call por ítem), pero preview no compromete las tags a Zotero
+  si no te gustan.
+- Usar `text-embedding-3-small` en lugar de `-large` para S2 corta los
+  costos ~6× pero degrada el recall multilingüe ~10 pts (ver ADR
+  004). Probablemente no vale la pena.
+
+---
+
+## 7. Referencias
+
+- `.env.example` — todos los caps con comentario explicativo.
+- `docs/plan_01_subsystem1.md` §3 — detalles por etapa, budgets.
+- `docs/decisions/005-gpt-4o-mini-tagging-extraction.md` — por qué
+  `gpt-4o-mini` como default.
+- `docs/decisions/004-openai-text-embedding-3-large.md` — por qué
+  `text-embedding-3-large`.
+- `src/zotai/api/openai_client.py` — pricing table + ledger.

--- a/docs/setup-linux.md
+++ b/docs/setup-linux.md
@@ -1,0 +1,153 @@
+# Setup — Linux
+
+Guía paso a paso para correr el toolkit en Linux (Ubuntu 22.04+, Fedora
+39+, Arch). Si algo falla, mirá `docs/troubleshooting.md`.
+
+---
+
+## 1. Prerequisitos
+
+1. **Docker Engine** 20.10+ con el plugin `docker-compose-v2`.
+   ```bash
+   # Ubuntu / Debian (siguiendo la guía oficial de Docker):
+   curl -fsSL https://get.docker.com | sudo sh
+   sudo usermod -aG docker "$USER"  # re-login después
+   ```
+   Verificar: `docker --version && docker compose version`.
+2. **Zotero 7** desktop, con la API local habilitada:
+   Preferences → Advanced → "Allow other applications on this computer
+   to communicate with Zotero". La API vive en `http://localhost:23119`.
+3. **API key de Zotero** — https://www.zotero.org/settings/keys (read+write
+   sobre tu biblioteca personal).
+4. **API key de OpenAI** — https://platform.openai.com/api-keys.
+5. **Python 3.11+** en el host *solo si vas a configurar S3* (el MCP
+   server corre en el host, fuera de Docker). Para S1 únicamente no
+   hace falta.
+
+---
+
+## 2. Clonar e instalar
+
+```bash
+git clone https://github.com/igalkej/auto_zotero.git zotero-ai-toolkit
+cd zotero-ai-toolkit
+cp .env.example .env
+```
+
+Editá `.env` con tus credenciales. Los campos mínimos para S1:
+
+```bash
+ZOTERO_API_KEY=...
+ZOTERO_LIBRARY_ID=...          # userID de https://www.zotero.org/settings/keys
+OPENAI_API_KEY=sk-...
+PDF_SOURCE_FOLDERS=/data/folder1,/data/folder2   # rutas dentro del container
+USER_EMAIL=tu@email.com        # requerido por OpenAlex para el "polite pool"
+```
+
+Montá tus carpetas de PDFs en `./data/` del repo (por ejemplo
+`ln -s ~/Descargas/papers data/folder1`). El `docker-compose.yml`
+monta `./data` en `/data:ro`.
+
+---
+
+## 3. Verificar networking
+
+En Linux la red bridge de Docker habla con el host a través de
+`host.docker.internal`, que el proyecto inyecta via
+`extra_hosts: "host.docker.internal:host-gateway"` en
+`docker-compose.yml` (ver `docs/decisions/013-bridge-networking-host-docker-internal.md`).
+No necesitás hacer nada extra — sólo asegurate de que Zotero Desktop
+esté abierto **en el mismo host** donde corrés Docker.
+
+Si corrés Zotero en otra máquina, editá `.env`:
+
+```bash
+ZOTERO_LOCAL_API_HOST=http://<IP-de-Zotero>:23119
+```
+
+---
+
+## 4. Primera corrida
+
+```bash
+# Status — siempre seguro; no escribe nada.
+docker compose --profile onboarding run --rm onboarding zotai s1 status
+
+# Pipeline completo S1 (interactivo, prompts entre etapas).
+./scripts/run-pipeline.sh
+```
+
+En el primer arranque `docker compose build` baja ~800 MB de imágenes
+base + deps (tesseract incluido). Las corridas siguientes son mucho
+más rápidas.
+
+`run-pipeline.sh` pasa todos los args al CLI de Typer, así que:
+
+```bash
+./scripts/run-pipeline.sh --yes                       # sin prompts
+./scripts/run-pipeline.sh --yes --tag-mode preview    # stop antes de Stage 06
+./scripts/run-pipeline.sh --allow-template-taxonomy   # probar sin customizar taxonomía
+```
+
+---
+
+## 5. Dashboard S2 (cuando esté implementado)
+
+S2 todavía no está mergeado (issues #12–#15), pero cuando lo esté:
+
+```bash
+docker compose up dashboard   # localhost:8000
+```
+
+El servicio `dashboard` monta ChromaDB desde el host
+(`${ZOTERO_MCP_CHROMA_HOST_PATH:-~/.config/zotero-mcp/chroma_db}`)
+en modo `:rw` — es owner del índice bajo ADR 015, y `zotero-mcp serve`
+en el host sólo lo lee.
+
+---
+
+## 6. Cron para S2 worker (opcional)
+
+Bajo ADR 012 el worker de S2 es APScheduler in-process por default.
+Si preferís no dejar el dashboard corriendo 24/7:
+
+```bash
+# /etc/crontab o crontab -e
+0 */6 * * * cd /ruta/a/zotero-ai-toolkit && \
+    docker compose --profile onboarding run --rm onboarding zotai s2 fetch-once
+```
+
+Y en `.env`:
+
+```bash
+S2_WORKER_DISABLED=true
+```
+
+---
+
+## 7. Troubleshooting
+
+- Permisos en `./workspace/`: el container corre como UID 1000 (el
+  usuario `zotai` del Dockerfile). Si montás `./workspace/` desde un
+  host con otro UID, cambiá la ownership:
+  ```bash
+  sudo chown -R 1000:1000 ./workspace
+  ```
+- Zotero no responde: verificar que esté abierto + Settings → Advanced
+  → Allow other applications marcado.
+- OCR muy lento: bajá `OCR_PARALLEL_PROCESSES` en `.env` si el host
+  tiene poco RAM; cada worker de tesseract usa ~300 MB.
+
+Ver `docs/troubleshooting.md` para más casos.
+
+---
+
+## 8. Referencias
+
+- `docs/plan_00_overview.md` — arquitectura general.
+- `docs/plan_01_subsystem1.md` — S1 pipeline detallado.
+- `docs/economics.md` — costos esperados por etapa.
+- `docs/decisions/001-use-docker.md` — por qué Docker.
+- `docs/decisions/013-bridge-networking-host-docker-internal.md` — por
+  qué `host.docker.internal` y no `network_mode: host`.
+- `CLAUDE.md` — convenciones del repo.

--- a/docs/setup-windows.md
+++ b/docs/setup-windows.md
@@ -1,0 +1,154 @@
+# Setup — Windows
+
+Guía paso a paso para Windows 10/11 con WSL2 y Docker Desktop. Si algo
+falla, mirá `docs/troubleshooting.md`.
+
+---
+
+## 1. Prerequisitos
+
+1. **WSL2** habilitado:
+   ```powershell
+   wsl --install
+   ```
+   Reiniciar. Al reiniciar se instala Ubuntu por default.
+2. **Docker Desktop for Windows** con integración WSL2 encendida
+   (Settings → Resources → WSL Integration → tu distro).
+3. **Zotero 7** desktop instalado, con la API local habilitada:
+   Preferences → Advanced → "Allow other applications on this
+   computer to communicate with Zotero". La API vive en
+   `http://localhost:23119`.
+4. **API key de Zotero** — https://www.zotero.org/settings/keys (read+write).
+5. **API key de OpenAI** — https://platform.openai.com/api-keys.
+6. **git** — `winget install Git.Git` o desde https://git-scm.com/download/win.
+
+---
+
+## 2. Clonar e instalar
+
+PowerShell (o la shell de WSL — ambas funcionan igual; Docker Desktop
+integra automáticamente):
+
+```powershell
+git clone https://github.com/igalkej/auto_zotero.git zotero-ai-toolkit
+cd zotero-ai-toolkit
+copy .env.example .env
+```
+
+Editá `.env` con tus credenciales. Los campos mínimos para S1:
+
+```bash
+ZOTERO_API_KEY=...
+ZOTERO_LIBRARY_ID=...                   # userID de zotero.org/settings/keys
+OPENAI_API_KEY=sk-...
+PDF_SOURCE_FOLDERS=/data/folder1,/data/folder2
+USER_EMAIL=tu@email.com                 # requerido por OpenAlex
+```
+
+Montá tus carpetas de PDFs en `.\data\` del repo. El
+`docker-compose.yml` monta `./data` en `/data:ro` dentro del
+container.
+
+---
+
+## 3. Networking — `host.docker.internal`
+
+En Windows Docker Desktop, `host.docker.internal` resuelve automáticamente
+al host. El proyecto inyecta `extra_hosts: "host.docker.internal:host-gateway"`
+en `docker-compose.yml` (ver ADR 013), y `.env.example` define
+`ZOTERO_LOCAL_API_HOST=http://host.docker.internal:23119` por
+default dentro de los containers.
+
+**Gotcha histórico**: versiones viejas de los docs sugerían
+`network_mode: host`. En Windows (y macOS) eso se silenciaba y la
+conexión a Zotero fallaba. Si editaste `docker-compose.yml` con un
+`network_mode: host`, sacalo — el bridge + `host-gateway` es el path
+correcto cross-platform.
+
+---
+
+## 4. Primera corrida
+
+PowerShell:
+
+```powershell
+# Status — siempre seguro; no escribe nada.
+docker compose --profile onboarding run --rm onboarding zotai s1 status
+
+# Pipeline completo S1 (interactivo).
+.\scripts\run-pipeline.ps1
+```
+
+En el primer arranque `docker compose build` baja ~800 MB. Corridas
+siguientes son mucho más rápidas.
+
+`run-pipeline.ps1` pasa todos los args al CLI, así que:
+
+```powershell
+.\scripts\run-pipeline.ps1 --yes
+.\scripts\run-pipeline.ps1 --yes --tag-mode preview
+.\scripts\run-pipeline.ps1 --allow-template-taxonomy
+```
+
+Si PowerShell se queja por la execution policy:
+
+```powershell
+Set-ExecutionPolicy -Scope CurrentUser -ExecutionPolicy RemoteSigned
+```
+
+---
+
+## 5. Permisos de volúmenes
+
+A diferencia de Linux, Docker Desktop for Windows hace la traducción
+de permisos entre Windows y los UIDs del container automáticamente.
+No deberías tener que hacer `chown` manual.
+
+Si ves errores `Permission denied` sobre `/workspace/`, es casi
+siempre Windows Defender / antivirus bloqueando el proyecto. Agregá
+la carpeta del repo como excepción.
+
+---
+
+## 6. Task Scheduler para S2 worker (opcional)
+
+Bajo ADR 012 el worker de S2 es APScheduler in-process por default.
+Si preferís no dejar el dashboard corriendo 24/7:
+
+1. `.env`: `S2_WORKER_DISABLED=true`.
+2. Task Scheduler:
+   - Create Task → Triggers → Daily, repetir cada 6 horas.
+   - Action → Start a program:
+     - Program: `powershell.exe`
+     - Arguments:
+       `-NoProfile -Command "cd C:\ruta\al\repo; docker compose --profile onboarding run --rm onboarding zotai s2 fetch-once"`
+
+---
+
+## 7. Troubleshooting
+
+- **Docker Desktop no arranca**: verificar WSL2 activo
+  (`wsl --status`). Si dice "WSL2 not installed", re-ejecutar
+  `wsl --install`.
+- **Zotero no responde desde el container**: verificar que Zotero
+  Desktop esté abierto **en Windows** (no en WSL), y que Settings →
+  Advanced → Allow other applications esté marcado.
+- **Path mapping raro**: si tu repo está en WSL (`\\wsl$\Ubuntu\...`),
+  Docker Desktop lee los volúmenes directamente. Si está en el
+  filesystem Windows (`C:\Users\...`), Docker Desktop hace traducción
+  transparente, pero el I/O es más lento. Preferí WSL.
+- **OCR muy lento**: bajá `OCR_PARALLEL_PROCESSES` en `.env`.
+
+Ver `docs/troubleshooting.md` para más casos.
+
+---
+
+## 8. Referencias
+
+- `docs/plan_00_overview.md` — arquitectura.
+- `docs/plan_01_subsystem1.md` — S1 pipeline.
+- `docs/economics.md` — costos esperados.
+- `docs/decisions/001-use-docker.md` — por qué Docker.
+- `docs/decisions/013-bridge-networking-host-docker-internal.md` — por
+  qué `host.docker.internal`.
+- `CLAUDE.md` — convenciones del repo.

--- a/docs/troubleshooting.md
+++ b/docs/troubleshooting.md
@@ -1,0 +1,224 @@
+# Troubleshooting
+
+Referencia de problemas comunes y cómo resolverlos. Agrupados por
+categoría — si no encontrás tu caso, corré primero
+`docker compose --profile onboarding run --rm onboarding zotai s1 status`
+y pegá el output en el issue tracker.
+
+---
+
+## 1. Docker
+
+### "Cannot connect to the Docker daemon"
+Docker no está corriendo. En Windows/macOS abrí Docker Desktop; en
+Linux: `sudo systemctl start docker` (o `sudo systemctl enable --now docker`
+para arrancar al boot).
+
+### `docker compose build` falla con un error de red
+Retry simple con `--pull`:
+```bash
+docker compose --profile onboarding build --pull --no-cache
+```
+Si falla al descargar `ghcr.io/astral-sh/uv:0.4`, ver si tu proxy
+corporativo bloquea `ghcr.io` o si el DNS corta. Podés forzar el
+registry via `docker login ghcr.io` con un PAT vacío (ghcr expone
+imágenes públicas, pero algunos proxies requieren auth previa).
+
+### "Permission denied" al montar `./workspace/`
+En Linux, el container corre como UID 1000 (`zotai` del Dockerfile).
+Si el UID del host no coincide:
+```bash
+sudo chown -R 1000:1000 ./workspace ./data
+```
+En Windows con Docker Desktop, Windows Defender a veces bloquea las
+escrituras — agregá la carpeta del repo como excepción.
+
+### La imagen crece desmesuradamente
+`tesseract-ocr-*` son ~300 MB por idioma. Si no necesitás español,
+editá el Dockerfile y dejá sólo `tesseract-ocr-eng`. También corré
+`docker image prune` regularmente.
+
+---
+
+## 2. Zotero connectivity
+
+### "Cannot reach Zotero: local API requires Zotero Desktop to be open"
+Checklist en orden:
+
+1. Zotero Desktop está abierto (no sólo instalado).
+2. Preferences → Advanced → "Allow other applications on this computer
+   to communicate with Zotero" está marcado.
+3. `ZOTERO_LOCAL_API=true` en `.env`.
+4. Probá desde el host: `curl http://localhost:23119/api/` devuelve JSON.
+5. Desde el container:
+   ```bash
+   docker compose --profile onboarding run --rm onboarding \
+       curl -sv http://host.docker.internal:23119/api/
+   ```
+   Si falla acá, el problema es el bridge → host path. Ver ADR 013.
+
+### Zotero corre en otra máquina
+Editar `.env`:
+```bash
+ZOTERO_LOCAL_API_HOST=http://<IP-de-Zotero>:23119
+```
+Y verificar que el firewall permita el puerto 23119 entrante.
+
+### Auth errors con la Web API (web fallback)
+Checkear `ZOTERO_API_KEY` y `ZOTERO_LIBRARY_ID` en `.env`. La key tiene
+que tener permisos read+write; la `library_id` es el número numérico
+de https://www.zotero.org/settings/keys, no el username.
+
+### Firewall bloquea `host.docker.internal:23119`
+En Windows, Windows Defender Firewall a veces bloquea el tráfico
+desde la red de Docker al host. Agregar una regla inbound que permita
+el puerto 23119 desde `Docker Desktop Networks` (o simplemente desde
+`172.0.0.0/12`).
+
+---
+
+## 3. OCR
+
+### Stage 02 aborta con "disk space"
+El chequeo pre-flight exige ≥ 2× el tamaño total del corpus libre en
+el volumen de staging. Liberá espacio o montá `./workspace/` en un
+disco más grande.
+
+### OCR muy lento
+Cada worker de tesseract usa ~300 MB de RAM. Si el host tiene poco
+RAM, bajá `OCR_PARALLEL_PROCESSES` en `.env` — `2` suele ser el sweet
+spot en laptops.
+
+### "OCR produjo texto vacío"
+Algún PDF escaneado tiene tan mala calidad que tesseract no recupera
+texto. El item queda marcado `ocr_failed=True` y avanza igual;
+Stage 04 intentará enriquecer por título. Si el título tampoco se
+extrae bien, va a cuarentena (Stage 04e).
+
+### `--force-ocr` en vez del default
+Por default `skip_text=True` (no re-OCR si ya hay texto). Si sospechás
+que el OCR previo fue malo:
+```bash
+docker compose --profile onboarding run --rm onboarding zotai s1 ocr --force-ocr
+```
+
+---
+
+## 4. PDFs grandes (>20 MB)
+
+### "attachment_simple failed: Request Entity Too Large"
+Zotero API tiene un límite práctico cerca de 20 MB. El pipeline
+fail-loud actual marca el item como `status=failed` y continúa. No
+hay handling automático todavía —
+[issue #39](https://github.com/igalkej/auto_zotero/issues/39) lo
+trackea. Opciones manuales mientras tanto:
+
+1. Importá el PDF a mano en Zotero Desktop (drag-and-drop). Stage 03
+   lo detecta en la próxima corrida via DOI y hace dedup.
+2. Comprimí el PDF (`ocrmypdf --optimize 3 --output-type pdf <in> <out>`)
+   y re-colocalo en `PDF_SOURCE_FOLDERS`.
+
+---
+
+## 5. Budget exceeded mid-run
+
+### Stage 01 o Stage 04 aborta con "Budget exceeded"
+El cap de `.env` es duro — el pipeline prefiere abortar antes que
+gastar demás. Subir el cap y re-correr; los items ya procesados se
+saltean (Stage N es idempotente por `stage_completed`).
+
+```bash
+# Ejemplo: bump Stage 04 de 2.00 a 4.00
+echo 'MAX_COST_USD_STAGE_04=4.00' >> .env
+docker compose --profile onboarding run --rm onboarding zotai s1 enrich --substage all
+```
+
+Para corpus LATAM-heavy, plan_01 sugiere
+`MAX_COST_USD_STAGE_04=4.00` como default (ver §"Aviso — corpus LATAM-heavy"
+en plan_01 §3 Etapa 04).
+
+### "run-all" se interrumpió al superar budget en Stage 04
+El orchestrator captura `BudgetExceededError` y rutea los items
+restantes a 04e (quarantine) en vez de volver a llamar al LLM. Para
+rescatar items quarantinados después de subir el cap:
+
+```bash
+# 1. Levantar el cap.
+# 2. Re-correr sólo stage 04:
+docker compose --profile onboarding run --rm onboarding zotai s1 enrich --substage all
+```
+Los items que estaban en cuarentena con `last_error` apuntando al
+budget vuelven a pasar por el cascade completo (`in_quarantine=False`
+selector es estricto — si ya están en cuarentena, no re-procesás
+automáticamente; sacalos de la colección Quarantine en Zotero
+Desktop o reseteá `in_quarantine=False` en `state.db` primero).
+
+---
+
+## 6. Interrupted runs y resume
+
+### Ctrl+C durante `run-all`
+`run_all` captura `KeyboardInterrupt` entre stages y sale ordenado:
+el estado commitado hasta ahí queda durable. Re-correr el mismo
+comando salta los stages completos y arranca desde el próximo.
+
+### El proceso fue matado sin chance de cleanup
+Cada stage commitea por-item (no all-or-nothing), así que los
+`state.db` rows ya insertados siguen ahí. Ejecutar `zotai s1 status`
+muestra dónde quedó. Re-correr el stage específico (o `run-all`)
+resume sin duplicar trabajo.
+
+### "alembic_version" out-of-sync después de un crash
+Raro, pero si `state.db` queda en un estado inconsistente:
+
+```bash
+# Backup primero.
+cp workspace/state.db workspace/state.db.bak
+
+# Ver revisión actual:
+docker compose --profile onboarding run --rm onboarding \
+    alembic -c /app/alembic.ini current
+
+# Si necesitás bajar todo:
+docker compose --profile onboarding run --rm onboarding \
+    alembic -c /app/alembic.ini downgrade base
+
+# Subir a head:
+docker compose --profile onboarding run --rm onboarding \
+    alembic -c /app/alembic.ini upgrade head
+```
+
+---
+
+## 7. Log y reportes
+
+Todos los stages escriben un CSV por corrida en `./workspace/reports/`:
+
+- `inventory_report_<ts>.csv` — Stage 01, incluye clasificación.
+- `excluded_report_<ts>.csv` — Stage 01, PDFs rechazados (no entran a state.db).
+- `ocr_report_<ts>.csv` — Stage 02.
+- `import_report_<ts>.csv` — Stage 03.
+- `enrich_report_<ts>.csv` — Stage 04.
+- `quarantine_report_<ts>.csv` — Stage 04e (sólo si hubo cuarentenas).
+- `tag_report_<ts>.csv` — Stage 05.
+- `s1_validation_<ts>.{html,csv}` — Stage 06.
+
+Ante dudas, **siempre** empezá por:
+
+```bash
+docker compose --profile onboarding run --rm onboarding zotai s1 status
+docker compose --profile onboarding run --rm onboarding zotai s1 validate --open-report
+```
+
+El status muestra en qué stage hay items atascados; el validation
+report lista issues puntuales con links a Zotero.
+
+---
+
+## Referencias cruzadas
+
+- ADR 013 — networking bridge + `host.docker.internal`.
+- ADR 014 — dedup policy de Stage 03.
+- ADR 015 — ownership ChromaDB (relevante para S2/S3).
+- `docs/economics.md` — caps de budget explicados.
+- `docs/setup-linux.md` / `docs/setup-windows.md` — instalación inicial.

--- a/scripts/run-pipeline.ps1
+++ b/scripts/run-pipeline.ps1
@@ -1,0 +1,37 @@
+# ─────────────────────────────────────────────────────────────
+# scripts/run-pipeline.ps1 — Windows wrapper for S1 run-all.
+#
+# Runs `docker compose run --rm onboarding zotai s1 run-all` with
+# sensible defaults. Any extra arguments are forwarded to the CLI
+# verbatim — use e.g.:
+#
+#     scripts\run-pipeline.ps1 --yes --tag-mode preview
+#
+# Prerequisites:
+#   * Docker Desktop for Windows running.
+#   * WSL2 enabled and integrated with Docker Desktop.
+#   * Zotero 7 desktop open (local API reachable on localhost:23119).
+#   * .env filled in — see .env.example and docs/setup-windows.md.
+#
+# See docs/troubleshooting.md if the run aborts mid-stage.
+# ─────────────────────────────────────────────────────────────
+
+$ErrorActionPreference = "Stop"
+
+# Resolve the repo root relative to this script.
+$scriptDir = Split-Path -Parent $MyInvocation.MyCommand.Path
+$repoRoot = Resolve-Path (Join-Path $scriptDir "..")
+Set-Location $repoRoot
+
+if (-not (Test-Path ".env")) {
+    Write-Host "⚠️  .env not found at $repoRoot\.env" -ForegroundColor Yellow
+    Write-Host "    Copy .env.example → .env and fill in your credentials." -ForegroundColor Yellow
+    exit 1
+}
+
+# `--rm` keeps the one-shot container from sticking around after the run.
+# The `onboarding` profile must be active; without it the service is
+# hidden from `docker compose run` (plan_00 + docker-compose.yml).
+& docker compose --profile onboarding run --rm onboarding `
+    zotai s1 run-all @args
+exit $LASTEXITCODE

--- a/scripts/run-pipeline.sh
+++ b/scripts/run-pipeline.sh
@@ -1,0 +1,36 @@
+#!/usr/bin/env bash
+# ─────────────────────────────────────────────────────────────
+# scripts/run-pipeline.sh — Linux / macOS wrapper for S1 run-all.
+#
+# Runs ``docker compose run --rm onboarding zotai s1 run-all`` with
+# sensible defaults. Any extra arguments are forwarded to the CLI
+# verbatim — use e.g.:
+#
+#     scripts/run-pipeline.sh --yes --tag-mode preview
+#
+# Prerequisites:
+#   * Docker Engine or Docker Desktop running.
+#   * Zotero 7 desktop open (local API reachable on localhost:23119).
+#   * .env filled in — see .env.example and docs/setup-linux.md.
+#
+# See docs/troubleshooting.md if the run aborts mid-stage.
+# ─────────────────────────────────────────────────────────────
+set -euo pipefail
+
+# Resolve the repo root relative to this script — works whether the
+# user invoked it from repo root or any subdirectory.
+SCRIPT_DIR="$(cd "$(dirname "${BASH_SOURCE[0]}")" && pwd)"
+REPO_ROOT="$(cd "${SCRIPT_DIR}/.." && pwd)"
+cd "${REPO_ROOT}"
+
+if [[ ! -f .env ]]; then
+    echo "⚠️  .env not found at ${REPO_ROOT}/.env"
+    echo "    Copy .env.example → .env and fill in your credentials."
+    exit 1
+fi
+
+# `--rm` keeps the one-shot container from sticking around after the run.
+# The `onboarding` profile must be active; without it the service is
+# hidden from `docker compose run` (plan_00 + docker-compose.yml).
+exec docker compose --profile onboarding run --rm onboarding \
+    zotai s1 run-all "$@"


### PR DESCRIPTION
Closes #10.

## Summary

Phase 9 is almost entirely documentation. The Dockerfile and \`docker-compose.yml\` were already finalised by earlier PRs (#37 bridge networking, #42 ChromaDB bind mount). This PR fills in the remaining user-facing surface:

- **\`scripts/run-pipeline.sh\` + \`.ps1\`** — thin wrappers around \`docker compose --profile onboarding run --rm onboarding zotai s1 run-all\`. Fail-fast if \`.env\` is missing with a clear pointer to \`.env.example\`. All extra args are forwarded verbatim:
  \`\`\`bash
  ./scripts/run-pipeline.sh --yes --tag-mode preview --allow-template-taxonomy
  \`\`\`
- **\`docs/setup-linux.md\`** — Docker Engine install, Zotero local API setup, minimum \`.env\`, first run, cron recipe for the S2 worker (ADR 012), ADR 013 networking notes.
- **\`docs/setup-windows.md\`** — WSL2 + Docker Desktop, \`host.docker.internal\` gotcha, PowerShell execution policy, Task Scheduler recipe for the S2 worker.
- **\`docs/troubleshooting.md\`** — seven categories: Docker, Zotero connectivity, OCR, >20 MB PDFs (links to the tracking issue #39), budget exceeded mid-run, interrupted runs + resume, plus starting-point pointers to \`zotai s1 status\` + \`validate --open-report\`.
- **\`docs/economics.md\`** — per-stage cost estimates (Jan 2026 OpenAI prices), how the hard caps in \`.env\` enforce them, LATAM-heavy corpus adjustments, optimization tips.
- **\`README.md\`** — quickstart now matches what Phase 8 actually exposes (the \`--profile onboarding\`, \`--rm\`, \`run-pipeline.*\` wrappers, \`--tag-mode\`, \`--allow-template-taxonomy\`). The status table shows S1 as functional end-to-end.

### Issue-body drift flagged (not blocking)

The issue body mentions the ChromaDB mount should be \`:ro\`. ADR 015 amended this to \`:rw\` because S2 is now the owner of the embeddings index; \`docker-compose.yml\` already reflects \`:rw\` (landed in #42). No compose change needed here.

## Acceptance criteria

- [x] \`docker compose --profile onboarding run --rm onboarding zotai s1 status\` works (manual, verified locally)
- [x] ChromaDB bind mount present on the \`dashboard\` service, absent on \`onboarding\` (unchanged since #42)
- [x] \`scripts/run-pipeline.sh\` and \`.ps1\` exist + executable
- [x] Setup docs cover both OSs
- [x] \`docs/troubleshooting.md\` covers the six (now seven) categories
- [x] \`docs/economics.md\` matches the \`.env.example\` budget caps
- [x] README quickstart matches Phase 8 CLI

## Test plan

- [x] \`pytest\` — 203 passed (no code changes)
- [x] Dockerfile / docker-compose.yml unchanged — \`mypy --strict\` and \`ruff\` not applicable here
- [ ] Manual: \`docker compose build\` (post-merge)
- [ ] Manual: \`./scripts/run-pipeline.sh --yes\` on a real workspace (post-merge)

## Related

- Issue #10 (Phase 9 — Docker finalization + setup docs)
- ADR 011 (ChromaDB bind mount, amended for :rw by ADR 015)
- ADR 012 (APScheduler default + cron alternative)
- ADR 013 (bridge networking + host.docker.internal)

## What's left after #10

S1 is done. The remaining roadmap is S3 (#11 — docs + scripts only; ~0.5 days) followed by S2 sprints (#12–#15; 2–3 weeks). The ADR 015 Fase 2 manual validation checklist is still required before S2 Sprint 1 code lands — user-side work.