### PR TITLE
docs(adr-018): SciELO (04bs) + DOAJ (04bd) substages for Stage 04 cascade

### DIFF
--- a/docs/decisions/018-scielo-and-doaj-substages.md
+++ b/docs/decisions/018-scielo-and-doaj-substages.md
@@ -1,0 +1,156 @@
+# ADR 018 — Stage 04 cascade: add SciELO (04bs) and DOAJ (04bd) substages for LATAM and open-access coverage
+
+**Status**: Accepted
+**Date**: 2026-04-27
+**Deciders**: project owner
+**Supersedes**: —
+**Superseded by**: —
+
+---
+
+## Context
+
+Issue #46 surfaces a known gap in S1 Stage 04's enrichment cascade. The current cascade is:
+
+```
+04a (aggressive ID extraction) → 04b (OpenAlex fuzzy) → 04c (Semantic Scholar fuzzy) → 04d (LLM extraction) → 04e (quarantine)
+```
+
+For corpora dominated by anglophone journals indexed in Crossref, this cascade is sufficient: the vast majority of items resolve at 04a–c, well within the <10% quarantine target documented in `plan_01_subsystem1.md` §3 Etapa 04.
+
+For the project's actual primary user — a CONICET researcher with a LATAM-heavy corpus (CEPAL Review, Desarrollo Económico, Estudios Económicos, Revista BCRA, BID/CAF/IADB working papers, plus most SciELO and RedALyC titles) — coverage of OpenAlex and Semantic Scholar drops to 20–50% per journal. Items that should resolve at 04b/04c instead fall through to 04d (LLM, $0.0004/item, with quarantine risk on malformed JSON) or 04e (quarantine, value loss). The plan_01 §3 Etapa 04 "Aviso — corpus LATAM-heavy" already calls this out; the existing target accepts up to <25% quarantine for LATAM corpora as an explicit weakness pending v1.1.
+
+This ADR closes part of that gap by adding two free, public, fuzzy-title-searchable metadata sources to the cascade between 04b and 04c. It also documents which other candidate sources from issue #46 and from the user's evaluation request (DOAJ, ERIH PLUS, Scopus) are *not* viable as cascade substages and why.
+
+### Sources evaluated
+
+| Source | API surface | Verdict |
+|---|---|---|
+| **SciELO** | `search.scielo.org` Solr-backed search (`q=ti:"<title>"&format=json`), public, no auth, no documented rate limit. The optional two-step ArticleMeta (`articlemeta.scielo.org/api/v1/article`) is unnecessary — the Solr response already carries DOI + multilingual title + authors + journal + year + language for the records we need to map. | ✅ Include — substage `04bs` |
+| **DOAJ** | `doaj.org/api/v3/search/articles/<query>`, Elasticsearch query syntax (`bibjson.title:"<title>"~`), public, no auth for read, **2 req/s with bursts up to 5**. Returns `bibjson` with title, author[], year, journal{title,country,language}, identifier[type=doi], abstract, keywords. | ✅ Include — substage `04bd` |
+| **REDIB** | OAI-PMH only at `redib.org/oai-redib`. OAI-PMH is for incremental harvesting, not fuzzy lookup; the protocol does not support free-text title query. Building a local index from harvest is out of scope for v1.1. | ❌ Defer — issue #46 stays open |
+| **RedALyC** | OAI-PMH (Dublin Core, throughput 20–200 records/min — insufficient for per-item lookup) plus a "Journal API" documented in a 2023 Zenodo PDF that is for journal-level metadata, not article search. | ❌ Defer — issue #46 stays open |
+| **La Referencia** | OAI-PMH aggregator over LATAM national repositories. Same problem as RedALyC. | ❌ Defer — issue #46 stays open |
+| **ERIH PLUS** | An *index of journals* (humanities and social sciences), not articles. Article-level data only via Dimensions (commercial). The public surface answers "is journal X indexed?" — not "what's the metadata for this article?". Does not fit the cascade's per-article fuzzy-lookup contract. | ❌ Reject as cascade source. Possible future use as a journal-quality gate downstream of 04d; tracked separately if it ever matters. |
+| **Scopus** | Full REST API with TITLE() and DOI search, 20k queries/7d quota, **but requires Elsevier API key bound to an institutional token tied to a subscribing institution**. The project's distribution scenario α (CLAUDE.md) is one researcher per instance against their own library, including researchers without Scopus institutional access. Adding Scopus as a default cascade source would gate LATAM coverage behind a commercial subscription. | ❌ Reject as default. Possible future opt-in via `SCOPUS_API_KEY` env when the user explicitly has access; not in v1.1. |
+
+## Decision
+
+**Add two new substages to S1 Stage 04 between `04b` and `04c`, in order:**
+
+1. **`04bs` — Match fuzzy contra SciELO**, single-step against `search.scielo.org`'s Solr-backed JSON endpoint. Default ON via `BehaviorSettings.s1_enable_scielo: bool = True` (env `S1_ENABLE_SCIELO`).
+2. **`04bd` — Match fuzzy contra DOAJ**, single-step against `doaj.org/api/v3/search/articles/<query>`. Default ON via `BehaviorSettings.s1_enable_doaj: bool = True` (env `S1_ENABLE_DOAJ`).
+
+The new cascade is:
+
+```
+04a → 04b (OpenAlex) → 04bs (SciELO) → 04bd (DOAJ) → 04c (Semantic Scholar) → 04d (LLM) → 04e (Quarantine)
+```
+
+### Order rationale
+
+- **04bs before 04bd**: SciELO has higher *per-request specificity* for LATAM-Spanish corpora (~1.7k iberoamerican journals, locally curated). DOAJ has higher *horizontal recall* (~20k open-access journals globally) but lower specificity per LATAM lookup. Trying the higher-specificity source first; the broader source picks up what the first misses.
+- **Both before 04c**: Semantic Scholar has stricter rate limits (100 req/5min without key) and weaker LATAM coverage than either SciELO or DOAJ for the project's target corpus. Putting the LATAM-stronger sources earlier in the cascade reduces load on 04c and the chance of it being the chokepoint.
+- **Both before 04d**: free vs paid. Both new substages are gratis; 04d costs ~$0.0004/item.
+
+### Implementation artefacts
+
+1. **`src/zotai/api/scielo.py`** (new). `SciELoClient.search_articles(title, *, per_page=5)` does a single GET to `search.scielo.org` with `format=json`, parses `payload["diaServerResponse"][0]["response"]["docs"]` with defensive shape handling (returns `[]` and logs `log.warning("scielo.unexpected_shape", ...)` on shape mismatch). `map_scielo_to_zotero(doc)` produces a Zotero-ready dict; quality gate identical to the Semantic Scholar mapper (returns `None` if title or authors missing). Multilingual title selection prefers the entry matching `doc["la"]`, falling back to the first non-empty title.
+
+2. **`src/zotai/api/doaj.py`** (new). `DOAJClient.search_articles(title, *, per_page=5)` does a single GET to `https://doaj.org/api/v3/search/articles/<URL-encoded query>` with `pageSize=per_page&page=1`. Query syntax: `bibjson.title:"<title>"~` (Elasticsearch fuzzy). Parses `payload["results"]`. `map_doaj_to_zotero(record)` extracts from `record["bibjson"]`: title, author[].name (split via `_split_name`), year, identifier[type=doi], journal.title, journal.language[0], abstract. Same quality gate.
+
+3. **`src/zotai/s1/stage_04_enrich.py`**. Two new helper functions, `_enrich_04bs_one()` and `_enrich_04bd_one()`, structurally cloned from `_enrich_04b_one()`. Both inserted between 04b and 04c in `_run_per_item_cascade()`, gated by their respective `*_client is not None` check (which is itself gated by the feature flag at client construction time). The `EnrichSubstage` Literal, the `EnrichStatus` Literal (`enriched_04bs`, `enriched_04bd`), and `_ENRICHED_STATUSES` all extend to include the new statuses. The `EnrichResult` dataclass gains `items_enriched_04bs` and `items_enriched_04bd` counters.
+
+4. **`src/zotai/config.py`**. `BehaviorSettings` gains `s1_enable_scielo: bool = True` and `s1_enable_doaj: bool = True`. No new settings classes — both sources are open and parameterless.
+
+5. **`src/zotai/cli.py`**. The `--substage` flag accepts `04bs` and `04bd`; output reports `enriched_04bs` and `enriched_04bd` counts.
+
+6. **No `utils/http.py` changes**. `make_async_client()` + `make_user_agent(mailto=...)` + `with_retry()` cover both clients.
+
+7. **No Alembic migration**. The Zotero-ready payload produced by both new mappers is structurally identical to the existing OpenAlex/SS payload (`itemType`, `title`, `creators`, `date`, `abstractNote`, `DOI?`, `publicationTitle?`). The `Item.metadata_json` column already accepts it.
+
+### Resilience policy
+
+The cascade orchestrator must not be brittle to a misbehaving external service. Both new substages, on `httpx.HTTPStatusError`:
+
+- **403 / 429 / 502 / 503** → return `no_progress` with error label `<source>_unavailable:<status>`. The cascade flows to the next substage. These statuses are operationally transient or service-side and should never single-handedly fail an item.
+- **Any other exception** → return `failed`. This is a genuine bug worth investigating in the CSV report.
+
+The defensive parsing inside `search_articles()` itself (unexpected response shape) returns `[]`, logs `log.warning("<source>.unexpected_shape", ...)`, and lets the cascade move on — same as 04b/04c behaviour.
+
+### Spec-compliance contract
+
+The code PR that implements this ADR must satisfy these literal names and defaults:
+
+| Concept | Canonical name |
+|---|---|
+| Substage names | `04bs`, `04bd` |
+| Status labels | `enriched_04bs`, `enriched_04bd` |
+| Settings fields | `BehaviorSettings.s1_enable_scielo`, `BehaviorSettings.s1_enable_doaj` |
+| Env vars | `S1_ENABLE_SCIELO`, `S1_ENABLE_DOAJ` |
+| Defaults | both `True` |
+| CLI substage values | `04a, 04b, 04bs, 04bd, 04c, 04d, 04e, all` |
+| Cascade order | `04a → 04b → 04bs → 04bd → 04c → 04d → 04e` |
+| Counter fields | `EnrichResult.items_enriched_04bs`, `EnrichResult.items_enriched_04bd` |
+
+Spec-compliance assertions belong in the test suite of the code PR (e.g. one test that the cascade visits substages in this exact order, one test that defaults are ON, one test that env var names match).
+
+## Consequences
+
+### Positive
+
+- **Closes the LATAM coverage gap as far as freely available APIs allow.** SciELO is the canonical Iberoamerican index; DOAJ is the canonical open-access index. Together they capture the bulk of LATAM economics and social-science journals not in Crossref/OpenAlex.
+- **Zero marginal cost.** Both substages are gratis. Using them ahead of 04d (LLM, $0.0004/item) reduces 04d's actual workload and therefore the realised cost on LATAM-heavy corpora.
+- **Reuses every existing pattern.** Both clients reuse `make_async_client` + `with_retry`. Both substages clone `_enrich_04b_one` literally with cosmetic substitutions. Same fuzzy threshold (`_FUZZ_THRESHOLD = 85`), same dedup-on-attach policy (ADR 014), same reparenting flow.
+- **Cleanly opt-out-able.** Anglo-only corpora can disable both via env vars. Default ON keeps the LATAM use case (the actual primary user) unblocked without surprising other users — the LATAM extension is the project's own primary use case, not an exotic add-on.
+- **Documents the rejected sources explicitly.** Future contributors don't need to re-evaluate REDIB / RedALyC / La Referencia / ERIH PLUS / Scopus from scratch. The conditions under which they'd become viable are written down (real corpus signal, harvest-and-index local store for OAI-only sources, opt-in env for Scopus).
+
+### Negative
+
+- **Two extra round trips per cascade hit beyond 04b.** For an item that ultimately falls to 04d, the cascade now does up to two extra calls (`search.scielo.org` + DOAJ). Latency: ~300–800 ms each, network-dependent. Mitigated by the resilience policy (transient errors fall through fast as `no_progress` without retry storms) and by the fact that fuzzy matches that resolve early in the cascade *save* time and money downstream.
+- **Cloudflare in front of `search.scielo.org`.** The endpoint is behind Cloudflare's WAF. Default `httpx` UAs sometimes 403; a polite UA (`zotai/<version> (mailto:<email>)`) typically passes. The implementation must validate empirically; if a future Cloudflare rule update breaks the polite-UA path, the substage degrades to `no_progress` per the resilience policy and the cascade still produces output, but coverage drops until the headers are adjusted.
+- **DOAJ rate limit (2 req/s).** In the cascade context (one request per item per substage, throughput dominated by OCR/LLM elsewhere), 2 req/s is holgado. Future batch reconcile or backfill-style flows would need a token bucket; out of scope for v1.1.
+- **Two new feature flags.** `S1_ENABLE_SCIELO` and `S1_ENABLE_DOAJ` enlarge the configuration surface by two booleans. Justified by the explicit per-source opt-out need (a researcher with a known anglo-only corpus may want the cleaner cascade); kept simple — booleans, no per-source settings classes.
+
+### Neutral
+
+- **Reversible.** Setting both flags to `false` recovers the pre-ADR cascade behaviour with zero code differences in the hot path (the `if scielo_client is not None` and `if doaj_client is not None` guards short-circuit cheaply).
+- **Doesn't affect 04a, 04b, 04c, 04d, or 04e semantics.** The new substages slot in without changing existing ones. Tests for existing substages stay green.
+- **Doesn't change the success target for LATAM corpora yet.** plan_01 §3 keeps the ≤25% LATAM quarantine target as the *worst-case* tolerance until empirical data from a real CONICET corpus run shows the post-ADR-018 number. The expectation is that 04bs+04bd absorbs 15–30% of items that previously fell through to 04d/04e, but this is not a contractual commitment.
+
+## Alternatives considered
+
+**A. Parallelise SciELO + DOAJ alongside 04b (race-to-first-match).**
+Rejected. Adds race-resolution complexity (which match wins if two come back over threshold?) without a clear gain over sequential. The existing cascade contract — "first match wins, in the order written" — is a strong invariant; breaking it for two sources is not justified by the latency saving.
+
+**B. Place both new substages after 04c, not before.**
+Rejected. Loses the rate-limit-saving benefit (Semantic Scholar is the cascade's tightest free rate limit). For a LATAM-heavy corpus, this also means the cascade hits SS's coverage hole *before* trying the LATAM-specific sources, increasing the chance of a no-progress slog through 04c that 04bs would have resolved cleanly.
+
+**C. Two-step SciELO (Solr search → ArticleMeta fetch by SciELO ID).**
+Rejected. The Solr response already carries DOI + title + authors + journal + year for the records we need to map. Two-step adds latency, complexity, and a partial-failure mode (search succeeds, ArticleMeta down). The single-step path is sufficient for the cascade's quality gate; if a future need for richer metadata emerges, ArticleMeta can be added behind a flag.
+
+**D. One umbrella `04L` substage that internally fans out to both SciELO and DOAJ.**
+Rejected. The status labels (`enriched_04bs` vs `enriched_04bd`) carry diagnostic value: when reading the CSV or running validation reports, knowing *which* source matched lets the user spot patterns ("DOAJ is doing all the work, SciELO matches nothing — maybe the SciELO endpoint is misconfigured"). Lumping them together hides that signal.
+
+**E. Dedicated `SciELoSettings` / `DOAJSettings` classes in `config.py`.**
+Rejected. Each source has exactly one configurable knob: the enable bool. Two booleans on `BehaviorSettings` is far simpler than two new pydantic classes that contain one field each. If a future ADR adds API keys, rate-limit overrides, or endpoint switches, the classes can be promoted then; YAGNI for v1.1.
+
+**F. Adopt Scopus as a default cascade source (gated by API key presence).**
+Rejected. The project's distribution scenario α explicitly assumes per-researcher instances; many target users (CONICET fellows without Elsevier institutional contracts) cannot use Scopus. Making it part of the default cascade would silently degrade their experience to "yet another item in quarantine because Scopus auth failed". Future opt-in via `SCOPUS_API_KEY` is a separate decision that requires its own ADR if and when a user requests it.
+
+**G. Adopt ERIH PLUS as a substage.**
+Rejected on factual grounds: ERIH PLUS does not expose article-level metadata. There is no fuzzy-title-to-article query for it to answer. ERIH PLUS could plausibly be a *journal-quality validator* downstream of 04d (verifying the LLM-derived journal name is real), but that's a different shape of integration and not in this ADR's scope.
+
+**H. Build a local OAI-PMH harvest of REDIB / RedALyC / La Referencia and lookup against the local index.**
+Rejected for v1.1. Bootstrapping a local copy of three OAI-PMH corpora is a significant project on its own (storage, refresh policy, indexing layer, query layer). The decision to do this should follow real-corpus data: if 04bs + 04bd together still leave >20–25% in quarantine on the user's actual corpus, the harvest path becomes worth the engineering. Until then, issue #46 stays open as the marker.
+
+## References
+
+- `docs/plan_01_subsystem1.md` §3 Etapa 04 — the cascade contract this ADR extends.
+- `docs/decisions/010-ruta-a-openalex-not-zotero-translator.md` — the upstream choice (OpenAlex over Zotero translator) for 04b that this ADR mirrors at 04bs and 04bd.
+- `docs/decisions/014-stage-03-dedup-skip-attach-if-pdf-exists.md` — dedup/attach policy reused unchanged in the new substages' reparenting flow.
+- Issue #46 — stays open; tracks the remaining LATAM sources (REDIB, RedALyC, La Referencia) plus the harvest-and-index strategy that would make them viable.
+- SciELO ArticleMeta API: `https://articlemeta.scielo.org/api/v1/article/` (referenced for completeness; not used in v1.1).
+- DOAJ Public API v3: `https://doaj.org/api/v3/docs` — the Elasticsearch query syntax and `bibjson` schema this ADR maps to Zotero fields.
+- ERIH PLUS: `https://kanalen.hkdir.no/publiseringskanaler/erihplus` — referenced for the rejection rationale.
+- Scopus API: `https://dev.elsevier.com/sc_apis.html` — referenced for the rejection rationale (institutional token requirement).

--- a/docs/economics.md
+++ b/docs/economics.md
@@ -13,7 +13,7 @@ al cambio de precios de OpenAI.
 | **Stage 01** — LLM gate (clasificador académico) | ~$0.12 | $1.00 | `MAX_COST_USD_STAGE_01` |
 | **Stage 02** — OCR | $0 | — | — (tesseract local, sin costo marginal) |
 | **Stage 03** — Import vía OpenAlex | $0 | — | — (API gratis) |
-| **Stage 04a-c** — Cascade gratis | $0 | — | — (APIs gratis + rate limits) |
+| **Stage 04a / 04b / 04bs / 04bd / 04c** — Cascade gratis | $0 | — | — (APIs gratis + rate limits; ver ADR 018) |
 | **Stage 04d** — LLM extraction | ~$0.40 | $2.00 | `MAX_COST_USD_STAGE_04` |
 | **Stage 05** — Tagging LLM | ~$0.40 | $1.00 | `MAX_COST_USD_STAGE_05` |
 | **Stage 06** — Validation | $0 | — | — (read-only) |
@@ -57,29 +57,37 @@ No hay costo de API.
 OpenAlex es gratuito con `USER_EMAIL` en el User-Agent (el "polite
 pool", 100 req/s vs 10). Zotero local API es gratis. Costo = $0.
 
-### Stage 04a-c — Cascade gratis
+### Stage 04a / 04b / 04bs / 04bd / 04c — Cascade gratis
 
 - **04a**: regex + OpenAlex por DOI. Gratis.
 - **04b**: OpenAlex por búsqueda de título. Gratis.
+- **04bs**: SciELO por búsqueda de título (Solr). Gratis. Cobertura
+  LATAM-Spanish específica. Ver ADR 018.
+- **04bd**: DOAJ por búsqueda de título (Elasticsearch). Gratis,
+  rate limit 2 req/s. Cobertura open-access global. Ver ADR 018.
 - **04c**: Semantic Scholar por búsqueda de título. Gratis (rate limit
   100 req / 5 min sin key, 1 req/s con key).
 
-Estas tres ramas suelen resolver 80-90 % del fallthrough de Stage 03
-en corpus anglo-dominantes. Para LATAM-heavy cae a 40-60 %, lo que
-empuja más items a Stage 04d.
+Estas cinco ramas (toda la cascade gratis) suelen resolver 80-90 %
+del fallthrough de Stage 03 en corpus anglo-dominantes. Para
+LATAM-heavy post-ADR-018, las substages 04bs + 04bd absorben gran
+parte de la brecha de OpenAlex/Semantic Scholar y suben la cobertura
+gratis estimada a 70-80 %, lo que empuja menos items a Stage 04d que
+antes.
 
 ### Stage 04d — LLM extraction
 
-Sólo los items que sobrevivieron 04a-c van al LLM. `gpt-4o-mini` con
-primeras 2 páginas + prompt estructurado + 1 retry. ~$0.0004 por item.
+Sólo los items que sobrevivieron toda la cascade gratis (04a → 04b →
+04bs → 04bd → 04c) van al LLM. `gpt-4o-mini` con primeras 2 páginas +
+prompt estructurado + 1 retry. ~$0.0004 por item.
 
 **Estimación anglo-dominante**: 10-20 % del corpus × 1000 PDFs ×
 $0.0004 = **$0.04-0.08**.
 
-**Estimación LATAM-heavy** (plan_01 §3 Etapa 04 "Aviso"): 40 % del
-corpus × 1000 × $0.0004 = **$0.16**, pero con ruido de retries
-malformados y papers largos puede llegar a **$1.00**. Subí el cap a
-`MAX_COST_USD_STAGE_04=4.00` si tu corpus es LATAM-pesado.
+**Estimación LATAM-heavy post-ADR-018** (plan_01 §3 Etapa 04 "Aviso"):
+25-30 % del corpus × 1000 × $0.0004 = **$0.10-0.12**, pero con ruido
+de retries malformados y papers largos puede llegar a **$1.00**. Subí
+el cap a `MAX_COST_USD_STAGE_04=4.00` si tu corpus es LATAM-pesado.
 
 Cuando el cap trip, el orchestrator de `run-all` rutea los items
 restantes directo a 04e (quarantine) — no vuelve a llamar al LLM.
@@ -153,8 +161,9 @@ costo marginal por query (Anthropic lo incluye en la suscripción).
 
 - Correr Stage 01 con `--skip-llm-gate` si tenés confianza en que tu
   corpus está limpio de no-académicos (ahorra los ~$0.12 del gate).
-- Correr Stage 04d con `--substage 04d` aislado después de 04a-c
-  cuando querés monitorear el gasto del LLM específicamente.
+- Correr Stage 04d con `--substage 04d` aislado después de la cascade
+  gratis (04a → 04b → 04bs → 04bd → 04c) cuando querés monitorear
+  el gasto del LLM específicamente.
 - `--preview` antes de `--apply` en Stage 05 — el costo es el mismo
   (un call por ítem), pero preview no compromete las tags a Zotero
   si no te gustan.

--- a/docs/plan_01_subsystem1.md
+++ b/docs/plan_01_subsystem1.md
@@ -161,7 +161,7 @@ zotai s1 ocr [--force-ocr] [--parallel N]
 **Ruta C** (fallback — captura todo lo que no entra por A):
 1. Aplica cuando `detected_doi is null`, cuando OpenAlex devuelve 404/no-match para el DOI, o cuando la metadata devuelta es insuficiente (sin título o sin autores).
 2. Subir PDF como attachment huérfano sin parent via `pyzotero.attachment_simple([path], parent_key=None)`. Zotero copia el PDF a su storage igual que en Ruta A; el item queda como attachment top-level sin metadata bibliográfica.
-3. Marcar `import_route='C'`, item queda pendiente de enrichment en Etapa 04. La cascada 04a-d intenta recuperar metadata por identificadores alternativos (arXiv/ISBN), título fuzzy-match contra OpenAlex/Semantic Scholar, y finalmente LLM extrayendo metadata del texto del PDF (grounded). 04e envía los que fallan a `Quarantine`.
+3. Marcar `import_route='C'`, item queda pendiente de enrichment en Etapa 04. La cascada 04a → 04b → 04bs → 04bd → 04c → 04d intenta recuperar metadata por identificadores alternativos (arXiv/ISBN), título fuzzy-match contra OpenAlex/SciELO/DOAJ/Semantic Scholar, y finalmente LLM extrayendo metadata del texto del PDF (grounded). 04e envía los que fallan a `Quarantine`.
 
 **Nota — ausencia de Ruta B y fuente de metadata en Ruta A**: versiones previas de este plan (a) incluían una Ruta B que llamaba al endpoint "Retrieve Metadata for PDFs" de Zotero Desktop y (b) describían la resolución de DOI en Ruta A como "via translator chain" de la Zotero API. Ambas decisiones implicaban depender de endpoints del Zotero connector / recognizer que no son API pública estable y son frágiles entre versiones del desktop. Ambas se eliminaron con el mismo rationale: consolidar la recuperación de metadata en clientes HTTP documentados (OpenAlex/Semantic Scholar) y en la cascada de Etapa 04. Ver ADR 010 para el detalle de por qué Ruta A usa OpenAlex en vez del translator de Zotero.
 
@@ -176,7 +176,7 @@ zotai s1 ocr [--force-ocr] [--parallel N]
 
 **Tasa esperada**:
 - Ruta A: 50-60% del corpus (items con DOI detectado y translator exitoso).
-- Ruta C: 40-50% del corpus (items sin DOI + items donde A falló). Todos pasan por Etapa 04. La cascada 04a-d apunta a recuperar metadata en ≥80% de estos antes de mandar el resto a cuarentena en 04e.
+- Ruta C: 40-50% del corpus (items sin DOI + items donde A falló). Todos pasan por Etapa 04. La cascada 04a → 04b → 04bs → 04bd → 04c → 04d apunta a recuperar metadata en ≥80% de estos antes de mandar el resto a cuarentena en 04e.
 
 **Aviso — corpus LATAM-heavy**. Los números anteriores asumen corpus
 anglo-dominante (revistas indexadas en CrossRef / PMC / arXiv). Para
@@ -230,8 +230,35 @@ zotai s1 import [--batch-size 50] [--dry-run]
   - Actualizar en Zotero via PATCH.
 - Rate limit: OpenAlex permite 10 req/sec sin autenticación, 100 con email en header. Setear `User-Agent: zotai/{version} (mailto:<user-email>)`.
 
-**04c — Match fuzzy contra Semantic Scholar**:
+**04bs — Match fuzzy contra SciELO** (per [ADR 018](decisions/018-scielo-and-doaj-substages.md)):
 - Solo para items que fallaron 04b.
+- Single-step contra `search.scielo.org` (Solr-backed):
+  - `GET https://search.scielo.org/?q=ti:"<title>"&format=json&output=site&count=5&lang=en`.
+- Mismo criterio fuzzy `rapidfuzz.fuzz.token_set_ratio` con threshold compartido `_FUZZ_THRESHOLD = 85`.
+- Si score >= 85:
+  - Hidratar item con metadata de SciELO (DOI cuando esté presente, título multilingual prefiriendo `doc["la"]`, autores, año, journal, abstract, language).
+  - Crear parent + reparent vía pyzotero (mismo dedup ADR 014).
+- Status output: `enriched_04bs`.
+- Default ON. Opt-out vía `S1_ENABLE_SCIELO=false` (sentido para corpus 100% anglo).
+- Sin API key, sin rate limit duro documentado. Polite pool con `User-Agent: zotai/{version} (mailto:<user-email>)`. SciELO está detrás de Cloudflare; UA polite typically passes.
+- Resilience: HTTP 403/429/502/503 → `no_progress` (cascade sigue a 04bd). Otras excepciones → `failed`.
+
+**04bd — Match fuzzy contra DOAJ** (per [ADR 018](decisions/018-scielo-and-doaj-substages.md)):
+- Solo para items que fallaron 04bs.
+- Single-step contra `doaj.org/api/v3/search/articles/`:
+  - `GET https://doaj.org/api/v3/search/articles/<URL-encoded query>?pageSize=5&page=1`.
+  - Query Elasticsearch syntax: `bibjson.title:"<title>"~`.
+- Mismo criterio fuzzy con threshold `_FUZZ_THRESHOLD = 85`.
+- Si score >= 85:
+  - Hidratar item con metadata de DOAJ (`bibjson.title`, `bibjson.author[].name`, `bibjson.year`, `bibjson.identifier[type=doi]`, `bibjson.journal.title`, `bibjson.journal.language[0]`, `bibjson.abstract`).
+  - Crear parent + reparent (mismo dedup ADR 014).
+- Status output: `enriched_04bd`.
+- Default ON. Opt-out vía `S1_ENABLE_DOAJ=false`.
+- Rate limit DOAJ: 2 req/s con bursts hasta 5. Holgado en el cascade (un request por item).
+- Resilience: misma política que 04bs.
+
+**04c — Match fuzzy contra Semantic Scholar**:
+- Solo para items que fallaron 04bd.
 - `GET https://api.semanticscholar.org/graph/v1/paper/search?query=<title>&limit=5`.
 - Mismo criterio fuzzy match.
 - Rate limit: 100 req/5min sin key. Si tenés `SEMANTIC_SCHOLAR_API_KEY`, 1 req/sec.
@@ -258,21 +285,21 @@ Do NOT invent information.
 - Persistir en CSV `quarantine_report.csv` con path original, primeras 200 chars del texto, razón de fracaso.
 
 **Presupuesto por sub-etapa**:
-- 04a-c: $0 (APIs gratuitas, solo rate limits).
+- 04a-c (incluyendo 04bs y 04bd): $0 (APIs gratuitas, solo rate limits).
 - 04d: max $2 configurable (`MAX_COST_USD_STAGE_04`, default 2.00). Si excede, pausar y pedir confirmación.
 
-**Aviso — corpus LATAM-heavy**. El default de $2 asume que la cascada 04a-c (gratis) resuelve 80%+ de los Ruta C. Para corpus LATAM-heavy (ver §3 Etapa 03 "Aviso — corpus LATAM-heavy"), la cobertura de OpenAlex y Semantic Scholar cae y una fracción mayor del corpus llega a 04d. Estimación pesimista: 40% del corpus (≈400 items sobre 1000) × $0.0004 / item = ~$1.60, todavía dentro de $2. Pero con ruido de retries malformados y papers largos puede exceder. **Recomendación para usuarios LATAM-heavy**: setear `MAX_COST_USD_STAGE_04=4.00` en `.env` antes de correr la etapa, y observar el costo real en el reporte de Etapa 06 para ajustar en corridas futuras. El cap duro sigue obligando a confirmación explícita antes de gastar extra.
+**Aviso — corpus LATAM-heavy**. La cascada 04a → 04b → 04bs → 04bd → 04c (toda gratis) está diseñada para resolver 80%+ de los Ruta C antes de tocar 04d. Para corpus LATAM-heavy (ver §3 Etapa 03 "Aviso — corpus LATAM-heavy"), el orden 04bs (SciELO) → 04bd (DOAJ) está específicamente dimensionado a esa cobertura: SciELO captura el grueso de revistas iberoamericanas no indexadas en Crossref; DOAJ captura el resto del open-access global. Estimación pesimista post-ADR-018: 25-30% del corpus (≈250-300 items sobre 1000) llega a 04d × $0.0004 / item = ~$1.00-1.20, holgadamente dentro de $2. Pero con ruido de retries malformados y papers largos puede exceder. **Recomendación para usuarios LATAM-heavy**: setear `MAX_COST_USD_STAGE_04=4.00` en `.env` antes de correr la etapa, y observar el costo real en el reporte de Etapa 06 para ajustar en corridas futuras. El cap duro sigue obligando a confirmación explícita antes de gastar extra.
 
 **Edge cases**:
 - API down (OpenAlex, Semantic Scholar): retry con backoff; tras 3 fallos, saltar item y continuar.
 - Título extraído es genérico ("Chapter 1", "Introduction"): detectable por longitud <5 palabras o coincidencia con blacklist. Saltar a siguiente sub-etapa directamente.
 - LLM retorna JSON malformado: reintentar 1 vez con mensaje corregir. Si falla, cuarentena.
 
-**Criterio de éxito etapa 04**: <10% del corpus original en cuarentena para corpus anglo-dominante; **<25% para corpus LATAM-heavy** hasta que el scope v1.1 agregue fuentes específicas (REDIB / SciELO / La Referencia / RedALyC). Etapa 06 Validation reporta el % real y permite al usuario decidir si (a) el corpus justifica priorizar la issue de fuentes LATAM o (b) el % está dentro de lo aceptable para este investigador.
+**Criterio de éxito etapa 04**: <10% del corpus original en cuarentena para corpus anglo-dominante; **<15-20% para corpus LATAM-heavy** post-ADR-018 (las substages 04bs SciELO + 04bd DOAJ cubren la fracción más grande de la brecha LATAM). El target previo de <25% queda como cota superior tolerada hasta que data empírica del corpus real muestre el número definitivo. Etapa 06 Validation reporta el % real y permite al usuario decidir si (a) el corpus justifica reabrir issue #46 para evaluar harvest de REDIB / RedALyC / La Referencia (fuentes que sólo exponen OAI-PMH y requieren índice local) o (b) el % está dentro de lo aceptable para este investigador.
 
 **CLI**:
 ```bash
-zotai s1 enrich [--substage {04a,04b,04c,04d,04e}] [--max-cost N]
+zotai s1 enrich [--substage {04a,04b,04bs,04bd,04c,04d,04e}] [--max-cost N]
 ```
 
 ---


### PR DESCRIPTION
## Summary

This is the **docs PR** for issue #46 (partial). It establishes ADR 018 as the canonical spec before any code lands. A code PR follows once GH issues are filed citing this ADR.

ADR 018 adds two new free substages to S1 Stage 04's cascade, between `04b` and `04c`:

- **`04bs`** — SciELO Solr search at `search.scielo.org`, single-step.
- **`04bd`** — DOAJ Elasticsearch query at `doaj.org/api/v3/search/articles/`, single-step.

Both default ON via `S1_ENABLE_SCIELO` and `S1_ENABLE_DOAJ`. The cascade becomes:

```
04a → 04b (OpenAlex) → 04bs (SciELO) → 04bd (DOAJ) → 04c (Semantic Scholar) → 04d (LLM) → 04e (Quarantine)
```

Order rationale: 04bs first for **specificity** on LATAM-Spanish; 04bd second for **horizontal recall** across global open-access. Both before 04c (rate-limit-cheaper) and 04d (gratis vs paid).

## What is NOT included

ADR 018 documents which other candidates from issue #46 and from the user's evaluation request are **not viable** as cascade sources, with explicit reasons:

| Source | Verdict | Reason |
|---|---|---|
| **REDIB / RedALyC / La Referencia** | ❌ Defer | Only OAI-PMH (harvest, no fuzzy lookup). Tracked in #46 pending real-corpus signal. |
| **ERIH PLUS** | ❌ Reject as cascade | Index of journals, not articles. Future possible quality gate post-04d. |
| **Scopus** | ❌ Reject as default | Requires Elsevier institutional token; not portable in scenario α. Future opt-in via \`SCOPUS_API_KEY\`. |

Issue #46 stays open; this PR + the upcoming code PR partially close it.

## Spec-compliance contract for the code PR

The upcoming code PR must respect these literal names and defaults (verifiable in tests):

| Concept | Canonical name |
|---|---|
| Substage names | \`04bs\`, \`04bd\` |
| Status labels | \`enriched_04bs\`, \`enriched_04bd\` |
| Settings fields | \`BehaviorSettings.s1_enable_scielo\`, \`BehaviorSettings.s1_enable_doaj\` |
| Env vars | \`S1_ENABLE_SCIELO\`, \`S1_ENABLE_DOAJ\` |
| Defaults | both \`True\` |
| CLI substage values | \`04a, 04b, 04bs, 04bd, 04c, 04d, 04e, all\` |
| Cascade order | \`04a → 04b → 04bs → 04bd → 04c → 04d → 04e\` |
| Counter fields | \`EnrichResult.items_enriched_04bs\`, \`EnrichResult.items_enriched_04bd\` |

## Files changed

- **NEW** \`docs/decisions/018-scielo-and-doaj-substages.md\` — full ADR with context, decision, consequences (positive/negative/neutral), 8 alternatives considered, references, and the spec-compliance contract above.
- \`docs/plan_01_subsystem1.md\` §3 Etapa 04 — two new substage blocks (04bs, 04bd), updated cascade summary, LATAM-heavy aviso, success criterion (15-20% target post-ADR-018), CLI block, plus upstream cascade references in §3 Etapa 03.
- \`docs/economics.md\` — cascade table row, free-cascade section with all five substages itemised, Stage 04d post-ADR-018 estimation (LATAM 25-30% drops from prior 40%), optimization tip.

ADR 008 (quarantine) intentionally untouched — it's a historical document and its parenthetical \`04a-d\` range still describes the cascade correctly.

## Next steps after merge

1. Open Issue-S: \"Phase 5a: S1 Stage 04 — substage 04bs (SciELO) per ADR 018\".
2. Open Issue-D: \"Phase 5b: S1 Stage 04 — substage 04bd (DOAJ) per ADR 018\".
3. Open the code PR on a \`feat/s1-stage-04-scielo-doaj-substages\` branch, closing both issues with a \"Spec compliance\" section that maps each ADR decision to its \`file:line\`.

## Test plan

- [ ] ADR 018 reads coherently end-to-end (context, decision, consequences, alternatives).
- [ ] No internal contradictions between ADR 018, plan_01 §3 Etapa 04, and economics.md.
- [ ] Stale-reference sweep: no remaining \`04a-c\` / \`04a-d\` mentions in operational docs that exclude 04bs/04bd (only ADR 008 historical, intentionally left).
- [ ] Cross-references work: ADR 018 ↔ plan_01 §3 Etapa 04, ADR 018 ↔ economics.md, ADR 014 mentioned in 04bs/04bd dedup behaviour.
- [ ] Spec-compliance contract section in ADR 018 lists every literal name the code PR will need to use.