### PR TITLE
feat(s1): Stage 04 substages 04bs (SciELO) + 04bd (DOAJ)

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -57,6 +57,16 @@ LOG_LEVEL=INFO
 # Required for OpenAlex User-Agent (unlocks 10x rate limit)
 USER_EMAIL=
 
+# ────────────── S1 Stage 04 LATAM substages (ADR 018 + ADR 019) ──────────────
+# 04bs (SciELO via Crossref Member 530): improves top-5 ranking for
+# LATAM-Spanish queries that OpenAlex (04b) ranks deep. Default ON.
+# Set false on anglo-only corpora.
+S1_ENABLE_SCIELO=true
+# 04bd (DOAJ): captures the open-access fraction of the cascade
+# fallthrough that 04b and 04bs miss. Public, no API key, 2 req/s.
+# Default ON.
+S1_ENABLE_DOAJ=true
+
 # ────────────── S2 Worker ──────────────
 S2_FETCH_INTERVAL_HOURS=6
 S2_CANDIDATES_DB=/workspace/candidates.db

--- a/src/zotai/api/doaj.py
+++ b/src/zotai/api/doaj.py
@@ -1,0 +1,188 @@
+"""DOAJ adapter — substage 04bd in the Stage 04 cascade (ADR 018).
+
+Hits ``doaj.org/api/v3/search/articles/<query>`` with an Elasticsearch
+query string. DOAJ's read-only article search is public (no API key)
+with a 2 req/s rate limit + bursts up to 5 — comfortable for the
+cascade's per-item rhythm. Per ADR 018, DOAJ rejects the Lucene fuzzy
+operator ``~``; we use a quoted ``bibjson.title:"<title>"`` query which
+DOAJ accepts and which still feeds ``rapidfuzz.fuzz.token_set_ratio``
+on the cascade side.
+"""
+
+from __future__ import annotations
+
+from typing import Any, Final, cast
+from urllib.parse import quote
+
+from zotai.utils.http import make_async_client, make_user_agent, with_retry
+from zotai.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+DOAJ_API_BASE: Final[str] = "https://doaj.org/api/v3"
+
+
+class DOAJClient:
+    """HTTP client for the DOAJ substage (04bd)."""
+
+    def __init__(self, user_email: str | None = None) -> None:
+        self._user_agent = make_user_agent(mailto=user_email)
+
+    async def search_articles(
+        self, title: str, *, per_page: int = 5
+    ) -> list[dict[str, Any]]:
+        """Search DOAJ for articles by free-text title.
+
+        Returns ``payload["results"]`` (DOAJ's per-record array).
+        Defensive about response shape: returns ``[]`` (and logs
+        ``doaj.unexpected_shape``) when the JSON does not match
+        DOAJ's documented structure.
+        """
+
+        async def _do() -> list[dict[str, Any]]:
+            query = f'bibjson.title:"{title}"'
+            url = f"{DOAJ_API_BASE}/search/articles/{quote(query, safe='')}"
+            params: dict[str, str | int] = {"pageSize": per_page, "page": 1}
+            async with make_async_client(user_agent=self._user_agent) as client:
+                resp = await client.get(url, params=params)
+                resp.raise_for_status()
+                payload = cast(dict[str, Any], resp.json())
+            results = payload.get("results")
+            if not isinstance(results, list):
+                log.warning(
+                    "doaj.unexpected_shape",
+                    reason="missing_results",
+                    top_keys=list(payload.keys())[:8],
+                )
+                return []
+            return cast(list[dict[str, Any]], results)
+
+        return await with_retry(_do)
+
+
+def map_doaj_to_zotero(record: dict[str, Any]) -> dict[str, Any] | None:
+    """Map a DOAJ article record to a Zotero payload.
+
+    Returns ``None`` when the quality gate fails — missing
+    ``bibjson.title`` or no parseable authors. Item type is hardcoded
+    to ``journalArticle``; DOAJ indexes only journal articles by
+    construction.
+    """
+    bib = record.get("bibjson")
+    if not isinstance(bib, dict):
+        return None
+
+    raw_title = bib.get("title")
+    if not isinstance(raw_title, str) or not raw_title.strip():
+        return None
+    title = raw_title.strip()
+
+    creators: list[dict[str, str]] = []
+    raw_authors = bib.get("author")
+    if isinstance(raw_authors, list):
+        for entry in raw_authors:
+            if not isinstance(entry, dict):
+                continue
+            name = (entry.get("name") or "").strip()
+            if not name:
+                continue
+            first, last = _split_doaj_name(name)
+            creators.append(
+                {"creatorType": "author", "firstName": first, "lastName": last}
+            )
+    if not creators:
+        return None
+
+    date_str = _date_from_doaj(bib.get("year"), bib.get("month"))
+
+    venue = ""
+    journal = bib.get("journal")
+    if isinstance(journal, dict):
+        venue_raw = journal.get("title")
+        if isinstance(venue_raw, str):
+            venue = venue_raw.strip()
+
+    abstract_raw = bib.get("abstract")
+    abstract = abstract_raw.strip() if isinstance(abstract_raw, str) else ""
+
+    doi = _doi_from_doaj_record(record) or ""
+
+    payload: dict[str, Any] = {
+        "itemType": "journalArticle",
+        "title": title,
+        "creators": creators,
+        "date": date_str,
+        "abstractNote": abstract,
+    }
+    if doi:
+        payload["DOI"] = doi
+    if venue:
+        payload["publicationTitle"] = venue
+    return payload
+
+
+def _doi_from_doaj_record(record: dict[str, Any]) -> str | None:
+    """Return the first DOI from DOAJ's ``bibjson.identifier`` list, or None."""
+    bib = record.get("bibjson")
+    if not isinstance(bib, dict):
+        return None
+    identifiers = bib.get("identifier")
+    if not isinstance(identifiers, list):
+        return None
+    for entry in identifiers:
+        if not isinstance(entry, dict):
+            continue
+        if (entry.get("type") or "").lower() == "doi":
+            raw = entry.get("id")
+            if isinstance(raw, str) and raw.strip():
+                return raw.strip()
+    return None
+
+
+def _split_doaj_name(name: str) -> tuple[str, str]:
+    """Split a DOAJ author ``name`` into ``(firstName, lastName)``.
+
+    DOAJ stores authors as a single ``name`` string, typically either
+    "Last, First" or "First Last". Mirrors the convention used by
+    :func:`zotai.s1.stage_03_import._split_name` so all substages keep
+    author shapes consistent. (Not imported from there to keep the
+    ``api/`` package free of ``s1/`` dependencies.)
+    """
+    name = name.strip()
+    if "," in name:
+        last, _, first = name.partition(",")
+        return first.strip(), last.strip()
+    parts = name.split()
+    if len(parts) == 1:
+        return "", parts[0]
+    return " ".join(parts[:-1]), parts[-1]
+
+
+def _date_from_doaj(year_raw: Any, month_raw: Any) -> str:
+    """Build a Zotero ``date`` from DOAJ's optional year + month fields."""
+    year_str = ""
+    if isinstance(year_raw, str) and year_raw.strip().isdigit():
+        year_str = year_raw.strip()
+    elif isinstance(year_raw, int):
+        year_str = f"{year_raw:04d}"
+    if not year_str:
+        return ""
+
+    month: int | None = None
+    if isinstance(month_raw, str) and month_raw.strip().isdigit():
+        m = int(month_raw.strip())
+        if 1 <= m <= 12:
+            month = m
+    elif isinstance(month_raw, int) and 1 <= month_raw <= 12:
+        month = month_raw
+
+    if month is not None:
+        return f"{year_str}-{month:02d}"
+    return year_str
+
+
+__all__ = [
+    "DOAJ_API_BASE",
+    "DOAJClient",
+    "map_doaj_to_zotero",
+]

--- a/src/zotai/api/scielo.py
+++ b/src/zotai/api/scielo.py
@@ -1,0 +1,221 @@
+"""SciELO substage adapter — implemented via Crossref Member 530 (ADR 019).
+
+Per ADR 019, ``search.scielo.org``'s Solr endpoint is closed to anonymous
+clients (403 Forbidden) and ArticleMeta only supports lookup by SciELO
+PID. The substage's contract (fuzzy-title-search → DOI-grade metadata)
+is satisfied via Crossref's REST API filtered to ``member:530``
+(Crossref's identifier for SciELO). The filter narrows the search space
+to SciELO-only records, which improves top-5 ranking for LATAM-Spanish
+queries even though every paper returned is also in OpenAlex's
+underlying corpus.
+
+The class :class:`SciELoClient` and the file ``src/zotai/api/scielo.py``
+are preserved as the substage's HTTP abstraction — the substage's
+identity (``04bs``, ``enriched_04bs``, ``S1_ENABLE_SCIELO``) is
+spec-compliance with ADR 018; ADR 019 documents why the implementation
+hits Crossref.
+"""
+
+from __future__ import annotations
+
+import html
+import re
+from typing import Any, Final, cast
+
+from zotai.utils.http import make_async_client, make_user_agent, with_retry
+from zotai.utils.logging import get_logger
+
+log = get_logger(__name__)
+
+CROSSREF_BASE: Final[str] = "https://api.crossref.org"
+SCIELO_CROSSREF_MEMBER: Final[str] = "530"
+_DEFAULT_SELECT: Final[str] = (
+    "DOI,title,author,published,container-title,abstract,type"
+)
+_JATS_TAG_RE: Final[re.Pattern[str]] = re.compile(r"<[^>]+>")
+
+
+class SciELoClient:
+    """HTTP client for the SciELO substage (04bs).
+
+    Implementation hits Crossref's REST API filtered to ``member:530``.
+    Per ADR 019, the substage uses Crossref-as-mirror rather than
+    ``search.scielo.org`` because the latter is gated. The filter
+    narrows the candidate list so the cascade's fuzzy-title match
+    surfaces SciELO papers in top-5 even for LATAM-Spanish queries.
+    """
+
+    def __init__(self, user_email: str | None = None) -> None:
+        self._user_agent = make_user_agent(mailto=user_email)
+
+    async def search_articles(
+        self, title: str, *, per_page: int = 5
+    ) -> list[dict[str, Any]]:
+        """Search Crossref (member:530) for SciELO papers by free-text title.
+
+        Returns ``payload["message"]["items"]``, possibly empty.
+        Defensive about response shape: returns ``[]`` (and logs
+        ``scielo.unexpected_shape``) when the JSON does not match
+        Crossref's documented structure.
+        """
+
+        async def _do() -> list[dict[str, Any]]:
+            params: dict[str, str | int] = {
+                "query.title": title,
+                "filter": f"member:{SCIELO_CROSSREF_MEMBER}",
+                "rows": per_page,
+                "select": _DEFAULT_SELECT,
+            }
+            async with make_async_client(user_agent=self._user_agent) as client:
+                resp = await client.get(f"{CROSSREF_BASE}/works", params=params)
+                resp.raise_for_status()
+                payload = cast(dict[str, Any], resp.json())
+            message = payload.get("message")
+            if not isinstance(message, dict):
+                log.warning(
+                    "scielo.unexpected_shape",
+                    reason="missing_message",
+                    top_keys=list(payload.keys())[:8],
+                )
+                return []
+            items = message.get("items")
+            if not isinstance(items, list):
+                log.warning(
+                    "scielo.unexpected_shape",
+                    reason="missing_items",
+                    message_keys=list(message.keys())[:8],
+                )
+                return []
+            return cast(list[dict[str, Any]], items)
+
+        return await with_retry(_do)
+
+
+def map_scielo_to_zotero(record: dict[str, Any]) -> dict[str, Any] | None:
+    """Map a Crossref ``works`` record (member:530) to a Zotero payload.
+
+    Returns ``None`` when the quality gate fails — missing title or no
+    parseable authors. Item type is hardcoded to ``journalArticle``;
+    Crossref's ``type`` for SciELO records is uniformly
+    ``'journal-article'``. Schema mirrors
+    :func:`zotai.s1.stage_04_enrich.map_semantic_scholar_to_zotero` so
+    every cascade substage feeds the same Zotero ``create_items``
+    endpoint.
+    """
+    title_list = record.get("title")
+    if not isinstance(title_list, list) or not title_list:
+        return None
+    raw_title = title_list[0]
+    if not isinstance(raw_title, str) or not raw_title.strip():
+        return None
+    title = html.unescape(raw_title.strip())
+
+    creators: list[dict[str, str]] = []
+    raw_authors = record.get("author")
+    if isinstance(raw_authors, list):
+        for entry in raw_authors:
+            if not isinstance(entry, dict):
+                continue
+            given = (entry.get("given") or "").strip()
+            family = (entry.get("family") or "").strip()
+            if given or family:
+                creators.append(
+                    {
+                        "creatorType": "author",
+                        "firstName": given,
+                        "lastName": family,
+                    }
+                )
+                continue
+            # Crossref also exposes ``name`` on corporate authors.
+            name = (entry.get("name") or "").strip()
+            if name:
+                creators.append(
+                    {"creatorType": "author", "firstName": "", "lastName": name}
+                )
+    if not creators:
+        return None
+
+    date_str = _date_from_crossref_published(record.get("published"))
+
+    venue = ""
+    container_list = record.get("container-title")
+    if isinstance(container_list, list) and container_list:
+        first = container_list[0]
+        if isinstance(first, str) and first.strip():
+            venue = html.unescape(first.strip())
+
+    abstract = _abstract_from_crossref(record.get("abstract"))
+
+    doi_raw = record.get("DOI")
+    doi = doi_raw.strip() if isinstance(doi_raw, str) else ""
+
+    payload: dict[str, Any] = {
+        "itemType": "journalArticle",
+        "title": title,
+        "creators": creators,
+        "date": date_str,
+        "abstractNote": abstract,
+    }
+    if doi:
+        payload["DOI"] = doi
+    if venue:
+        payload["publicationTitle"] = venue
+    return payload
+
+
+def _doi_from_scielo_record(record: dict[str, Any]) -> str | None:
+    """Return the normalised DOI from a Crossref record, or None."""
+    raw = record.get("DOI")
+    if isinstance(raw, str):
+        cleaned = raw.strip()
+        if cleaned:
+            return cleaned
+    return None
+
+
+def _date_from_crossref_published(published: Any) -> str:
+    """Build a Zotero ``date`` string from Crossref's ``published.date-parts``.
+
+    Crossref returns ``{"date-parts": [[year, month?, day?]]}``. Returns
+    "YYYY", "YYYY-MM", or "YYYY-MM-DD" when the inner triple is well
+    formed; "" otherwise.
+    """
+    if not isinstance(published, dict):
+        return ""
+    parts = published.get("date-parts")
+    if not isinstance(parts, list) or not parts:
+        return ""
+    inner = parts[0]
+    if not isinstance(inner, list) or not inner:
+        return ""
+    year = inner[0] if isinstance(inner[0], int) else None
+    if year is None:
+        return ""
+    out = f"{year:04d}"
+    if len(inner) >= 2 and isinstance(inner[1], int):
+        out += f"-{inner[1]:02d}"
+        if len(inner) >= 3 and isinstance(inner[2], int):
+            out += f"-{inner[2]:02d}"
+    return out
+
+
+def _abstract_from_crossref(raw: Any) -> str:
+    """Strip JATS XML tags from a Crossref abstract; return "" if missing.
+
+    Crossref returns abstracts wrapped in JATS markup (``<jats:p>``,
+    ``<jats:italic>``, ``<jats:title>``, etc.). We strip every angle-bracket
+    tag and collapse the resulting whitespace.
+    """
+    if not isinstance(raw, str):
+        return ""
+    stripped = _JATS_TAG_RE.sub(" ", raw)
+    return " ".join(stripped.split())
+
+
+__all__ = [
+    "CROSSREF_BASE",
+    "SCIELO_CROSSREF_MEMBER",
+    "SciELoClient",
+    "map_scielo_to_zotero",
+]

--- a/src/zotai/cli.py
+++ b/src/zotai/cli.py
@@ -268,11 +268,14 @@ def s1_enrich(
             "--substage",
             help=(
                 "Which enrichment substage to run. '04a' (identifier "
-                "extraction), '04b' (OpenAlex fuzzy), '04c' (Semantic "
-                "Scholar fuzzy), '04d' (gpt-4o-mini extraction — costs "
-                "money, bounded by MAX_COST_USD_STAGE_04), '04e' "
-                "(Quarantine), or 'all' for the full per-item cascade "
-                "04a → 04b → 04c → 04d → 04e. See plan_01 §3 Etapa 04."
+                "extraction), '04b' (OpenAlex fuzzy), '04bs' (SciELO "
+                "via Crossref Member 530, ADR 018 + ADR 019), '04bd' "
+                "(DOAJ fuzzy, ADR 018), '04c' (Semantic Scholar fuzzy), "
+                "'04d' (gpt-4o-mini extraction — costs money, bounded "
+                "by MAX_COST_USD_STAGE_04), '04e' (Quarantine), or "
+                "'all' for the full per-item cascade "
+                "04a → 04b → 04bs → 04bd → 04c → 04d → 04e. "
+                "See plan_01 §3 Etapa 04."
             ),
         ),
     ] = "04a",
@@ -298,10 +301,10 @@ def s1_enrich(
     settings = Settings()
     dry_run = bool(ctx.obj.get("dry_run", False)) or settings.behavior.dry_run
 
-    if substage not in ("04a", "04b", "04c", "04d", "04e", "all"):
+    if substage not in ("04a", "04b", "04bs", "04bd", "04c", "04d", "04e", "all"):
         typer.secho(
             f"Substage '{substage}' is not valid. Choose one of: "
-            "'04a' | '04b' | '04c' | '04d' | '04e' | 'all'.",
+            "'04a' | '04b' | '04bs' | '04bd' | '04c' | '04d' | '04e' | 'all'.",
             err=True,
             fg=typer.colors.YELLOW,
         )
@@ -327,6 +330,8 @@ def s1_enrich(
         f"processed={result.items_processed} failed={result.items_failed} "
         f"enriched_04a={result.items_enriched_04a} "
         f"enriched_04b={result.items_enriched_04b} "
+        f"enriched_04bs={result.items_enriched_04bs} "
+        f"enriched_04bd={result.items_enriched_04bd} "
         f"enriched_04c={result.items_enriched_04c} "
         f"enriched_04d={result.items_enriched_04d} "
         f"quarantined={result.items_quarantined} "

--- a/src/zotai/config.py
+++ b/src/zotai/config.py
@@ -167,6 +167,11 @@ class BehaviorSettings(_GroupBase):
     dry_run: bool = False
     log_level: str = "INFO"
     user_email: str = ""
+    # Stage 04 cascade — LATAM coverage substages (ADR 018 + ADR 019).
+    # Default ON: the project's primary user is CONICET (LATAM-heavy
+    # corpus). Anglo-only corpora can opt out via env.
+    s1_enable_scielo: bool = True
+    s1_enable_doaj: bool = True
 
 
 class S2Settings(_GroupBase):

--- a/src/zotai/s1/run_all.py
+++ b/src/zotai/s1/run_all.py
@@ -197,6 +197,7 @@ def run_all(
                 summary=(
                     f"processed={enr.items_processed} failed={enr.items_failed} "
                     f"04a={enr.items_enriched_04a} 04b={enr.items_enriched_04b} "
+                    f"04bs={enr.items_enriched_04bs} 04bd={enr.items_enriched_04bd} "
                     f"04c={enr.items_enriched_04c} 04d={enr.items_enriched_04d} "
                     f"quarantined={enr.items_quarantined}"
                 ),

--- a/src/zotai/s1/stage_04_enrich.py
+++ b/src/zotai/s1/stage_04_enrich.py
@@ -55,13 +55,20 @@ from datetime import UTC, datetime
 from pathlib import Path
 from typing import Any, Final, Literal
 
+import httpx
 from pydantic import BaseModel, Field, ValidationError
 from rapidfuzz import fuzz
 from sqlalchemy.engine import Engine
 from sqlmodel import Session, select
 
+from zotai.api.doaj import DOAJClient, _doi_from_doaj_record, map_doaj_to_zotero
 from zotai.api.openai_client import BudgetExceededError, OpenAIClient
 from zotai.api.openalex import OpenAlexClient
+from zotai.api.scielo import (
+    SciELoClient,
+    _doi_from_scielo_record,
+    map_scielo_to_zotero,
+)
 from zotai.api.semantic_scholar import SemanticScholarClient
 from zotai.api.zotero import ZoteroClient
 from zotai.config import Settings
@@ -135,10 +142,14 @@ _CSV_COLUMNS: Final[tuple[str, ...]] = (
     "error",
 )
 
-EnrichSubstage = Literal["04a", "04b", "04c", "04d", "04e", "all"]
+EnrichSubstage = Literal[
+    "04a", "04b", "04bs", "04bd", "04c", "04d", "04e", "all"
+]
 EnrichStatus = Literal[
     "enriched_04a",
     "enriched_04b",
+    "enriched_04bs",
+    "enriched_04bd",
     "enriched_04c",
     "enriched_04d",
     "quarantined_04e",
@@ -150,8 +161,19 @@ EnrichStatus = Literal[
     "dry_run",
 ]
 _ENRICHED_STATUSES: Final[frozenset[str]] = frozenset(
-    {"enriched_04a", "enriched_04b", "enriched_04c", "enriched_04d"}
+    {
+        "enriched_04a",
+        "enriched_04b",
+        "enriched_04bs",
+        "enriched_04bd",
+        "enriched_04c",
+        "enriched_04d",
+    }
 )
+# 04bs / 04bd resilience policy (ADR 018 + ADR 019): transient or
+# upstream-side HTTP errors fall through to the next substage as
+# ``no_progress`` rather than failing the item outright.
+_LATAM_TRANSIENT_STATUSES: Final[frozenset[int]] = frozenset({403, 429, 502, 503})
 
 
 # ─── Identifier regexes (shared patterns reused from Stage 01 classifier) ──
@@ -204,6 +226,8 @@ class EnrichResult:
     items_failed: int
     items_enriched_04a: int
     items_enriched_04b: int
+    items_enriched_04bs: int
+    items_enriched_04bd: int
     items_enriched_04c: int
     items_enriched_04d: int
     items_quarantined: int
@@ -766,6 +790,435 @@ async def _enrich_04b_one(
             zotero_item_key_before=item.zotero_item_key,
             zotero_item_key_after=parent_key,
             substage_resolved="04b",
+            new_doi=doi,
+            status=status,
+            error=None,
+        ),
+        payload,
+    )
+
+
+# ─── 04bs (SciELO via Crossref Member 530, ADR 018 + ADR 019) ────────────
+
+
+def _picked_via_crossref_title(
+    title: str, candidates: list[dict[str, Any]]
+) -> tuple[dict[str, Any], float] | None:
+    """Apply the cascade's fuzzy threshold against Crossref's list-shaped title.
+
+    Crossref returns ``record["title"]`` as a list of strings (typically
+    one element). :func:`_pick_best_fuzzy_match` skips non-string titles,
+    so we project to a flat ``{"title": str, "_record": dict}`` shape
+    first.
+    """
+    flat: list[dict[str, Any]] = []
+    for cand in candidates:
+        if not isinstance(cand, dict):
+            continue
+        title_list = cand.get("title")
+        if not isinstance(title_list, list) or not title_list:
+            continue
+        flat_title = title_list[0]
+        if not isinstance(flat_title, str) or not flat_title.strip():
+            continue
+        flat.append({"title": flat_title, "_record": cand})
+    picked = _pick_best_fuzzy_match(title, flat, title_key="title")
+    if picked is None:
+        return None
+    best_flat, score = picked
+    return best_flat["_record"], score
+
+
+async def _enrich_04bs_one(
+    item: Item,
+    *,
+    staging_folder: Path,
+    zotero_client: ZoteroClient,
+    scielo_client: SciELoClient,
+    dry_run: bool,
+) -> tuple[EnrichRow, dict[str, Any] | None]:
+    """04bs for a single item: title → SciELO (Crossref member:530) → fuzzy → reparent.
+
+    On transient HTTP failure (403/429/502/503 — see ADR 018 §Resilience
+    policy) the substage returns ``no_progress`` so the cascade flows to
+    04bd; only genuine bugs land as ``failed``.
+    """
+    pdf_path = _pdf_for_text(item, staging_folder)
+    if not pdf_path.exists():
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"pdf_missing:{pdf_path}",
+            ),
+            None,
+        )
+
+    try:
+        title = extract_probable_title(pdf_path)
+    except Exception as exc:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"pdf_extract:{type(exc).__name__}:{exc}",
+            ),
+            None,
+        )
+
+    if title is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="skipped_generic_title",
+                error=None,
+            ),
+            None,
+        )
+
+    try:
+        candidates = await scielo_client.search_articles(title)
+    except httpx.HTTPStatusError as exc:
+        status_code = exc.response.status_code
+        if status_code in _LATAM_TRANSIENT_STATUSES:
+            log.warning(
+                "stage_04bs.scielo_unavailable", title=title, status=status_code
+            )
+            return (
+                EnrichRow(
+                    sha256=item.id,
+                    source_path=item.source_path,
+                    zotero_item_key_before=item.zotero_item_key,
+                    zotero_item_key_after=None,
+                    substage_resolved=None,
+                    new_doi=None,
+                    status="no_progress",
+                    error=f"scielo_unavailable:{status_code}",
+                ),
+                None,
+            )
+        log.warning("stage_04bs.scielo_error", title=title, error=str(exc))
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"scielo_error:{type(exc).__name__}:{exc}",
+            ),
+            None,
+        )
+    except Exception as exc:
+        log.warning("stage_04bs.scielo_error", title=title, error=str(exc))
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"scielo_error:{type(exc).__name__}:{exc}",
+            ),
+            None,
+        )
+
+    picked = _picked_via_crossref_title(title, candidates)
+    if picked is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="no_progress",
+                error=None,
+            ),
+            None,
+        )
+    best, _score = picked
+
+    payload = map_scielo_to_zotero(best)
+    if payload is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="no_progress",
+                error="quality_gate_failed",
+            ),
+            None,
+        )
+
+    doi = _doi_from_scielo_record(best)
+    parent_key, error = await _create_parent_and_reparent(
+        item,
+        payload,
+        doi=doi,
+        zotero_client=zotero_client,
+        dry_run=dry_run,
+    )
+    if error is not None or parent_key is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=doi,
+                status="failed",
+                error=error,
+            ),
+            None,
+        )
+
+    status: EnrichStatus = "dry_run" if dry_run else "enriched_04bs"
+    return (
+        EnrichRow(
+            sha256=item.id,
+            source_path=item.source_path,
+            zotero_item_key_before=item.zotero_item_key,
+            zotero_item_key_after=parent_key,
+            substage_resolved="04bs",
+            new_doi=doi,
+            status=status,
+            error=None,
+        ),
+        payload,
+    )
+
+
+# ─── 04bd (DOAJ, ADR 018) ─────────────────────────────────────────────────
+
+
+def _picked_via_bibjson_title(
+    title: str, candidates: list[dict[str, Any]]
+) -> tuple[dict[str, Any], float] | None:
+    """Apply the cascade's fuzzy threshold against DOAJ's nested title field.
+
+    DOAJ records carry the title at ``record["bibjson"]["title"]`` rather
+    than ``record["title"]`` — :func:`_pick_best_fuzzy_match` doesn't
+    follow nested keys, so we project to a flat shape first.
+    """
+    flat: list[dict[str, Any]] = []
+    for cand in candidates:
+        bib = cand.get("bibjson") if isinstance(cand, dict) else None
+        if not isinstance(bib, dict):
+            continue
+        flat_title = bib.get("title")
+        if not isinstance(flat_title, str) or not flat_title.strip():
+            continue
+        flat.append({"title": flat_title, "_record": cand})
+    picked = _pick_best_fuzzy_match(title, flat, title_key="title")
+    if picked is None:
+        return None
+    best_flat, score = picked
+    return best_flat["_record"], score
+
+
+async def _enrich_04bd_one(
+    item: Item,
+    *,
+    staging_folder: Path,
+    zotero_client: ZoteroClient,
+    doaj_client: DOAJClient,
+    dry_run: bool,
+) -> tuple[EnrichRow, dict[str, Any] | None]:
+    """04bd for a single item: title → DOAJ search → fuzzy match → reparent.
+
+    Same resilience policy as 04bs: HTTP 403/429/502/503 →
+    ``no_progress`` (cascade falls through to 04c); other exceptions
+    → ``failed``.
+    """
+    pdf_path = _pdf_for_text(item, staging_folder)
+    if not pdf_path.exists():
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"pdf_missing:{pdf_path}",
+            ),
+            None,
+        )
+
+    try:
+        title = extract_probable_title(pdf_path)
+    except Exception as exc:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"pdf_extract:{type(exc).__name__}:{exc}",
+            ),
+            None,
+        )
+
+    if title is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="skipped_generic_title",
+                error=None,
+            ),
+            None,
+        )
+
+    try:
+        candidates = await doaj_client.search_articles(title)
+    except httpx.HTTPStatusError as exc:
+        status_code = exc.response.status_code
+        if status_code in _LATAM_TRANSIENT_STATUSES:
+            log.warning(
+                "stage_04bd.doaj_unavailable", title=title, status=status_code
+            )
+            return (
+                EnrichRow(
+                    sha256=item.id,
+                    source_path=item.source_path,
+                    zotero_item_key_before=item.zotero_item_key,
+                    zotero_item_key_after=None,
+                    substage_resolved=None,
+                    new_doi=None,
+                    status="no_progress",
+                    error=f"doaj_unavailable:{status_code}",
+                ),
+                None,
+            )
+        log.warning("stage_04bd.doaj_error", title=title, error=str(exc))
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"doaj_error:{type(exc).__name__}:{exc}",
+            ),
+            None,
+        )
+    except Exception as exc:
+        log.warning("stage_04bd.doaj_error", title=title, error=str(exc))
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="failed",
+                error=f"doaj_error:{type(exc).__name__}:{exc}",
+            ),
+            None,
+        )
+
+    picked = _picked_via_bibjson_title(title, candidates)
+    if picked is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="no_progress",
+                error=None,
+            ),
+            None,
+        )
+    best, _score = picked
+
+    payload = map_doaj_to_zotero(best)
+    if payload is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=None,
+                status="no_progress",
+                error="quality_gate_failed",
+            ),
+            None,
+        )
+
+    doi = _doi_from_doaj_record(best)
+    parent_key, error = await _create_parent_and_reparent(
+        item,
+        payload,
+        doi=doi,
+        zotero_client=zotero_client,
+        dry_run=dry_run,
+    )
+    if error is not None or parent_key is None:
+        return (
+            EnrichRow(
+                sha256=item.id,
+                source_path=item.source_path,
+                zotero_item_key_before=item.zotero_item_key,
+                zotero_item_key_after=None,
+                substage_resolved=None,
+                new_doi=doi,
+                status="failed",
+                error=error,
+            ),
+            None,
+        )
+
+    status: EnrichStatus = "dry_run" if dry_run else "enriched_04bd"
+    return (
+        EnrichRow(
+            sha256=item.id,
+            source_path=item.source_path,
+            zotero_item_key_before=item.zotero_item_key,
+            zotero_item_key_after=parent_key,
+            substage_resolved="04bd",
             new_doi=doi,
             status=status,
             error=None,
@@ -1380,6 +1833,8 @@ def run_enrich(
     engine: Engine | None = None,
     zotero_client: ZoteroClient | None = None,
     openalex_client: OpenAlexClient | None = None,
+    scielo_client: SciELoClient | None = None,
+    doaj_client: DOAJClient | None = None,
     semantic_scholar_client: SemanticScholarClient | None = None,
     openai_client: OpenAIClient | None = None,
     sleep: Callable[[float], Awaitable[None]] = asyncio.sleep,
@@ -1389,12 +1844,16 @@ def run_enrich(
 
     ``04a`` — identifier extraction + OpenAlex DOI retry.
     ``04b`` — title fuzzy match against OpenAlex.
+    ``04bs`` — title fuzzy match against SciELO via Crossref Member 530
+    (ADR 018 + ADR 019). Default ON; opt-out via ``S1_ENABLE_SCIELO=false``.
+    ``04bd`` — title fuzzy match against DOAJ (ADR 018). Default ON;
+    opt-out via ``S1_ENABLE_DOAJ=false``.
     ``04c`` — title fuzzy match against Semantic Scholar.
     ``04d`` — LLM (``gpt-4o-mini``) extraction with budget enforcement
     (``MAX_COST_USD_STAGE_04``, overridable via ``max_cost``).
     ``04e`` — Quarantine: tag ``needs-manual-review`` + move to the
     Quarantine collection + append to ``quarantine_report.csv``.
-    ``all`` — per-item cascade 04a → 04b → 04c → 04d → 04e.
+    ``all`` — per-item cascade 04a → 04b → 04bs → 04bd → 04c → 04d → 04e.
 
     Once 04d's budget is exhausted during an ``all`` or ``04d`` run, the
     remaining items route directly to 04e without retrying the LLM.
@@ -1408,6 +1867,8 @@ def run_enrich(
             engine=engine,
             zotero_client=zotero_client,
             openalex_client=openalex_client,
+            scielo_client=scielo_client,
+            doaj_client=doaj_client,
             semantic_scholar_client=semantic_scholar_client,
             openai_client=openai_client,
             sleep=sleep,
@@ -1425,6 +1886,8 @@ async def _run_enrich_async(
     engine: Engine | None,
     zotero_client: ZoteroClient | None,
     openalex_client: OpenAlexClient | None,
+    scielo_client: SciELoClient | None,
+    doaj_client: DOAJClient | None,
     semantic_scholar_client: SemanticScholarClient | None,
     openai_client: OpenAIClient | None,
     sleep: Callable[[float], Awaitable[None]],
@@ -1448,9 +1911,30 @@ async def _run_enrich_async(
     if openalex_client is None:
         email = settings.behavior.user_email or None
         openalex_client = OpenAlexClient(user_email=email)
+    # 04bs / 04bd are opt-out-able (ADR 018 + ADR 019). Build only when
+    # the corresponding flag is True; the cascade short-circuits a
+    # ``None`` client cleanly. Explicit substage selection of a disabled
+    # source is a config error and raises StageAbortedError below.
+    if scielo_client is None and settings.behavior.s1_enable_scielo:
+        scielo_email = settings.behavior.user_email or None
+        scielo_client = SciELoClient(user_email=scielo_email)
+    if doaj_client is None and settings.behavior.s1_enable_doaj:
+        doaj_email = settings.behavior.user_email or None
+        doaj_client = DOAJClient(user_email=doaj_email)
     if semantic_scholar_client is None:
         ss_key = settings.semantic_scholar.api_key.get_secret_value() or None
         semantic_scholar_client = SemanticScholarClient(api_key=ss_key)
+
+    if substage == "04bs" and scielo_client is None:
+        raise StageAbortedError(
+            "Substage 04bs requires S1_ENABLE_SCIELO=true. Set it in .env "
+            "or pass scielo_client explicitly."
+        )
+    if substage == "04bd" and doaj_client is None:
+        raise StageAbortedError(
+            "Substage 04bd requires S1_ENABLE_DOAJ=true. Set it in .env "
+            "or pass doaj_client explicitly."
+        )
 
     # 04d / "all" need the OpenAI client + a budget. Build lazily so the
     # free substages don't require ``OPENAI_API_KEY``.
@@ -1526,6 +2010,36 @@ async def _run_enrich_async(
             return row_b, None, row_b.error
         last_error = row_b.error or last_error
 
+        # 04bs (SciELO via Crossref Member 530 — ADR 018 + ADR 019)
+        if scielo_client is not None:
+            row_bs, mapped_bs = await _enrich_04bs_one(
+                item,
+                staging_folder=staging_folder,
+                zotero_client=zotero_client,
+                scielo_client=scielo_client,
+                dry_run=dry_run,
+            )
+            if row_bs.status in _ENRICHED_STATUSES or row_bs.status == "dry_run":
+                return row_bs, mapped_bs, None
+            if row_bs.status == "failed":
+                return row_bs, None, row_bs.error
+            last_error = row_bs.error or last_error
+
+        # 04bd (DOAJ — ADR 018)
+        if doaj_client is not None:
+            row_bd, mapped_bd = await _enrich_04bd_one(
+                item,
+                staging_folder=staging_folder,
+                zotero_client=zotero_client,
+                doaj_client=doaj_client,
+                dry_run=dry_run,
+            )
+            if row_bd.status in _ENRICHED_STATUSES or row_bd.status == "dry_run":
+                return row_bd, mapped_bd, None
+            if row_bd.status == "failed":
+                return row_bd, None, row_bd.error
+            last_error = row_bd.error or last_error
+
         # 04c
         row_c, mapped_c = await _enrich_04c_one(
             item,
@@ -1598,6 +2112,24 @@ async def _run_enrich_async(
                         staging_folder=staging_folder,
                         zotero_client=zotero_client,
                         openalex_client=openalex_client,
+                        dry_run=dry_run,
+                    )
+                elif substage == "04bs":
+                    assert scielo_client is not None  # gated by the StageAbortedError check
+                    row, mapped = await _enrich_04bs_one(
+                        item,
+                        staging_folder=staging_folder,
+                        zotero_client=zotero_client,
+                        scielo_client=scielo_client,
+                        dry_run=dry_run,
+                    )
+                elif substage == "04bd":
+                    assert doaj_client is not None  # gated by the StageAbortedError check
+                    row, mapped = await _enrich_04bd_one(
+                        item,
+                        staging_folder=staging_folder,
+                        zotero_client=zotero_client,
+                        doaj_client=doaj_client,
                         dry_run=dry_run,
                     )
                 elif substage == "04c":
@@ -1723,6 +2255,8 @@ async def _run_enrich_async(
         items_failed=items_failed,
         items_enriched_04a=sum(1 for r in rows if r.status == "enriched_04a"),
         items_enriched_04b=sum(1 for r in rows if r.status == "enriched_04b"),
+        items_enriched_04bs=sum(1 for r in rows if r.status == "enriched_04bs"),
+        items_enriched_04bd=sum(1 for r in rows if r.status == "enriched_04bd"),
         items_enriched_04c=sum(1 for r in rows if r.status == "enriched_04c"),
         items_enriched_04d=sum(1 for r in rows if r.status == "enriched_04d"),
         items_quarantined=sum(1 for r in rows if r.status == "quarantined_04e"),
@@ -1741,6 +2275,8 @@ async def _run_enrich_async(
         failed=result.items_failed,
         enriched_04a=result.items_enriched_04a,
         enriched_04b=result.items_enriched_04b,
+        enriched_04bs=result.items_enriched_04bs,
+        enriched_04bd=result.items_enriched_04bd,
         enriched_04c=result.items_enriched_04c,
         enriched_04d=result.items_enriched_04d,
         quarantined=result.items_quarantined,
@@ -1762,3 +2298,6 @@ __all__ = [
     "map_semantic_scholar_to_zotero",
     "run_enrich",
 ]
+# Note: ``map_scielo_to_zotero`` and ``map_doaj_to_zotero`` live with their
+# clients in ``zotai.api.scielo`` and ``zotai.api.doaj`` respectively (per
+# ADR 018 §"Implementation artefacts" §1 and ADR 019 §Decision §1).

--- a/tests/test_s1/test_run_all.py
+++ b/tests/test_s1/test_run_all.py
@@ -102,6 +102,8 @@ def _fake_enrich(**_: Any) -> EnrichResult:
         items_failed=0,
         items_enriched_04a=0,
         items_enriched_04b=1,
+        items_enriched_04bs=0,
+        items_enriched_04bd=0,
         items_enriched_04c=0,
         items_enriched_04d=0,
         items_quarantined=0,

--- a/tests/test_s1/test_stage_04.py
+++ b/tests/test_s1/test_stage_04.py
@@ -22,10 +22,13 @@ from collections.abc import Awaitable, Callable
 from pathlib import Path
 from typing import Any
 
+import httpx
 from sqlmodel import Session, select
 
+from zotai.api.doaj import map_doaj_to_zotero
 from zotai.api.openai_client import BudgetExceededError
-from zotai.config import PathSettings, Settings, ZoteroSettings
+from zotai.api.scielo import map_scielo_to_zotero
+from zotai.config import BehaviorSettings, PathSettings, Settings, ZoteroSettings
 from zotai.s1.stage_04_enrich import (
     LLMExtractedMetadata,
     map_llm_extraction_to_zotero,
@@ -225,6 +228,54 @@ class FakeSemanticScholarClient:
         return self._search_responses.get(query, [])
 
 
+class FakeSciELoClient:
+    """Fake :class:`zotai.api.scielo.SciELoClient` for the 04bs tests.
+
+    Returns scripted responses keyed by query title, or raises a queued
+    exception (used to simulate Cloudflare 403, rate-limit 429, etc.).
+    """
+
+    def __init__(
+        self,
+        search_responses: dict[str, list[dict[str, Any]]] | None = None,
+        *,
+        raise_on_search: Exception | None = None,
+    ) -> None:
+        self._search_responses = search_responses or {}
+        self._raise = raise_on_search
+        self.search_calls: list[tuple[str, int]] = []
+
+    async def search_articles(
+        self, title: str, *, per_page: int = 5
+    ) -> list[dict[str, Any]]:
+        self.search_calls.append((title, per_page))
+        if self._raise is not None:
+            raise self._raise
+        return self._search_responses.get(title, [])
+
+
+class FakeDOAJClient:
+    """Fake :class:`zotai.api.doaj.DOAJClient` for the 04bd tests."""
+
+    def __init__(
+        self,
+        search_responses: dict[str, list[dict[str, Any]]] | None = None,
+        *,
+        raise_on_search: Exception | None = None,
+    ) -> None:
+        self._search_responses = search_responses or {}
+        self._raise = raise_on_search
+        self.search_calls: list[tuple[str, int]] = []
+
+    async def search_articles(
+        self, title: str, *, per_page: int = 5
+    ) -> list[dict[str, Any]]:
+        self.search_calls.append((title, per_page))
+        if self._raise is not None:
+            raise self._raise
+        return self._search_responses.get(title, [])
+
+
 def _no_sleep() -> Callable[[float], Awaitable[None]]:
     async def _s(_: float) -> None:
         return None
@@ -235,7 +286,19 @@ def _no_sleep() -> Callable[[float], Awaitable[None]]:
 # ─── Fixtures / helpers ───────────────────────────────────────────────────
 
 
-def _settings(tmp_path: Path) -> Settings:
+def _settings(
+    tmp_path: Path,
+    *,
+    enable_scielo: bool = False,
+    enable_doaj: bool = False,
+) -> Settings:
+    """Test fixture for ``Settings``.
+
+    The 04bs / 04bd flags default to ``False`` here so existing tests that
+    pre-date ADR 018 don't try to construct real
+    :class:`SciELoClient` / :class:`DOAJClient` instances. New tests that
+    cover the substages set the flags explicitly.
+    """
     return Settings(
         paths=PathSettings(
             state_db=tmp_path / "state.db",
@@ -244,6 +307,10 @@ def _settings(tmp_path: Path) -> Settings:
             pdf_source_folders=[],
         ),
         zotero=ZoteroSettings(library_id="123", library_type="user", local_api=True),
+        behavior=BehaviorSettings(
+            s1_enable_scielo=enable_scielo,
+            s1_enable_doaj=enable_doaj,
+        ),
     )
 
 
@@ -1675,3 +1742,658 @@ def test_04d_without_api_key_raises_stage_aborted(tmp_path: Path) -> None:
         assert "OPENAI_API_KEY" in str(exc)
     else:  # pragma: no cover
         raise AssertionError("expected StageAbortedError")
+
+
+# ─────────────────────────────────────────────────────────────────────────
+# 04bs (SciELO via Crossref Member 530, ADR 018 + ADR 019) and
+# 04bd (DOAJ, ADR 018) tests.
+# ─────────────────────────────────────────────────────────────────────────
+
+
+def _good_crossref_record(
+    doi: str = "10.1590/test-scielo-doi",
+    title: str = "Informalidad laboral en Argentina",
+    *,
+    abstract: str | None = "<jats:p>Resumen <jats:italic>importante</jats:italic></jats:p>",
+    container: str = "Desarrollo Económico",
+    year: int = 2024,
+    month: int | None = 7,
+) -> dict[str, Any]:
+    """Build a Crossref ``works`` record matching what filter:member:530 returns."""
+    parts = [year]
+    if month is not None:
+        parts.append(month)
+    rec: dict[str, Any] = {
+        "DOI": doi,
+        "title": [title],
+        "container-title": [container],
+        "type": "journal-article",
+        "member": "530",
+        "publisher": "FapUNIFESP (SciELO)",
+        "published": {"date-parts": [parts]},
+        "author": [
+            {"given": "Jane", "family": "Doe", "ORCID": "https://orcid.org/0000-0000"},
+            {"given": "John", "family": "Smith"},
+        ],
+    }
+    if abstract is not None:
+        rec["abstract"] = abstract
+    return rec
+
+
+def _good_doaj_record(
+    doi: str = "10.5555/doaj-test-doi",
+    title: str = "An open-access economics paper",
+    *,
+    journal: str = "Revista de Economía",
+    year: str = "2023",
+    month: str | None = "5",
+    abstract: str = "Open-access abstract content.",
+) -> dict[str, Any]:
+    """Build a DOAJ article record (mimics ``payload['results'][i]``)."""
+    bib: dict[str, Any] = {
+        "title": title,
+        "year": year,
+        "author": [{"name": "Doe, Jane"}, {"name": "Smith, John"}],
+        "journal": {"title": journal, "country": "AR", "language": ["spa"]},
+        "abstract": abstract,
+        "identifier": [{"type": "doi", "id": doi}],
+    }
+    if month is not None:
+        bib["month"] = month
+    return {"id": "doaj-internal-id", "bibjson": bib}
+
+
+def _http_status_error(status: int, url: str) -> httpx.HTTPStatusError:
+    """Build a ready-to-raise ``HTTPStatusError`` for resilience tests."""
+    request = httpx.Request("GET", url)
+    response = httpx.Response(status, request=request)
+    return httpx.HTTPStatusError(f"status {status}", request=request, response=response)
+
+
+# ─── Mapper tests: SciELO (Crossref-shape) ──────────────────────────────
+
+
+def test_map_scielo_to_zotero_full_payload() -> None:
+    rec = _good_crossref_record()
+    payload = map_scielo_to_zotero(rec)
+    assert payload is not None
+    assert payload["itemType"] == "journalArticle"
+    assert payload["title"] == "Informalidad laboral en Argentina"
+    assert payload["DOI"] == "10.1590/test-scielo-doi"
+    assert payload["publicationTitle"] == "Desarrollo Económico"
+    assert payload["date"] == "2024-07"
+    assert payload["creators"][0] == {
+        "creatorType": "author",
+        "firstName": "Jane",
+        "lastName": "Doe",
+    }
+    assert "Resumen importante" in payload["abstractNote"]
+    assert "<" not in payload["abstractNote"], "JATS tags must be stripped"
+
+
+def test_map_scielo_to_zotero_returns_none_on_missing_title() -> None:
+    rec = _good_crossref_record()
+    rec["title"] = []
+    assert map_scielo_to_zotero(rec) is None
+    rec["title"] = [""]
+    assert map_scielo_to_zotero(rec) is None
+
+
+def test_map_scielo_to_zotero_returns_none_on_missing_authors() -> None:
+    rec = _good_crossref_record()
+    rec["author"] = []
+    assert map_scielo_to_zotero(rec) is None
+    # Authors with neither given nor family nor name → still None.
+    rec["author"] = [{"sequence": "first"}]
+    assert map_scielo_to_zotero(rec) is None
+
+
+def test_map_scielo_to_zotero_decodes_html_entities_and_year_only() -> None:
+    rec = _good_crossref_record(month=None)
+    rec["container-title"] = ["Ciência &amp; Saúde Coletiva"]
+    payload = map_scielo_to_zotero(rec)
+    assert payload is not None
+    assert payload["publicationTitle"] == "Ciência & Saúde Coletiva"
+    assert payload["date"] == "2024", "year-only date when no month available"
+
+
+# ─── Mapper tests: DOAJ ──────────────────────────────────────────────────
+
+
+def test_map_doaj_to_zotero_full_payload() -> None:
+    rec = _good_doaj_record()
+    payload = map_doaj_to_zotero(rec)
+    assert payload is not None
+    assert payload["itemType"] == "journalArticle"
+    assert payload["title"] == "An open-access economics paper"
+    assert payload["DOI"] == "10.5555/doaj-test-doi"
+    assert payload["publicationTitle"] == "Revista de Economía"
+    assert payload["date"] == "2023-05"
+    # "Doe, Jane" → firstName="Jane", lastName="Doe".
+    assert payload["creators"][0] == {
+        "creatorType": "author",
+        "firstName": "Jane",
+        "lastName": "Doe",
+    }
+
+
+def test_map_doaj_to_zotero_returns_none_on_missing_title() -> None:
+    rec = _good_doaj_record()
+    rec["bibjson"]["title"] = ""
+    assert map_doaj_to_zotero(rec) is None
+    del rec["bibjson"]["title"]
+    assert map_doaj_to_zotero(rec) is None
+
+
+def test_map_doaj_to_zotero_returns_none_on_missing_authors() -> None:
+    rec = _good_doaj_record()
+    rec["bibjson"]["author"] = []
+    assert map_doaj_to_zotero(rec) is None
+    rec["bibjson"]["author"] = [{"affiliation": "X"}]  # no name
+    assert map_doaj_to_zotero(rec) is None
+
+
+def test_map_doaj_to_zotero_extracts_doi_from_identifier_list() -> None:
+    rec = _good_doaj_record()
+    rec["bibjson"]["identifier"] = [
+        {"type": "issn", "id": "1234-5678"},
+        {"type": "doi", "id": "10.9999/correct-doi"},
+        {"type": "eissn", "id": "8765-4321"},
+    ]
+    payload = map_doaj_to_zotero(rec)
+    assert payload is not None
+    assert payload["DOI"] == "10.9999/correct-doi"
+
+
+# ─── 04bs cascade: title match → reparent ───────────────────────────────
+
+
+def test_04bs_title_match_creates_parent_and_reparents(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path, enable_scielo=True)
+    pdf = _write_pdf(tmp_path / "pdfs" / "bs1.pdf")
+    orphan_key = "ORPH-BS1"
+    title = "Política fiscal y crecimiento"
+    _seed_orphan(
+        settings,
+        sha="b" * 63 + "s",
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    sce = FakeSciELoClient(
+        search_responses={title: [_good_crossref_record(title=title)]},
+    )
+
+    result = run_enrich(
+        substage="04bs",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        scielo_client=sce,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04bs == 1
+    assert sce.search_calls == [(title, 5)]
+    assert len(zot.created_items) == 1
+    assert zot.created_items[0]["payload"]["DOI"] == "10.1590/test-scielo-doi"
+    assert len(zot.updated_items) == 1, "orphan must be reparented"
+
+
+def test_04bs_no_fuzzy_match_is_no_progress(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path, enable_scielo=True)
+    pdf = _write_pdf(tmp_path / "pdfs" / "bs2.pdf")
+    orphan_key = "ORPH-BS2"
+    title = "An obscure recalcitrant title"
+    _seed_orphan(
+        settings,
+        sha="c" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    sce = FakeSciELoClient(
+        search_responses={
+            title: [_good_crossref_record(title="Totally unrelated paper")]
+        },
+    )
+
+    result = run_enrich(
+        substage="04bs",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        scielo_client=sce,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04bs == 0
+    assert result.items_no_progress == 1
+    assert zot.created_items == []
+
+
+# ─── 04bd cascade: title match → reparent ───────────────────────────────
+
+
+def test_04bd_title_match_creates_parent_and_reparents(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path, enable_doaj=True)
+    pdf = _write_pdf(tmp_path / "pdfs" / "bd1.pdf")
+    orphan_key = "ORPH-BD1"
+    title = "Open access study on inflation"
+    _seed_orphan(
+        settings,
+        sha="d" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    do = FakeDOAJClient(
+        search_responses={title: [_good_doaj_record(title=title)]},
+    )
+
+    result = run_enrich(
+        substage="04bd",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        doaj_client=do,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04bd == 1
+    assert do.search_calls == [(title, 5)]
+    assert len(zot.created_items) == 1
+    assert zot.created_items[0]["payload"]["DOI"] == "10.5555/doaj-test-doi"
+
+
+def test_04bd_no_fuzzy_match_is_no_progress(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path, enable_doaj=True)
+    pdf = _write_pdf(tmp_path / "pdfs" / "bd2.pdf")
+    orphan_key = "ORPH-BD2"
+    title = "Another nothing-matches title"
+    _seed_orphan(
+        settings,
+        sha="e" * 64,
+        source_path=pdf,
+        detected_doi=None,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    do = FakeDOAJClient(
+        search_responses={title: [_good_doaj_record(title="Off-topic paper")]},
+    )
+
+    result = run_enrich(
+        substage="04bd",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        doaj_client=do,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04bd == 0
+    assert result.items_no_progress == 1
+
+
+# ─── Resilience: HTTP transients fall through, others fail ──────────────
+
+
+def test_04bs_403_falls_through_as_no_progress(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path, enable_scielo=True)
+    pdf = _write_pdf(tmp_path / "pdfs" / "bs403.pdf")
+    orphan_key = "ORPH-BS403"
+    title = "Some title"
+    _seed_orphan(
+        settings,
+        sha="f" * 64,
+        source_path=pdf,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    sce = FakeSciELoClient(
+        raise_on_search=_http_status_error(403, "https://api.crossref.org/works")
+    )
+
+    result = run_enrich(
+        substage="04bs",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        scielo_client=sce,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_no_progress == 1
+    assert result.items_failed == 0
+    assert result.rows[0].error == "scielo_unavailable:403"
+
+
+def test_04bs_500_returns_failed(tmp_path: Path, monkeypatch: Any) -> None:
+    settings = _settings(tmp_path, enable_scielo=True)
+    pdf = _write_pdf(tmp_path / "pdfs" / "bs500.pdf")
+    orphan_key = "ORPH-BS500"
+    title = "Unexpected server error path"
+    _seed_orphan(
+        settings,
+        sha="g" * 64,
+        source_path=pdf,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    sce = FakeSciELoClient(
+        raise_on_search=_http_status_error(500, "https://api.crossref.org/works")
+    )
+
+    result = run_enrich(
+        substage="04bs",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        scielo_client=sce,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_failed == 1
+    assert result.items_no_progress == 0
+    assert result.rows[0].status == "failed"
+    assert "scielo_error" in (result.rows[0].error or "")
+
+
+def test_04bd_429_falls_through_as_no_progress(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    settings = _settings(tmp_path, enable_doaj=True)
+    pdf = _write_pdf(tmp_path / "pdfs" / "bd429.pdf")
+    orphan_key = "ORPH-BD429"
+    title = "Rate limited query"
+    _seed_orphan(
+        settings,
+        sha="h" * 64,
+        source_path=pdf,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    do = FakeDOAJClient(
+        raise_on_search=_http_status_error(429, "https://doaj.org/api/v3/search/articles/x")
+    )
+
+    result = run_enrich(
+        substage="04bd",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        doaj_client=do,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_no_progress == 1
+    assert result.rows[0].error == "doaj_unavailable:429"
+
+
+def test_04bd_500_returns_failed(tmp_path: Path, monkeypatch: Any) -> None:
+    settings = _settings(tmp_path, enable_doaj=True)
+    pdf = _write_pdf(tmp_path / "pdfs" / "bd500.pdf")
+    orphan_key = "ORPH-BD500"
+    title = "Server error path"
+    _seed_orphan(
+        settings,
+        sha="i" * 64,
+        source_path=pdf,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    do = FakeDOAJClient(
+        raise_on_search=_http_status_error(500, "https://doaj.org/api/v3/search/articles/x")
+    )
+
+    result = run_enrich(
+        substage="04bd",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        doaj_client=do,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_failed == 1
+    assert "doaj_error" in (result.rows[0].error or "")
+
+
+# ─── Feature flags ────────────────────────────────────────────────────────
+
+
+def test_04bs_disabled_skips_substage_in_cascade(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """When S1_ENABLE_SCIELO=false, the cascade goes 04b → 04bd (no 04bs)."""
+    settings = _settings(tmp_path, enable_scielo=False, enable_doaj=True)
+    pdf = _write_pdf(tmp_path / "pdfs" / "noflag.pdf")
+    orphan_key = "ORPH-NOFLAG"
+    title = "Disabled scielo cascade"
+    _seed_orphan(
+        settings,
+        sha="j" * 64,
+        source_path=pdf,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: ["body", "", ""]})
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    oa = FakeOpenAlexClient(search_responses={title: []})
+    do = FakeDOAJClient(search_responses={title: [_good_doaj_record(title=title)]})
+    ss = FakeSemanticScholarClient()
+    llm = FakeOpenAIClient()
+
+    result = run_enrich(
+        substage="all",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        doaj_client=do,  # type: ignore[arg-type]
+        semantic_scholar_client=ss,  # type: ignore[arg-type]
+        openai_client=llm,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04bd == 1, "04bd must hit when 04bs is disabled"
+    assert result.items_enriched_04bs == 0
+
+
+def test_04bs_explicit_substage_aborts_when_disabled(tmp_path: Path) -> None:
+    from zotai.s1.handler import StageAbortedError
+
+    settings = _settings(tmp_path, enable_scielo=False)
+    try:
+        run_enrich(substage="04bs", settings=settings)
+    except StageAbortedError as exc:
+        assert "S1_ENABLE_SCIELO" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected StageAbortedError")
+
+
+def test_04bd_disabled_skips_substage_in_cascade(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """When S1_ENABLE_DOAJ=false, the cascade skips 04bd cleanly."""
+    settings = _settings(tmp_path, enable_scielo=True, enable_doaj=False)
+    pdf = _write_pdf(tmp_path / "pdfs" / "noflagd.pdf")
+    orphan_key = "ORPH-NOFLAGD"
+    title = "Disabled doaj cascade"
+    _seed_orphan(
+        settings,
+        sha="k" * 64,
+        source_path=pdf,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: ["body", "", ""]})
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    oa = FakeOpenAlexClient(search_responses={title: []})
+    sce = FakeSciELoClient(
+        search_responses={title: [_good_crossref_record(title=title)]}
+    )
+    ss = FakeSemanticScholarClient()
+    llm = FakeOpenAIClient()
+
+    result = run_enrich(
+        substage="all",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        scielo_client=sce,  # type: ignore[arg-type]
+        semantic_scholar_client=ss,  # type: ignore[arg-type]
+        openai_client=llm,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04bs == 1
+    assert result.items_enriched_04bd == 0
+
+
+def test_04bd_explicit_substage_aborts_when_disabled(tmp_path: Path) -> None:
+    from zotai.s1.handler import StageAbortedError
+
+    settings = _settings(tmp_path, enable_doaj=False)
+    try:
+        run_enrich(substage="04bd", settings=settings)
+    except StageAbortedError as exc:
+        assert "S1_ENABLE_DOAJ" in str(exc)
+    else:  # pragma: no cover
+        raise AssertionError("expected StageAbortedError")
+
+
+# ─── Combined cascade — 04bs surfaces before 04bd ────────────────────────
+
+
+def test_cascade_uses_04bs_after_04b_misses(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """``all``: 04a/04b miss, 04bs hits → 04bd / 04c / 04d are not invoked."""
+    settings = _settings(tmp_path, enable_scielo=True, enable_doaj=True)
+    pdf = _write_pdf(tmp_path / "pdfs" / "cas1.pdf")
+    orphan_key = "ORPH-CAS1"
+    title = "Cascade hit at 04bs"
+    _seed_orphan(
+        settings,
+        sha="l" * 64,
+        source_path=pdf,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: ["body without ids", "", ""]})
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    oa = FakeOpenAlexClient(search_responses={title: []})
+    sce = FakeSciELoClient(
+        search_responses={title: [_good_crossref_record(title=title)]}
+    )
+    do = FakeDOAJClient(search_responses={title: [_good_doaj_record(title=title)]})
+    ss = FakeSemanticScholarClient(search_responses={title: [_ss_paper(title)]})
+    llm = FakeOpenAIClient()
+
+    result = run_enrich(
+        substage="all",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        scielo_client=sce,  # type: ignore[arg-type]
+        doaj_client=do,  # type: ignore[arg-type]
+        semantic_scholar_client=ss,  # type: ignore[arg-type]
+        openai_client=llm,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04bs == 1
+    assert result.items_enriched_04bd == 0
+    assert do.search_calls == [], "DOAJ must not be called once 04bs hits"
+    assert ss.search_calls == [], "Semantic Scholar must not be called"
+    assert llm.extract_calls == []
+
+
+def test_cascade_uses_04bd_when_04b_and_04bs_miss(
+    tmp_path: Path, monkeypatch: Any
+) -> None:
+    """``all``: 04a/04b/04bs miss, 04bd hits → 04c / 04d are not invoked."""
+    settings = _settings(tmp_path, enable_scielo=True, enable_doaj=True)
+    pdf = _write_pdf(tmp_path / "pdfs" / "cas2.pdf")
+    orphan_key = "ORPH-CAS2"
+    title = "Cascade hit at 04bd"
+    _seed_orphan(
+        settings,
+        sha="m" * 64,
+        source_path=pdf,
+        zotero_item_key=orphan_key,
+    )
+    _patch_extract_text_pages(monkeypatch, {pdf.name: ["body without ids", "", ""]})
+    _patch_extract_probable_title(monkeypatch, {pdf.name: title})
+
+    zot = FakeZoteroClient(orphans={orphan_key: {"key": orphan_key}})
+    oa = FakeOpenAlexClient(search_responses={title: []})
+    sce = FakeSciELoClient(
+        search_responses={title: [_good_crossref_record(title="Off-topic")]}
+    )
+    do = FakeDOAJClient(search_responses={title: [_good_doaj_record(title=title)]})
+    ss = FakeSemanticScholarClient(search_responses={title: [_ss_paper(title)]})
+    llm = FakeOpenAIClient()
+
+    result = run_enrich(
+        substage="all",
+        settings=settings,
+        zotero_client=zot,  # type: ignore[arg-type]
+        openalex_client=oa,  # type: ignore[arg-type]
+        scielo_client=sce,  # type: ignore[arg-type]
+        doaj_client=do,  # type: ignore[arg-type]
+        semantic_scholar_client=ss,  # type: ignore[arg-type]
+        openai_client=llm,  # type: ignore[arg-type]
+        sleep=_no_sleep(),
+    )
+
+    assert result.items_enriched_04bd == 1
+    assert result.items_enriched_04bs == 0
+    assert sce.search_calls == [(title, 5)], "SciELO is consulted before DOAJ"
+    assert ss.search_calls == [], "Semantic Scholar must not be called once 04bd hits"
+
+
+# ─── Spec compliance with ADR 018 + ADR 019 ──────────────────────────────
+
+
+def test_default_flags_are_on() -> None:
+    """ADR 018 + ADR 019 §Decision: both new substage flags default ON."""
+    fields = BehaviorSettings.model_fields
+    assert fields["s1_enable_scielo"].default is True
+    assert fields["s1_enable_doaj"].default is True
+
+
+def test_env_var_names_match_spec(tmp_path: Path, monkeypatch: Any) -> None:
+    """Spec: env vars S1_ENABLE_SCIELO / S1_ENABLE_DOAJ map to the flags."""
+    monkeypatch.chdir(tmp_path)  # avoid the repo's local .env
+    monkeypatch.setenv("S1_ENABLE_SCIELO", "false")
+    monkeypatch.setenv("S1_ENABLE_DOAJ", "false")
+    b = BehaviorSettings()
+    assert b.s1_enable_scielo is False
+    assert b.s1_enable_doaj is False


### PR DESCRIPTION
## Summary

Code PR for ADR 018 + ADR 019. Adds substages \`04bs\` (SciELO via Crossref Member 530) and \`04bd\` (DOAJ) to S1 Stage 04, between the existing \`04b\` (OpenAlex) and \`04c\` (Semantic Scholar). Closes #60 and #61. Partially closes #46 (REDIB / RedALyC / La Referencia stay open per ADR 018).

The cascade becomes:

\`\`\`
04a → 04b (OpenAlex) → 04bs (SciELO) → 04bd (DOAJ) → 04c (Semantic Scholar) → 04d (LLM) → 04e (Quarantine)
\`\`\`

## Spec compliance (per ADR 018 + ADR 019)

Each row below is asserted in tests. The contract from ADR 018 §Spec-compliance survives the implementation pivot in ADR 019.

| Concept | Canonical name | Implementation |
|---|---|---|
| Substage names | \`04bs\`, \`04bd\` | \`EnrichSubstage\` Literal in \`stage_04_enrich.py:138\` |
| Status labels | \`enriched_04bs\`, \`enriched_04bd\` | \`EnrichStatus\` Literal + \`_ENRICHED_STATUSES\` |
| Settings fields | \`BehaviorSettings.s1_enable_scielo\`, \`s1_enable_doaj\` | \`config.py\` |
| Env vars | \`S1_ENABLE_SCIELO\`, \`S1_ENABLE_DOAJ\` | inherited via pydantic-settings (no env_prefix on BehaviorSettings) |
| Defaults | both \`True\` | \`BehaviorSettings\` field defaults; asserted via \`model_fields[...].default\` |
| CLI substage values | \`04a, 04b, 04bs, 04bd, 04c, 04d, 04e, all\` | \`cli.py\` validation set + help text |
| Cascade order | \`04a → 04b → 04bs → 04bd → 04c → 04d → 04e\` | \`_run_per_item_cascade\` in \`stage_04_enrich.py\` |
| Counter fields | \`EnrichResult.items_enriched_04bs/04bd\` | \`EnrichResult\` dataclass + \`_run_enrich_async\` aggregator |
| File paths | \`src/zotai/api/scielo.py\`, \`src/zotai/api/doaj.py\` | new files |
| Class names | \`SciELoClient\`, \`DOAJClient\` | preserved per ADR 019 §Decision (substage abstraction; underlying API target documented in docstring) |
| Resilience | 403/429/502/503 → \`no_progress\`, others → \`failed\` | \`_LATAM_TRANSIENT_STATUSES\` constant + split \`except\` block |

## Implementation choices that follow the spike

- **SciELO via Crossref Member 530** (ADR 019). \`search.scielo.org\` returns 403 to anonymous httpx clients; ArticleMeta is by-PID only. Crossref filtered to \`member:530\` carries the SciELO catalog with full metadata + JATS abstracts. The class \`SciELoClient\` and the file \`src/zotai/api/scielo.py\` preserve the substage's identity per the spec-compliance contract; the docstring + ADR 019 document the indirection.
- **DOAJ Lucene query without fuzzy** (ADR 018). DOAJ rejects the Lucene \`~\` operator (spike returned 400 \"Query contains disallowed Lucene features\"). Quoted \`bibjson.title:\"<title>\"\` works and feeds \`rapidfuzz.fuzz.token_set_ratio\` on our side.
- **Custom title-shape helpers**: \`_picked_via_crossref_title\` and \`_picked_via_bibjson_title\` flatten Crossref's list-shape \`title\` and DOAJ's nested \`bibjson.title\` to the flat shape \`_pick_best_fuzzy_match\` expects. Threshold \`_FUZZ_THRESHOLD = 85\` reused unchanged.
- **No Alembic migration**: new payloads are structurally identical to OpenAlex / SS payloads (\`itemType\`, \`title\`, \`creators\`, \`date\`, \`abstractNote\`, \`DOI?\`, \`publicationTitle?\`).
- **No utils/http.py changes**: \`make_async_client\` + \`make_user_agent(mailto=...)\` + \`with_retry\` cover both clients.

## Files changed (commit-by-commit)

**Commit A — API clients + flags**

- NEW \`src/zotai/api/scielo.py\` (221 lines)
- NEW \`src/zotai/api/doaj.py\` (188 lines)
- \`src/zotai/config.py\` — 2 new flags on \`BehaviorSettings\`
- \`.env.example\` — \`S1_ENABLE_SCIELO\` / \`S1_ENABLE_DOAJ\` doc block

**Commit B — cascade wire-up + tests**

- \`src/zotai/s1/stage_04_enrich.py\` — \`+545 lines\`: types, two new substage helpers, two new title-shape pickers, cascade insertion, dispatcher branches, signature extensions, counter aggregations, logging extensions, \`StageAbortedError\` checks.
- \`src/zotai/cli.py\` — accept \`04bs\` / \`04bd\` in choices + help, report new counters
- \`src/zotai/s1/run_all.py\` — include 04bs / 04bd in stage summary
- \`tests/test_s1/test_stage_04.py\` — \`+726 lines\`: \`FakeSciELoClient\` + \`FakeDOAJClient\`, \`_settings()\` default-disables flags so existing cascade tests don't make real HTTP calls, **24 new tests** (4×2 mapper, 2×2 cascade, 2×2 resilience, 2×2 feature flag, 2 combined cascade, 2 spec-compliance).
- \`tests/test_s1/test_run_all.py\` — backfill new counter fields in fake \`EnrichResult\`

## Verification

- [x] \`uv run pytest\` — **227 passed** (24 new + 203 existing, no regressions).
- [x] \`uv run ruff check\` on every modified file — **All checks passed**.
- [x] \`uv run mypy --strict\` on \`src/zotai/api/scielo.py\` + \`src/zotai/api/doaj.py\` + \`src/zotai/s1/stage_04_enrich.py\` — **no issues**.
- [x] Pre-implementation spike (recorded in ADR 019): \`httpx\` polite UA against Crossref \`member:530\` returned 2,172 hits for \`informalidad laboral argentina\` with full metadata + JATS abstracts. DOAJ quoted query against \`doaj.org/api/v3/search/articles\` works.
- [ ] Live one-shot end-to-end on a real corpus is left for the user — the substages are dry-run-safe and resilience-tested.

## Test plan

- [ ] CI green on the branch.
- [ ] Manual review: \`SciELoClient\` / \`DOAJClient\` follow the existing OpenAlex / SemanticScholar adapter pattern (\`make_async_client\`, \`with_retry\`, \`make_user_agent\`).
- [ ] Manual review: \`_enrich_04bs_one\` and \`_enrich_04bd_one\` are structurally aligned with \`_enrich_04b_one\` (the reference clone target) and \`_enrich_04c_one\` (resilience checked separately).
- [ ] Manual review: ADR 018 + ADR 019 §"Implementation artefacts" → file:line correspondence holds.
- [ ] Quick scan of the 24 new test names to confirm coverage of the spec-compliance contract.