### PR TITLE
refactor(s1): extract Zotero query helpers to api/zotero_queries

### DIFF
--- a/src/zotai/api/doaj.py
+++ b/src/zotai/api/doaj.py
@@ -143,10 +143,10 @@ def _split_doaj_name(name: str) -> tuple[str, str]:
     """Split a DOAJ author ``name`` into ``(firstName, lastName)``.
 
     DOAJ stores authors as a single ``name`` string, typically either
-    "Last, First" or "First Last". Mirrors the convention used by
-    :func:`zotai.s1.stage_03_import._split_name` so all substages keep
-    author shapes consistent. (Not imported from there to keep the
-    ``api/`` package free of ``s1/`` dependencies.)
+    "Last, First" or "First Last". The "Last, First" branch is unique
+    to DOAJ; the Western-order fallback mirrors
+    :func:`zotai.api.zotero_queries.split_name` so all substages keep
+    author shapes consistent.
     """
     name = name.strip()
     if "," in name:

--- a/src/zotai/api/zotero_queries.py
+++ b/src/zotai/api/zotero_queries.py
@@ -1,0 +1,75 @@
+"""Shared Zotero lookup + payload helpers reused across S1 stages.
+
+Stage 03 (import via Route A) and every Stage 04 enrichment substage
+that creates a parent item need the same three primitives:
+
+- :func:`find_existing_doi` — locate a Zotero item by DOI before
+  creating a duplicate (ADR 014 dedup).
+- :func:`existing_has_pdf_attachment` — decide whether to attach our
+  PDF to an existing parent or skip the attach (ADR 014).
+- :func:`split_name` — split a display name into ``(first, last)`` for
+  Zotero's ``creators`` payload, used by every metadata mapper that
+  consumes a free-form display name (OpenAlex, Semantic Scholar,
+  SciELO, DOAJ, the LLM extractor).
+
+Kept here rather than in ``stage_03_import`` so that Stage 04 substages
+do not have to reach into Stage 03's private namespace.
+"""
+
+from __future__ import annotations
+
+from zotai.api.zotero import ZoteroClient
+
+
+def find_existing_doi(zotero_client: ZoteroClient, doi: str) -> str | None:
+    """Return the item_key of an existing Zotero item with this DOI, or None."""
+    results = zotero_client.items(q=doi, qmode="everything", limit=25)
+    lowered = doi.lower()
+    for result in results:
+        data = result.get("data") or {}
+        existing_doi = (data.get("DOI") or "").lower()
+        if existing_doi == lowered:
+            key = result.get("key") or data.get("key")
+            if isinstance(key, str) and key:
+                return key
+    return None
+
+
+def existing_has_pdf_attachment(
+    zotero_client: ZoteroClient, item_key: str
+) -> bool:
+    """Return True iff the item already has at least one PDF attachment.
+
+    Used on the dedup path (ADR 014): when an importer finds that the
+    DOI is already in the user's Zotero library, we skip attaching our
+    PDF if an existing PDF child is there — the user already had the
+    paper and its own copy. If the parent has *no* PDF (metadata-only
+    import from a prior session), we still attach.
+    """
+    for child in zotero_client.children(item_key):
+        data = child.get("data") or {}
+        if data.get("itemType") != "attachment":
+            continue
+        content_type = (data.get("contentType") or "").lower()
+        if content_type.startswith("application/pdf"):
+            return True
+    return False
+
+
+def split_name(display_name: str) -> tuple[str, str]:
+    """Split ``"Jane A. Doe"`` into ``("Jane A.", "Doe")``.
+
+    Heuristic: the last whitespace-separated token is the surname. Works
+    well for Western name order; misclassifies some Spanish compound
+    surnames (``"Gabriel García Márquez"`` → ``("Gabriel García", "Márquez")``)
+    but the upstream sources only store display names, so we cannot do
+    better without more data. Stage 04 LLM extraction has a chance to
+    correct this when a document falls through.
+    """
+    cleaned = display_name.strip()
+    if not cleaned:
+        return "", ""
+    parts = cleaned.split()
+    if len(parts) == 1:
+        return "", parts[0]
+    return " ".join(parts[:-1]), parts[-1]

--- a/src/zotai/s1/stage_03_import.py
+++ b/src/zotai/s1/stage_03_import.py
@@ -66,6 +66,11 @@ from sqlmodel import Session, select
 
 from zotai.api.openalex import OpenAlexClient
 from zotai.api.zotero import ZoteroClient
+from zotai.api.zotero_queries import (
+    existing_has_pdf_attachment,
+    find_existing_doi,
+    split_name,
+)
 from zotai.config import Settings
 from zotai.s1.handler import StageAbortedError
 from zotai.state import Item, Run, init_s1, make_s1_engine
@@ -181,25 +186,6 @@ def _reconstruct_abstract(inverted: dict[str, list[int]] | None) -> str:
     return " ".join(word for _, word in positions)
 
 
-def _split_name(display_name: str) -> tuple[str, str]:
-    """Split ``"Jane A. Doe"`` into ``("Jane A.", "Doe")``.
-
-    Heuristic: the last whitespace-separated token is the surname. Works
-    well for Western name order; misclassifies some Spanish compound
-    surnames (``"Gabriel García Márquez"`` → ``("Gabriel García", "Márquez")``)
-    but OpenAlex itself only stores display names, so we cannot do better
-    without more data. Stage 04 LLM extraction has a chance to correct
-    this when a document falls through.
-    """
-    cleaned = display_name.strip()
-    if not cleaned:
-        return "", ""
-    parts = cleaned.split()
-    if len(parts) == 1:
-        return "", parts[0]
-    return " ".join(parts[:-1]), parts[-1]
-
-
 def _strip_doi_url(raw: str | None) -> str | None:
     """OpenAlex returns DOIs as URLs; Zotero wants the bare identifier."""
     if not raw:
@@ -228,7 +214,7 @@ def map_openalex_to_zotero(work: dict[str, Any]) -> dict[str, Any] | None:
         display_name = (author.get("display_name") or "").strip()
         if not display_name:
             continue
-        first, last = _split_name(display_name)
+        first, last = split_name(display_name)
         creators.append(
             {"creatorType": "author", "firstName": first, "lastName": last}
         )
@@ -283,43 +269,6 @@ def _check_connectivity(zotero_client: ZoteroClient) -> None:
             f"open; web API requires ZOTERO_API_KEY / ZOTERO_LIBRARY_ID. "
             f"Underlying error: {type(exc).__name__}: {exc}"
         ) from exc
-
-
-def _find_existing_doi(
-    zotero_client: ZoteroClient, doi: str
-) -> str | None:
-    """Return the item_key of an existing Zotero item with this DOI, or None."""
-    results = zotero_client.items(q=doi, qmode="everything", limit=25)
-    lowered = doi.lower()
-    for result in results:
-        data = result.get("data") or {}
-        existing_doi = (data.get("DOI") or "").lower()
-        if existing_doi == lowered:
-            key = result.get("key") or data.get("key")
-            if isinstance(key, str) and key:
-                return key
-    return None
-
-
-def _existing_has_pdf_attachment(
-    zotero_client: ZoteroClient, item_key: str
-) -> bool:
-    """Return True iff the item already has at least one PDF attachment.
-
-    Used on the dedup path (ADR 014): when Stage 03 finds that the DOI
-    is already in the user's Zotero library, we skip attaching our PDF
-    if an existing PDF child is there — the user already had the paper
-    and its own copy. If the parent has *no* PDF (metadata-only import
-    from a prior session), we still attach.
-    """
-    for child in zotero_client.children(item_key):
-        data = child.get("data") or {}
-        if data.get("itemType") != "attachment":
-            continue
-        content_type = (data.get("contentType") or "").lower()
-        if content_type.startswith("application/pdf"):
-            return True
-    return False
 
 
 def _pick_attach_path(item: Item, staging_folder: Path) -> Path:
@@ -382,7 +331,7 @@ async def _import_one(
             existing_key = (
                 None
                 if dry_run
-                else _find_existing_doi(zotero_client, doi_value)
+                else find_existing_doi(zotero_client, doi_value)
             )
             if existing_key:
                 # ADR 014: if the existing Zotero item already carries a
@@ -392,7 +341,7 @@ async def _import_one(
                 if dry_run:
                     dedup_status: ImportStatus = "dry_run"
                 else:
-                    already_has_pdf = _existing_has_pdf_attachment(
+                    already_has_pdf = existing_has_pdf_attachment(
                         zotero_client, existing_key
                     )
                     if already_has_pdf:

--- a/src/zotai/s1/stage_04_enrich.py
+++ b/src/zotai/s1/stage_04_enrich.py
@@ -71,25 +71,18 @@ from zotai.api.scielo import (
 )
 from zotai.api.semantic_scholar import SemanticScholarClient
 from zotai.api.zotero import ZoteroClient
+from zotai.api.zotero_queries import (
+    existing_has_pdf_attachment,
+    find_existing_doi,
+    split_name,
+)
 from zotai.config import Settings
 from zotai.s1.handler import StageAbortedError
-from zotai.s1.stage_03_import import (
-    _existing_has_pdf_attachment,
-    _find_existing_doi,
-    _split_name,
-    map_openalex_to_zotero,
-)
+from zotai.s1.stage_03_import import map_openalex_to_zotero
 from zotai.state import Item, Run, init_s1, make_s1_engine
 from zotai.utils.fs import ensure_dir
 from zotai.utils.logging import bind, get_logger
 from zotai.utils.pdf import extract_probable_title, extract_text_pages
-
-# TODO(refactor): _find_existing_doi, _existing_has_pdf_attachment, and
-# _split_name are now reused across Stage 03 and every 04 substage via
-# _create_parent_and_reparent. A follow-up chore PR should promote them
-# to `zotai.api.zotero_queries` (or similar) and drop the noqa imports
-# below. Deferred — trivial, not worth mixing with Stage 04 feature
-# work; pick up when Stage 05 lands (it will want the same helpers).
 
 log = get_logger(__name__)
 
@@ -352,7 +345,7 @@ def map_semantic_scholar_to_zotero(
         name = (entry.get("name") or "").strip()
         if not name:
             continue
-        first, last = _split_name(name)
+        first, last = split_name(name)
         creators.append(
             {"creatorType": "author", "firstName": first, "lastName": last}
         )
@@ -459,10 +452,10 @@ async def _create_parent_and_reparent(
 
     existing_parent: str | None = None
     if doi:
-        existing_parent = _find_existing_doi(zotero_client, doi)
+        existing_parent = find_existing_doi(zotero_client, doi)
 
     if existing_parent is not None:
-        if _existing_has_pdf_attachment(zotero_client, existing_parent):
+        if existing_has_pdf_attachment(zotero_client, existing_parent):
             log.info(
                 "stage_04.dedup.existing_item_with_pdf",
                 doi=doi,


### PR DESCRIPTION
## Summary

Promote three helpers reused across Stage 03 and every Stage 04 substage from `s1/stage_03_import` (private) to `api/zotero_queries` (public):

- `find_existing_doi` — DOI dedup lookup (ADR 014)
- `existing_has_pdf_attachment` — attach-or-skip decision on dedup hit
- `split_name` — display-name → (first, last) for Zotero `creators`

Resolves the `TODO(refactor)` block at `stage_04_enrich.py:87-92` and removes Stage 04's underscore-imports into Stage 03's private namespace.

## Why

Stage 04's cascade (04a / 04b / 04bs / 04bd / 04c / 04d) all funnel through `_create_parent_and_reparent`, which uses every one of these helpers. The cross-stage coupling was already real with 04a-04c; PR #63 (04bs + 04bd) added two more callsites. Cleaning this up before S2 Push (#13) lands prevents the same pattern from spreading further — S2 push will need the same DOI lookups.

Scope chosen per the alternative discussed before opening: move the three helpers exactly as the original TODO proposed. Did not bundle the mappers (`map_openalex_to_zotero` etc.) — that decision pays off when S2 Push adds its own mappers and is better tackled with use cases on the table.

## What changed

- New: `src/zotai/api/zotero_queries.py` (public versions of the three helpers, with the original docstrings preserved).
- `src/zotai/s1/stage_03_import.py`: removed the three private definitions; imports them from `zotero_queries`; updates the two internal callsites.
- `src/zotai/s1/stage_04_enrich.py`: imports from `zotero_queries` instead of from `stage_03_import._private`; drops the `TODO(refactor)` comment block; updates the three callsites.
- `src/zotai/api/doaj.py`: docstring on `_split_doaj_name` re-points to the new location and drops the now-obsolete justification ("not imported to keep `api/` free of `s1/` deps" — no longer applicable since `split_name` is in `api/`).

No behavior change. `map_openalex_to_zotero` stays in `stage_03_import` for now (out of scope here).

## Test plan

- [x] `uv run pytest -q` — **227/227 passing** (no test changes; tests do not import the moved helpers directly).
- [x] `uv run mypy --strict` clean on all modified files.
- [x] `uv run ruff check` clean on all modified files.
- [ ] Reviewer: confirm `zotero_queries.py` is the right home (vs `api/zotero.py` / a separate `zotero_mappers.py`). Picked `zotero_queries` per the original TODO.