### PR TITLE
test(api): cover search adapters (openalex, scielo, doaj, semantic_scholar)

### DIFF
--- a/tests/test_api/test_doaj.py
+++ b/tests/test_api/test_doaj.py
@@ -1,0 +1,265 @@
+"""Tests for :mod:`zotai.api.doaj`.
+
+The DOAJ adapter is the 04bd substage's HTTP client + a Zotero payload
+mapper + two small parsing helpers. Coverage matches:
+
+- ``DOAJClient.search_articles``: query construction (URL-quoted Lucene
+  query against ``bibjson.title``), ``pageSize`` / ``page`` params,
+  defensive parsing.
+- ``map_doaj_to_zotero``: every quality-gate path (missing bibjson,
+  blank title, no authors → ``None``); abstract / venue / DOI / date
+  population; comma-form vs Western-order author parsing.
+- ``_doi_from_doaj_record``: identifier list parsing — DOI vs other
+  types, missing list, malformed entries.
+- ``_split_doaj_name``: comma form, Western order, single token,
+  whitespace handling.
+- ``_date_from_doaj``: year as str / int, with / without month, invalid
+  month, missing year.
+
+HTTP is mocked with respx; no live network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+from urllib.parse import unquote
+
+import httpx
+import respx
+
+from zotai.api.doaj import (
+    DOAJ_API_BASE,
+    DOAJClient,
+    _date_from_doaj,
+    _doi_from_doaj_record,
+    _split_doaj_name,
+    map_doaj_to_zotero,
+)
+
+# ── DOAJClient.search_articles ────────────────────────────────────────────
+
+
+async def test_search_articles_quotes_title_in_lucene_query() -> None:
+    async with respx.mock() as router:
+        # The query is URL-encoded into the path — match by base prefix.
+        route = router.get(
+            url__startswith=f"{DOAJ_API_BASE}/search/articles/"
+        ).mock(return_value=httpx.Response(200, json={"results": []}))
+        client = DOAJClient()
+        await client.search_articles("Inflación")
+
+    request = route.calls.last.request
+    decoded = unquote(str(request.url.path))
+    assert 'bibjson.title:"Inflación"' in decoded
+
+
+async def test_search_articles_passes_paging_params() -> None:
+    async with respx.mock() as router:
+        route = router.get(
+            url__startswith=f"{DOAJ_API_BASE}/search/articles/"
+        ).mock(return_value=httpx.Response(200, json={"results": []}))
+        client = DOAJClient()
+        await client.search_articles("foo", per_page=3)
+
+    params = route.calls.last.request.url.params
+    assert params["pageSize"] == "3"
+    assert params["page"] == "1"
+
+
+async def test_search_articles_returns_results_array() -> None:
+    sample = [{"id": "1", "bibjson": {"title": "X"}}]
+    async with respx.mock() as router:
+        router.get(url__startswith=f"{DOAJ_API_BASE}/search/articles/").mock(
+            return_value=httpx.Response(200, json={"results": sample})
+        )
+        client = DOAJClient()
+        out = await client.search_articles("x")
+
+    assert out == sample
+
+
+async def test_search_articles_returns_empty_when_results_missing() -> None:
+    async with respx.mock() as router:
+        router.get(url__startswith=f"{DOAJ_API_BASE}/search/articles/").mock(
+            return_value=httpx.Response(200, json={"timestamp": "..."})
+        )
+        client = DOAJClient()
+        out = await client.search_articles("x")
+
+    assert out == []
+
+
+# ── map_doaj_to_zotero ─────────────────────────────────────────────────────
+
+
+def _full_record() -> dict[str, Any]:
+    return {
+        "bibjson": {
+            "title": "Inflación en LATAM",
+            "author": [
+                {"name": "Doe, Jane"},
+                {"name": "Smith Jr."},
+            ],
+            "year": "2024",
+            "month": "06",
+            "journal": {"title": "Revista DOAJ"},
+            "abstract": "An abstract.",
+            "identifier": [
+                {"type": "doi", "id": "10.1590/abc"},
+                {"type": "issn", "id": "1234-5678"},
+            ],
+        }
+    }
+
+
+def test_map_doaj_to_zotero_happy_path() -> None:
+    payload = map_doaj_to_zotero(_full_record())
+
+    assert payload is not None
+    assert payload["itemType"] == "journalArticle"
+    assert payload["title"] == "Inflación en LATAM"
+    assert payload["DOI"] == "10.1590/abc"
+    assert payload["date"] == "2024-06"
+    assert payload["publicationTitle"] == "Revista DOAJ"
+    assert payload["abstractNote"] == "An abstract."
+    assert payload["creators"] == [
+        {"creatorType": "author", "firstName": "Jane", "lastName": "Doe"},
+        {"creatorType": "author", "firstName": "Smith", "lastName": "Jr."},
+    ]
+
+
+def test_map_doaj_to_zotero_drops_when_bibjson_missing() -> None:
+    assert map_doaj_to_zotero({"id": "1"}) is None
+
+
+def test_map_doaj_to_zotero_drops_when_title_blank() -> None:
+    record = _full_record()
+    record["bibjson"]["title"] = "  "
+    assert map_doaj_to_zotero(record) is None
+
+
+def test_map_doaj_to_zotero_drops_when_no_authors() -> None:
+    record = _full_record()
+    record["bibjson"]["author"] = []
+    assert map_doaj_to_zotero(record) is None
+
+
+def test_map_doaj_to_zotero_skips_non_dict_authors() -> None:
+    record = _full_record()
+    record["bibjson"]["author"] = ["not a dict", {"name": "Doe, Jane"}]
+    payload = map_doaj_to_zotero(record)
+    assert payload is not None
+    assert payload["creators"] == [
+        {"creatorType": "author", "firstName": "Jane", "lastName": "Doe"}
+    ]
+
+
+def test_map_doaj_to_zotero_omits_doi_field_when_no_identifier() -> None:
+    record = _full_record()
+    record["bibjson"]["identifier"] = [{"type": "issn", "id": "1234"}]
+    payload = map_doaj_to_zotero(record)
+    assert payload is not None
+    assert "DOI" not in payload
+
+
+def test_map_doaj_to_zotero_handles_missing_optional_fields() -> None:
+    record = {
+        "bibjson": {
+            "title": "Minimal",
+            "author": [{"name": "Solo Author"}],
+        }
+    }
+    payload = map_doaj_to_zotero(record)
+    assert payload is not None
+    assert payload["title"] == "Minimal"
+    assert payload["abstractNote"] == ""
+    assert payload["date"] == ""
+    assert "DOI" not in payload
+    assert "publicationTitle" not in payload or payload["publicationTitle"] == ""
+
+
+# ── _doi_from_doaj_record ─────────────────────────────────────────────────
+
+
+def test_doi_from_doaj_record_picks_doi_type_only() -> None:
+    record = {
+        "bibjson": {
+            "identifier": [
+                {"type": "issn", "id": "1234-5678"},
+                {"type": "doi", "id": "10.x/abc"},
+            ]
+        }
+    }
+    assert _doi_from_doaj_record(record) == "10.x/abc"
+
+
+def test_doi_from_doaj_record_returns_none_when_no_doi_type() -> None:
+    record = {"bibjson": {"identifier": [{"type": "issn", "id": "1234"}]}}
+    assert _doi_from_doaj_record(record) is None
+
+
+def test_doi_from_doaj_record_returns_none_when_bibjson_missing() -> None:
+    assert _doi_from_doaj_record({}) is None
+
+
+def test_doi_from_doaj_record_returns_none_when_identifier_missing() -> None:
+    assert _doi_from_doaj_record({"bibjson": {}}) is None
+
+
+def test_doi_from_doaj_record_skips_non_dict_entries() -> None:
+    record = {
+        "bibjson": {
+            "identifier": ["str-not-dict", {"type": "doi", "id": "10.1/x"}],
+        }
+    }
+    assert _doi_from_doaj_record(record) == "10.1/x"
+
+
+# ── _split_doaj_name ──────────────────────────────────────────────────────
+
+
+def test_split_doaj_name_comma_form() -> None:
+    assert _split_doaj_name("Doe, Jane A.") == ("Jane A.", "Doe")
+
+
+def test_split_doaj_name_western_order() -> None:
+    assert _split_doaj_name("Jane A. Doe") == ("Jane A.", "Doe")
+
+
+def test_split_doaj_name_single_token() -> None:
+    assert _split_doaj_name("Plato") == ("", "Plato")
+
+
+def test_split_doaj_name_strips_whitespace() -> None:
+    assert _split_doaj_name("  Doe, Jane  ") == ("Jane", "Doe")
+
+
+# ── _date_from_doaj ───────────────────────────────────────────────────────
+
+
+def test_date_from_doaj_year_string_only() -> None:
+    assert _date_from_doaj("2024", None) == "2024"
+
+
+def test_date_from_doaj_year_int_zero_pads() -> None:
+    assert _date_from_doaj(987, None) == "0987"
+
+
+def test_date_from_doaj_year_with_month_string() -> None:
+    assert _date_from_doaj("2024", "6") == "2024-06"
+
+
+def test_date_from_doaj_year_with_month_int() -> None:
+    assert _date_from_doaj(2024, 12) == "2024-12"
+
+
+def test_date_from_doaj_invalid_month_drops_month() -> None:
+    assert _date_from_doaj("2024", "13") == "2024"
+    assert _date_from_doaj("2024", 0) == "2024"
+    assert _date_from_doaj("2024", "abc") == "2024"
+
+
+def test_date_from_doaj_blank_year_returns_empty_string() -> None:
+    assert _date_from_doaj("", "6") == ""
+    assert _date_from_doaj(None, "6") == ""
+    assert _date_from_doaj("not-a-year", "6") == ""

--- a/tests/test_api/test_openalex.py
+++ b/tests/test_api/test_openalex.py
@@ -1,0 +1,105 @@
+"""Tests for :mod:`zotai.api.openalex`.
+
+The adapter is a thin wrapper around two endpoints: ``/works`` (free-text
+search) and ``/works/doi:<doi>`` (DOI lookup). We cover happy paths,
+empty responses, the documented 404 → ``None`` contract on the DOI
+lookup, the User-Agent ``mailto`` polite-pool wiring, and the request
+parameters Stage 03 / 04b rely on (``search``, ``per-page``).
+
+HTTP is mocked with respx; no live network.
+"""
+
+from __future__ import annotations
+
+import httpx
+import pytest
+import respx
+
+from zotai.api.openalex import OPENALEX_BASE, OpenAlexClient
+
+
+async def test_search_works_happy_path() -> None:
+    sample = {"results": [{"id": "W1", "title": "A paper"}]}
+    async with respx.mock(assert_all_called=True) as router:
+        route = router.get(f"{OPENALEX_BASE}/works").mock(
+            return_value=httpx.Response(200, json=sample)
+        )
+        client = OpenAlexClient(user_email="user@example.org")
+        results = await client.search_works("A paper", per_page=5)
+
+    assert results == [{"id": "W1", "title": "A paper"}]
+    request = route.calls.last.request
+    assert request.url.params["search"] == "A paper"
+    assert request.url.params["per-page"] == "5"
+    # mailto goes into the User-Agent (polite pool).
+    assert "mailto:user@example.org" in request.headers["user-agent"]
+
+
+async def test_search_works_returns_empty_list_when_no_results() -> None:
+    async with respx.mock() as router:
+        router.get(f"{OPENALEX_BASE}/works").mock(
+            return_value=httpx.Response(200, json={"results": []})
+        )
+        client = OpenAlexClient()
+        results = await client.search_works("nothing matches")
+
+    assert results == []
+
+
+async def test_search_works_tolerates_missing_results_key() -> None:
+    # OpenAlex always returns ``results`` but the adapter falls back to
+    # an empty list defensively. Verify that contract.
+    async with respx.mock() as router:
+        router.get(f"{OPENALEX_BASE}/works").mock(
+            return_value=httpx.Response(200, json={"meta": {}})
+        )
+        client = OpenAlexClient()
+        results = await client.search_works("anything")
+
+    assert results == []
+
+
+async def test_work_by_doi_happy_path() -> None:
+    sample = {"id": "W42", "doi": "https://doi.org/10.1000/x", "title": "Paper"}
+    async with respx.mock() as router:
+        route = router.get(
+            f"{OPENALEX_BASE}/works/doi:10.1000/x"
+        ).mock(return_value=httpx.Response(200, json=sample))
+        client = OpenAlexClient()
+        result = await client.work_by_doi("10.1000/x")
+
+    assert result == sample
+    assert route.calls.call_count == 1
+
+
+async def test_work_by_doi_returns_none_on_404() -> None:
+    async with respx.mock() as router:
+        router.get(f"{OPENALEX_BASE}/works/doi:10.0/notfound").mock(
+            return_value=httpx.Response(404, json={"error": "Not Found"})
+        )
+        client = OpenAlexClient()
+        result = await client.work_by_doi("10.0/notfound")
+
+    assert result is None
+
+
+async def test_work_by_doi_raises_on_5xx() -> None:
+    async with respx.mock() as router:
+        router.get(f"{OPENALEX_BASE}/works/doi:10.0/boom").mock(
+            return_value=httpx.Response(500)
+        )
+        client = OpenAlexClient()
+        with pytest.raises(httpx.HTTPStatusError):
+            await client.work_by_doi("10.0/boom")
+
+
+async def test_user_agent_omits_mailto_when_no_email() -> None:
+    async with respx.mock() as router:
+        route = router.get(f"{OPENALEX_BASE}/works").mock(
+            return_value=httpx.Response(200, json={"results": []})
+        )
+        client = OpenAlexClient()
+        await client.search_works("x")
+
+    ua = route.calls.last.request.headers["user-agent"]
+    assert "mailto:" not in ua

--- a/tests/test_api/test_scielo.py
+++ b/tests/test_api/test_scielo.py
@@ -1,0 +1,219 @@
+"""Tests for :mod:`zotai.api.scielo`.
+
+Per ADR 019, the substage hits Crossref filtered to ``member:530``
+rather than ``search.scielo.org`` directly. The tests cover both halves
+of the module:
+
+- ``SciELoClient.search_articles`` — request shape (filter, query.title,
+  rows, select), happy path, defensive parsing when the JSON does not
+  match Crossref's documented shape.
+- ``map_scielo_to_zotero`` — full mapping + every quality-gate path
+  (missing title / no authors return ``None``), corporate-author
+  handling, JATS abstract stripping.
+- ``_doi_from_scielo_record`` and ``_date_from_crossref_published`` —
+  the small helpers that surrounded the mapper.
+
+HTTP is mocked with respx; no live network.
+"""
+
+from __future__ import annotations
+
+from typing import Any
+
+import httpx
+import respx
+
+from zotai.api.scielo import (
+    CROSSREF_BASE,
+    SCIELO_CROSSREF_MEMBER,
+    SciELoClient,
+    _date_from_crossref_published,
+    _doi_from_scielo_record,
+    map_scielo_to_zotero,
+)
+
+# ── SciELoClient.search_articles ──────────────────────────────────────────
+
+
+def _crossref_payload(items: list[dict[str, Any]]) -> dict[str, Any]:
+    return {"status": "ok", "message": {"items": items}}
+
+
+async def test_search_articles_sends_member_filter_and_select() -> None:
+    async with respx.mock() as router:
+        route = router.get(f"{CROSSREF_BASE}/works").mock(
+            return_value=httpx.Response(200, json=_crossref_payload([])),
+        )
+        client = SciELoClient(user_email="user@example.org")
+        await client.search_articles("inflación", per_page=3)
+
+    params = route.calls.last.request.url.params
+    assert params["query.title"] == "inflación"
+    assert params["filter"] == f"member:{SCIELO_CROSSREF_MEMBER}"
+    assert params["rows"] == "3"
+    assert "DOI" in params["select"]
+    assert "title" in params["select"]
+
+
+async def test_search_articles_returns_items_array() -> None:
+    items = [{"DOI": "10.1590/abc", "title": ["Paper"]}]
+    async with respx.mock() as router:
+        router.get(f"{CROSSREF_BASE}/works").mock(
+            return_value=httpx.Response(200, json=_crossref_payload(items)),
+        )
+        client = SciELoClient()
+        out = await client.search_articles("paper")
+
+    assert out == items
+
+
+async def test_search_articles_returns_empty_when_message_missing() -> None:
+    async with respx.mock() as router:
+        router.get(f"{CROSSREF_BASE}/works").mock(
+            return_value=httpx.Response(200, json={"status": "ok"}),
+        )
+        client = SciELoClient()
+        out = await client.search_articles("paper")
+
+    assert out == []
+
+
+async def test_search_articles_returns_empty_when_items_missing() -> None:
+    async with respx.mock() as router:
+        router.get(f"{CROSSREF_BASE}/works").mock(
+            return_value=httpx.Response(
+                200, json={"status": "ok", "message": {"total-results": 0}}
+            ),
+        )
+        client = SciELoClient()
+        out = await client.search_articles("paper")
+
+    assert out == []
+
+
+# ── map_scielo_to_zotero ───────────────────────────────────────────────────
+
+
+def _full_record() -> dict[str, Any]:
+    return {
+        "DOI": "10.1590/abc",
+        "title": ["Inflación y crecimiento en LATAM"],
+        "author": [
+            {"given": "Jane", "family": "Doe"},
+            {"given": "", "family": "Smith"},
+        ],
+        "published": {"date-parts": [[2024, 6, 15]]},
+        "container-title": ["Revista CEPAL"],
+        "abstract": "<jats:p>This paper discusses <jats:italic>X</jats:italic>.</jats:p>",
+        "type": "journal-article",
+    }
+
+
+def test_map_scielo_to_zotero_happy_path() -> None:
+    payload = map_scielo_to_zotero(_full_record())
+
+    assert payload is not None
+    assert payload["itemType"] == "journalArticle"
+    assert payload["title"] == "Inflación y crecimiento en LATAM"
+    assert payload["DOI"] == "10.1590/abc"
+    assert payload["date"] == "2024-06-15"
+    assert payload["publicationTitle"] == "Revista CEPAL"
+    # JATS tags stripped, whitespace collapsed.
+    assert payload["abstractNote"] == "This paper discusses X ."
+    assert payload["creators"] == [
+        {"creatorType": "author", "firstName": "Jane", "lastName": "Doe"},
+        {"creatorType": "author", "firstName": "", "lastName": "Smith"},
+    ]
+
+
+def test_map_scielo_to_zotero_drops_record_without_title() -> None:
+    record = _full_record()
+    record["title"] = []
+    assert map_scielo_to_zotero(record) is None
+
+
+def test_map_scielo_to_zotero_drops_record_with_blank_title() -> None:
+    record = _full_record()
+    record["title"] = ["   "]
+    assert map_scielo_to_zotero(record) is None
+
+
+def test_map_scielo_to_zotero_drops_record_without_authors() -> None:
+    record = _full_record()
+    record["author"] = []
+    assert map_scielo_to_zotero(record) is None
+
+
+def test_map_scielo_to_zotero_falls_back_to_corporate_name() -> None:
+    record = _full_record()
+    record["author"] = [{"name": "Comisión Económica para América Latina"}]
+    payload = map_scielo_to_zotero(record)
+    assert payload is not None
+    assert payload["creators"] == [
+        {
+            "creatorType": "author",
+            "firstName": "",
+            "lastName": "Comisión Económica para América Latina",
+        }
+    ]
+
+
+def test_map_scielo_to_zotero_unescapes_html_entities_in_title_and_venue() -> None:
+    record = _full_record()
+    record["title"] = ["Café &amp; Sociedad"]
+    record["container-title"] = ["Revista &lt;X&gt;"]
+    payload = map_scielo_to_zotero(record)
+    assert payload is not None
+    assert payload["title"] == "Café & Sociedad"
+    assert payload["publicationTitle"] == "Revista <X>"
+
+
+def test_map_scielo_to_zotero_omits_doi_field_when_missing() -> None:
+    record = _full_record()
+    record["DOI"] = ""
+    payload = map_scielo_to_zotero(record)
+    assert payload is not None
+    assert "DOI" not in payload
+
+
+# ── _doi_from_scielo_record ────────────────────────────────────────────────
+
+
+def test_doi_from_scielo_record_returns_stripped_doi() -> None:
+    assert _doi_from_scielo_record({"DOI": "  10.1590/abc  "}) == "10.1590/abc"
+
+
+def test_doi_from_scielo_record_returns_none_when_missing() -> None:
+    assert _doi_from_scielo_record({}) is None
+
+
+def test_doi_from_scielo_record_returns_none_when_blank() -> None:
+    assert _doi_from_scielo_record({"DOI": "   "}) is None
+
+
+# ── _date_from_crossref_published ──────────────────────────────────────────
+
+
+def test_date_from_crossref_published_year_only() -> None:
+    assert _date_from_crossref_published({"date-parts": [[2024]]}) == "2024"
+
+
+def test_date_from_crossref_published_year_month() -> None:
+    assert _date_from_crossref_published({"date-parts": [[2024, 6]]}) == "2024-06"
+
+
+def test_date_from_crossref_published_year_month_day() -> None:
+    assert (
+        _date_from_crossref_published({"date-parts": [[2024, 6, 5]]}) == "2024-06-05"
+    )
+
+
+def test_date_from_crossref_published_returns_empty_for_missing_input() -> None:
+    assert _date_from_crossref_published(None) == ""
+    assert _date_from_crossref_published({}) == ""
+    assert _date_from_crossref_published({"date-parts": []}) == ""
+    assert _date_from_crossref_published({"date-parts": [[]]}) == ""
+
+
+def test_date_from_crossref_published_handles_non_int_year() -> None:
+    assert _date_from_crossref_published({"date-parts": [["2024"]]}) == ""

--- a/tests/test_api/test_semantic_scholar.py
+++ b/tests/test_api/test_semantic_scholar.py
@@ -1,0 +1,124 @@
+"""Tests for :mod:`zotai.api.semantic_scholar`.
+
+Coverage:
+
+- ``search_paper`` happy path with the default field set Stage 04c
+  consumes (``title,authors,year,venue,abstract,externalIds``).
+- Custom ``fields`` overrides; empty ``fields`` falls back to the
+  Semantic Scholar API default (``paperId + title``).
+- API key wiring: ``x-api-key`` header is present iff a key was passed
+  to the constructor.
+- Defensive parse: missing ``data`` key returns an empty list rather
+  than blowing up.
+
+HTTP is mocked with respx; no live network.
+"""
+
+from __future__ import annotations
+
+import httpx
+import respx
+
+from zotai.api.semantic_scholar import (
+    SEMANTIC_SCHOLAR_BASE,
+    SemanticScholarClient,
+)
+
+
+async def test_search_paper_happy_path_with_default_fields() -> None:
+    sample = {
+        "data": [
+            {
+                "paperId": "abc",
+                "title": "Inflación en LATAM",
+                "authors": [{"name": "Doe, J."}],
+                "year": 2024,
+            }
+        ]
+    }
+    async with respx.mock() as router:
+        route = router.get(f"{SEMANTIC_SCHOLAR_BASE}/paper/search").mock(
+            return_value=httpx.Response(200, json=sample)
+        )
+        client = SemanticScholarClient()
+        results = await client.search_paper("inflación LATAM", limit=5)
+
+    assert results == sample["data"]
+    request = route.calls.last.request
+    assert request.url.params["query"] == "inflación LATAM"
+    assert request.url.params["limit"] == "5"
+    # Default fields include the columns Stage 04c's mapper needs.
+    fields = request.url.params["fields"]
+    for required in ("title", "authors", "year", "venue", "abstract", "externalIds"):
+        assert required in fields
+
+
+async def test_search_paper_custom_fields_passthrough() -> None:
+    async with respx.mock() as router:
+        route = router.get(f"{SEMANTIC_SCHOLAR_BASE}/paper/search").mock(
+            return_value=httpx.Response(200, json={"data": []})
+        )
+        client = SemanticScholarClient()
+        await client.search_paper("x", fields="title,year")
+
+    assert route.calls.last.request.url.params["fields"] == "title,year"
+
+
+async def test_search_paper_empty_fields_omits_param() -> None:
+    # Passing ``fields=""`` should fall back to the Semantic Scholar
+    # API default (paperId + title) — i.e. the param is not sent.
+    async with respx.mock() as router:
+        route = router.get(f"{SEMANTIC_SCHOLAR_BASE}/paper/search").mock(
+            return_value=httpx.Response(200, json={"data": []})
+        )
+        client = SemanticScholarClient()
+        await client.search_paper("x", fields="")
+
+    assert "fields" not in route.calls.last.request.url.params
+
+
+async def test_search_paper_returns_empty_list_when_data_missing() -> None:
+    async with respx.mock() as router:
+        router.get(f"{SEMANTIC_SCHOLAR_BASE}/paper/search").mock(
+            return_value=httpx.Response(200, json={"meta": {}})
+        )
+        client = SemanticScholarClient()
+        results = await client.search_paper("nothing")
+
+    assert results == []
+
+
+async def test_api_key_sets_x_api_key_header() -> None:
+    async with respx.mock() as router:
+        route = router.get(f"{SEMANTIC_SCHOLAR_BASE}/paper/search").mock(
+            return_value=httpx.Response(200, json={"data": []})
+        )
+        client = SemanticScholarClient(api_key="key-abc")
+        await client.search_paper("x")
+
+    headers = route.calls.last.request.headers
+    assert headers["x-api-key"] == "key-abc"
+
+
+async def test_no_api_key_omits_x_api_key_header() -> None:
+    async with respx.mock() as router:
+        route = router.get(f"{SEMANTIC_SCHOLAR_BASE}/paper/search").mock(
+            return_value=httpx.Response(200, json={"data": []})
+        )
+        client = SemanticScholarClient()
+        await client.search_paper("x")
+
+    assert "x-api-key" not in route.calls.last.request.headers
+
+
+async def test_empty_string_api_key_treated_as_absent() -> None:
+    # Constructor coalesces falsy api_key to None. A `.env` value left
+    # blank should not produce a literal ``x-api-key: `` header.
+    async with respx.mock() as router:
+        route = router.get(f"{SEMANTIC_SCHOLAR_BASE}/paper/search").mock(
+            return_value=httpx.Response(200, json={"data": []})
+        )
+        client = SemanticScholarClient(api_key="")
+        await client.search_paper("x")
+
+    assert "x-api-key" not in route.calls.last.request.headers


### PR DESCRIPTION
## Summary

Adds direct unit tests for the four search adapters in `zotai.api/`, previously only exercised indirectly via Stage 04 substage tests (04a/04b → openalex, 04bs → scielo, 04bd → doaj, 04c → semantic_scholar).

Closes part 2 of the adapter-test gap flagged in the project status review (PR #65 covered `openai_client`).

## Why

All four adapters wrap external APIs that change without notice: OpenAlex polite-pool semantics, Semantic Scholar field-list contract, Crossref's `member:530` filter (the SciELO mirror under ADR 019), DOAJ's Lucene quoting rule (ADR 018). When one of these breaks, the failure surfaces three layers up as a Stage 04 substage failure — direct unit tests catch it where the bug is.

Picked respx because all four use `httpx.AsyncClient` via `make_async_client`, so the same mocking pattern works for all of them. respx is already a dev dep.

## What's covered

**openalex (7 tests)** — `search_works` happy path + empty + missing-`results` fallback; `work_by_doi` happy path + 404 → None contract + 5xx raises; User-Agent `mailto` polite-pool wiring.

**semantic_scholar (7 tests)** — default field set Stage 04c needs, custom fields passthrough, `fields=\"\"` falls back to API default; `x-api-key` header iff a key was passed (and empty-string env value treated as absent); defensive parse on missing `data`.

**scielo (19 tests)** — `SciELoClient.search_articles` Crossref request shape (`filter=member:530`, `query.title`, `rows`, `select`), defensive parse when JSON shape unexpected; `map_scielo_to_zotero` full mapping + every quality-gate path (missing/blank title, no authors → None) + corporate-author fallback + JATS abstract stripping + HTML entity unescape; `_doi_from_scielo_record` and `_date_from_crossref_published` variants (year / year-month / year-month-day + invalid input).

**doaj (26 tests)** — `DOAJClient.search_articles` Lucene query encoding + paging; `map_doaj_to_zotero` full mapping + quality-gate paths + non-dict author entries + missing optional fields; `_doi_from_doaj_record` (DOI vs other types, missing, malformed); `_split_doaj_name` (comma form, Western order, single token, whitespace); `_date_from_doaj` (year str/int, with/without month, invalid month, missing year).

**Total: 59 new tests in 4 files.**

## Findings (not fixed in this PR)

`_split_doaj_name(\"\")` raises `IndexError` — the caller filters blank `name` before calling so the bug is unreachable in production today, but the helper signature does not document the precondition. **Not patched in this PR** (it is a tests-only PR; bug fixes belong in their own commit). If desired, a one-liner follow-up adds the empty-string guard. Flagging here for visibility.

## Test plan

- [x] `uv run pytest -q` — **286/286 passing** (227 baseline + 18 from PR #65 + 59 new — but PR #65 is on its own branch, so on this branch it's 227 + 59 = 286).
- [x] `uv run ruff check tests/test_api/` clean.
- [x] No production code modified.

## Stacking note

This PR is independent from PR #64 (refactor) and PR #65 (openai_client tests) — all three branch off `main` directly and can land in any order. Suite stays green at every merge order.