### PR TITLE
fix(api): guard _split_doaj_name against empty / whitespace-only input

### DIFF
--- a/src/zotai/api/doaj.py
+++ b/src/zotai/api/doaj.py
@@ -149,6 +149,8 @@ def _split_doaj_name(name: str) -> tuple[str, str]:
     ``api/`` package free of ``s1/`` dependencies.)
     """
     name = name.strip()
+    if not name:
+        return "", ""
     if "," in name:
         last, _, first = name.partition(",")
         return first.strip(), last.strip()

--- a/tests/test_api/test_doaj.py
+++ b/tests/test_api/test_doaj.py
@@ -12,7 +12,7 @@ mapper + two small parsing helpers. Coverage matches:
 - ``_doi_from_doaj_record``: identifier list parsing — DOI vs other
   types, missing list, malformed entries.
 - ``_split_doaj_name``: comma form, Western order, single token,
-  whitespace handling.
+  empty / whitespace-only input, leading/trailing whitespace.
 - ``_date_from_doaj``: year as str / int, with / without month, invalid
   month, missing year.
 
@@ -228,6 +228,18 @@ def test_split_doaj_name_western_order() -> None:
 
 def test_split_doaj_name_single_token() -> None:
     assert _split_doaj_name("Plato") == ("", "Plato")
+
+
+def test_split_doaj_name_empty_string_returns_empty_pair() -> None:
+    # The caller in ``map_doaj_to_zotero`` filters blanks before
+    # invoking, but the helper still must not raise on an empty string —
+    # its contract should match
+    # ``zotai.api.zotero_queries.split_name``.
+    assert _split_doaj_name("") == ("", "")
+
+
+def test_split_doaj_name_whitespace_only_returns_empty_pair() -> None:
+    assert _split_doaj_name("   ") == ("", "")
 
 
 def test_split_doaj_name_strips_whitespace() -> None:


### PR DESCRIPTION
## Summary

Adds an early return in `_split_doaj_name` (`src/zotai/api/doaj.py`) so empty / whitespace-only input no longer raises `IndexError`. The helper's contract now matches `zotai.api.zotero_queries.split_name` on the same input.

Re-introduces the empty-string test that PR #66 had to drop because it would have failed against the buggy implementation.

## Why

Surfaced by PR #66's test coverage. The bug was unreachable in production today — the only caller (`map_doaj_to_zotero`, line 86 of `doaj.py`) filters blank `name` before invoking — so this is a defense-in-depth fix rather than a behavior change for end users. But the helper's signature did not document the "caller must filter blanks" precondition, so any future caller that does not filter would crash.

## Diff

```python
def _split_doaj_name(name: str) -> tuple[str, str]:
    name = name.strip()
+   if not name:
+       return "", ""
    if "," in name:
        last, _, first = name.partition(",")
        return first.strip(), last.strip()
    parts = name.split()
    if len(parts) == 1:
        return "", parts[0]
    return " ".join(parts[:-1]), parts[-1]
```

## Stacking

**Base = `test/search-adapters-coverage`** (PR #66). Stacked because the test that validates this fix lives in `test_doaj.py`, which is created by PR #66. Merge order:

1. Land PR #66 (search-adapter tests)
2. This PR rebases onto `main` automatically and lands

If PR #66 is rebased or its head changes, this PR needs to be rebased too.

## Test plan

- [x] `uv run pytest tests/test_api/test_doaj.py -v` — **28/28 passing** (26 from PR #66 + 2 new: empty string + whitespace only).
- [x] `uv run pytest -q` — full suite **288/288 passing** on this branch (286 baseline from #66 + 2 new).
- [x] `uv run ruff check` clean on modified files.
- [x] `uv run mypy --strict src/zotai/api/doaj.py` clean.