### PR TITLE
fix(api): guard _split_doaj_name against empty / whitespace-only input

### DIFF
--- a/src/zotai/api/doaj.py
+++ b/src/zotai/api/doaj.py
@@ -149,6 +149,8 @@ def _split_doaj_name(name: str) -> tuple[str, str]:
     author shapes consistent.
     """
     name = name.strip()
+    if not name:
+        return "", ""
     if "," in name:
         last, _, first = name.partition(",")
         return first.strip(), last.strip()

--- a/tests/test_api/test_doaj.py
+++ b/tests/test_api/test_doaj.py
@@ -12,7 +12,7 @@ mapper + two small parsing helpers. Coverage matches:
 - ``_doi_from_doaj_record``: identifier list parsing — DOI vs other
   types, missing list, malformed entries.
 - ``_split_doaj_name``: comma form, Western order, single token,
-  whitespace handling.
+  empty / whitespace-only input, leading/trailing whitespace.
 - ``_date_from_doaj``: year as str / int, with / without month, invalid
   month, missing year.
 
@@ -228,6 +228,18 @@ def test_split_doaj_name_western_order() -> None:
 
 def test_split_doaj_name_single_token() -> None:
     assert _split_doaj_name("Plato") == ("", "Plato")
+
+
+def test_split_doaj_name_empty_string_returns_empty_pair() -> None:
+    # The caller in ``map_doaj_to_zotero`` filters blanks before
+    # invoking, but the helper still must not raise on an empty string —
+    # its contract should match
+    # ``zotai.api.zotero_queries.split_name``.
+    assert _split_doaj_name("") == ("", "")
+
+
+def test_split_doaj_name_whitespace_only_returns_empty_pair() -> None:
+    assert _split_doaj_name("   ") == ("", "")
 
 
 def test_split_doaj_name_strips_whitespace() -> None:


### PR DESCRIPTION
## Summary

Adds an early return in `_split_doaj_name` (`src/zotai/api/doaj.py`) so empty / whitespace-only input no longer raises `IndexError`. Matches the behavior of `zotai.api.zotero_queries.split_name` on the same input.

Re-applies the content of PR #67 against `main`. See "Why this PR exists" below.

## Why the bug fix

`_split_doaj_name("")` raised `IndexError` on `parts[-1]` when the input stripped to zero tokens. Unreachable in production today — the only caller (`map_doaj_to_zotero`, line 86) filters blank `name` before invoking — so this is defense-in-depth, not a behavior change for end users. But the helper's signature did not document the "caller must filter blanks" precondition, so any future caller that does not filter would crash.

## Why this PR exists (vs the already-merged #67)

PR #67 was stacked on PR #66's branch (`test/search-adapters-coverage`). When #66 squash-merged into `main`, its head branch became orphaned with respect to `main`'s history. The subsequent merge of #67 landed `7cb70fa` into that orphaned branch rather than `main`. End result: `main` has the search-adapter tests but neither the fix nor the two empty-string tests.

Verified before re-applying: `grep "if not name" src/zotai/api/doaj.py` on `main` returned only the caller-side filter, not the helper-side guard; `pytest tests/test_api/test_doaj.py::test_split_doaj_name_empty_string_returns_empty_pair` collected 0 tests.

## Diff

```python
def _split_doaj_name(name: str) -> tuple[str, str]:
    name = name.strip()
+   if not name:
+       return "", ""
    if "," in name:
        last, _, first = name.partition(",")
        return first.strip(), last.strip()
    parts = name.split()
    if len(parts) == 1:
        return "", parts[0]
    return " ".join(parts[:-1]), parts[-1]
```

Plus two tests in `tests/test_api/test_doaj.py`: `test_split_doaj_name_empty_string_returns_empty_pair` and `test_split_doaj_name_whitespace_only_returns_empty_pair`.

## Test plan

- [x] `uv run pytest tests/test_api/test_doaj.py -q` — **28/28 passing** (26 from #66 + 2 new).
- [x] `uv run pytest -q` — full suite **306/306 passing**.
- [x] `uv run ruff check` clean on modified files.
- [x] `uv run mypy --strict src/zotai/api/doaj.py` clean.

## Lesson learned (for the project)

Stacked PRs against squash-merged GitHub repos have a sharp edge: when the base squash-merges, GitHub's UI still happily merges the dependent PR, but it lands in the orphaned base branch rather than `main`. Two safer alternatives next time:

1. After the base lands, **manually rebase the dependent PR onto `main`** before clicking merge. GitHub re-targets `base` automatically only on rebase-merge, not squash-merge.
2. **Avoid stacking when the fix is small** — open the dependent PR against `main` directly and accept a temporary failing test until the base lands. The cost (one red CI run) is lower than the cost of a fix going into the void.