### PR TITLE
docs: align README + plan_00/03 with ADR 015 ordering

### DIFF
--- a/README.md
+++ b/README.md
@@ -68,8 +68,13 @@ Ver `docs/plan_01_subsystem1.md` §3.1 para el detalle del clasificador.
 | Subsistema | Estado | Plan |
 |---|---|---|
 | S1 – Retroactive | 🟢 Funcional end-to-end (Stages 01-06 + `run-all` + `status` + Docker + setup docs). Taxonomía pendiente de customizar por cada investigador antes de aplicar tags reales. | `docs/plan_01_subsystem1.md` |
-| S3 – MCP access | 🟡 Spec, pendiente implementación ([#11](https://github.com/igalkej/auto_zotero/issues/11)) | `docs/plan_03_subsystem3.md` |
 | S2 – Prospective | 🟡 Spec, pendiente implementación ([#12](https://github.com/igalkej/auto_zotero/issues/12)–[#15](https://github.com/igalkej/auto_zotero/issues/15)) | `docs/plan_02_subsystem2.md` |
+| S3 – MCP access | 🟡 Spec, pendiente implementación ([#11](https://github.com/igalkej/auto_zotero/issues/11)) | `docs/plan_03_subsystem3.md` |
+
+Orden de implementación (plan_00 §4): **S1 → S2 → S3**. S2 es owner del
+índice de embeddings (ADR 015); S3 es lector puro y arranca a darle
+valor al modo descubrimiento una vez que el primer `zotai s2
+backfill-index` haya corrido.
 
 ---
 

--- a/docs/plan_00_overview.md
+++ b/docs/plan_00_overview.md
@@ -83,7 +83,7 @@ Cada una con ADR correspondiente en `docs/decisions/`.
 | 004 | OpenAI text-embedding-3-large | Corpus mix es/en requiere embedder multilingual. Default de zotero-mcp (MiniLM) degrada 20+ puntos en queries en español. |
 | 005 | gpt-4o-mini para tagging/extracción | Calidad suficiente, $0.00042/paper. $2 para toda la biblioteca. |
 | 006 | zotero-mcp (54yyyu) para S3 | Existe, estable, cubre los 3 modos out-of-the-box. Build propio no justificado. |
-| 007 | FastAPI + HTMX para dashboard S2 | HTMX evita SPA, renderizado server-side, más simple de mantener. Un único investigador hace cambios. |
+| 007 | FastAPI + HTMX para dashboard S2 _(pendiente — ver [#12](https://github.com/igalkej/auto_zotero/issues/12))_ | HTMX evita SPA, renderizado server-side, más simple de mantener. Un único investigador hace cambios. ADR escrito como entregable de S2 Sprint 1. |
 | 008 | Cuarentena en S1 en vez de "todo o nada" | Resuelve tensión completitud vs calidad. Lo dudoso queda accesible pero marcado. |
 | 009 | zotero-mcp usado por S3 **pero no por S1/S2** | S1/S2 usan la API de Zotero directa (pyzotero). MCP es para consumo conversacional. **Parcialmente superseded por ADR 015** en lo que hace al ChromaDB: S2 ahora también escribe directo al índice (sin pasar por `zotero-mcp update-db`), aunque sigue usando pyzotero para Zotero. |
 | 010 | Ruta A usa OpenAlex para DOI → metadata (no el translator de Zotero) | Translator de Zotero es API no pública / frágil entre versiones. OpenAlex cubre >98% DOIs académicos con API estable. |

--- a/docs/plan_03_subsystem3.md
+++ b/docs/plan_03_subsystem3.md
@@ -253,9 +253,22 @@ Bajo **ADR 015**, la dirección de la integración se invierte respecto a versio
 
 ## 11. Orden de ejecución en contexto del proyecto
 
-Este subsistema se implementa **después del S1**, **antes del S2**.
+Bajo **ADR 015** el orden de valor entregado es **S1 → S2 → S3** (ver
+plan_00 §4). S2 es owner del índice de embeddings; S3 (`zotero-mcp
+serve`) es lector puro.
 
 Razones:
-- Requiere biblioteca poblada (S1).
-- Es el primer punto donde el usuario experimenta valor del producto (cierra MVP).
-- Su ChromaDB es usada por el S2, por lo que debe estar operativo antes de que el S2 dependa de ella.
+- Requiere biblioteca Zotero poblada (S1).
+- Requiere ChromaDB poblada — la primer vez con `zotai s2 backfill-index`
+  (S2 Sprint 1, issue #12). Antes de eso `zotero_semantic_search` retorna
+  vacío. El setup de Claude Desktop / `zotero-mcp` funciona igual, sólo
+  el modo descubrimiento queda degradado.
+- Setup ligero (~0.5d, mayormente docs y config) — el código propio del
+  subsistema es nulo, la complejidad está en `zotero-mcp` upstream.
+
+**Paralelización**. Las issues #11 (S3 docs) y #12 (S2 Sprint 1) no
+tienen dependencia técnica entre sí: S3 sólo necesita la biblioteca de
+S1, y S2 no necesita el MCP server configurado. Si conviene
+operativamente, los entregables de S3 (docs + scripts) pueden
+empaquetarse en paralelo con S2 Sprint 1; el orden lineal **S1 → S2 →
+S3** sigue siendo el orden de valor entregado al usuario.


### PR DESCRIPTION
## Summary

Surfaces three small text inconsistencies found during a status-review
pass; all predate ADR 015 (S2 owns the embeddings index, S3 is a pure
reader) and only need text fixes — no code change, no ADR.

- **`docs/plan_03_subsystem3.md` §11** — said *"S3 implements **before**
  S2"* with the rationale *"its ChromaDB is used by S2"*. Both inverted
  under ADR 015. Rewrites §11 to match plan_00 §4 (`S1 → S2 → S3`),
  notes that #11 (S3 docs) and #12 (S2 Sprint 1) have no technical
  dependency, and clarifies that `zotero_semantic_search` returns
  empty until the first `zotai s2 backfill-index` runs.
- **`README.md` "Estado del proyecto"** — swaps the S2 / S3 rows so the
  table reads in implementation order, plus a one-paragraph pointer to
  plan_00 §4 + ADR 015.
- **`docs/plan_00_overview.md` §5 ADR 007 row** — marks "_pendiente —
  ver #12_". The ADR file does not exist yet; it lands as a Sprint 1
  deliverable per the #12 acceptance criteria, and the forward
  declaration was drifting from `docs/decisions/`.

## Why now

Cheap cleanup before opening the larger S2 Sprint 1 PR — keeps the
diff there focused on code without bundling docs fixes. Same scope
discipline as PRs #58 and #41.

## Test plan

- [x] `git diff` — only the three text changes intended.
- [x] Cross-references resolve: plan_03 §11 now matches plan_00 §4 +
      plan_03 §8 + ADR 015 §3 / §6.
- [x] No code touched, no test impact.

Co-authored-by: Claude Opus 4.7 (1M context) <noreply@anthropic.com>