### PR TITLE
docs(adr): add 020/021/022 — citation graph + refs cascade + metadata-only push

### DIFF
--- a/docs/decisions/020-s2-owns-citation-graph.md
+++ b/docs/decisions/020-s2-owns-citation-graph.md
@@ -1,0 +1,260 @@
+# ADR 020 — S2 es owner del grafo de citas de la biblioteca
+
+**Status**: Accepted
+**Date**: 2026-04-28
+**Deciders**: project owner
+**Related**: ADR 015 (S2 owna ChromaDB), ADR 016 (RRF composite), ADR 017 (hybrid retrieval), plan_02 §5, §7, §11.
+**Spawns**: ADR 021 (cascade de captura de refs), ADR 022 (metadata-only push).
+
+---
+
+## 1. Contexto
+
+Cada paper en la biblioteca tiene información estructural que el sistema hoy descarta: su bibliografía. Esa información está disponible gratuitamente en OpenAlex (`referenced_works`) y, para casos no cubiertos, vía HTML scraping de la página del artículo (especialmente OJS / SciELO en LATAM — ver ADR 021). Ignorarla deja sobre la mesa tres ejes de valor:
+
+- **Discovery de papers ausentes muy citados por el corpus**. Un DOI que aparece citado por k≥2 papers de mi biblioteca y no está en ella = un anchor del campo que no tengo. Hoy es invisible.
+- **Scoring por overlap bibliográfico** para candidates de S2. Particularmente importante cuando la señal semántica es débil: papers paywalled con abstract genérico, papers en humanidades / LATAM con metadata escasa, o papers que aplican ideas viejas a problemas nuevos (taxonomía distinta, bibliografía compartida). Hoy `score_composite` depende de tags + semantic + queries; las tres degradan en esos casos.
+- **Persistencia útil de items no-OA**. ADR 022 establece que items metadata-only son ciudadanos de primera clase. Sin grafo de citas son agujeros informativos; con grafo, contribuyen su bibliografía a la cobertura del usuario aun sin PDF.
+
+La pregunta arquitectónica es quién owna ese grafo. Bajo el contrato de plan_00 §3 ("no hay DB compartida entre S1 y S2; comunicación sólo via Zotero"), refs son un derivado del corpus que cualquier subsistema podría capturar. Las opciones:
+
+- **S1 captura refs en Etapa 04 enrichment, las escribe a `state.db`, S2 lee desde ahí**. Más eficiente (una sola llamada a OpenAlex). Viola el contrato.
+- **DB nueva (`references.db`) con su propio módulo**. Mantiene cleanness pero suma una tercera SQLite y owner ambiguo.
+- **S2 captura, persiste en `candidates.db`, mantiene el invariante por reconciliación** (mismo patrón ADR 015). Respeta el contrato. Cuesta una duplicación de calls a OpenAlex (gratis) que se asume con un comentario explícito.
+
+Este ADR adopta la tercera opción.
+
+## 2. Decisión
+
+**S2 es owner del grafo de citas de la biblioteca, en `candidates.db`. S1 no captura refs.**
+
+Concretamente:
+
+- S2 mantiene el invariante: para todo paper en Zotero (no cuarentenado), existen refs persistidas en la tabla `Reference` indexadas por `zotero_item_key`.
+- El invariante se preserva por **reconciliación por diff**, paralelo al de embeddings (ADR 015):
+
+  ```
+  zotero_keys := { items en Zotero, no cuarentenados }
+  refs_keys   := { citing_zotero_key DISTINCT FROM Reference }
+
+  to_fetch  := zotero_keys − refs_keys
+  to_remove := refs_keys − zotero_keys
+
+  Para cada key en to_fetch (limitado a S2_MAX_REFS_FETCH_PER_CYCLE):
+      doi := zotero.get_doi(key)
+      refs := refs_cascade.fetch(doi, landing_url)   # ADR 021
+      Reference.upsert_many(citing_zotero_key=key, refs=refs)
+      ExternalPaper.upsert_many(refs cuyo cited_doi ∉ zotero_dois)
+
+  Si |to_remove| / |refs_keys| ≤ S2_SAFE_DELETE_RATIO:
+      Reference.delete(citing_zotero_key in to_remove)
+  Else:
+      log WARNING, no borrar, requerir intervención
+  ```
+
+- El primer poblado se expone como comando explícito `zotai s2 backfill-references`, con su propio budget cap. No es un caso especial de código — es el mismo código de reconciliación, expuesto como comando para que el usuario lo dispare intencionalmente la primera vez.
+- Reconcile de refs corre como **step 0.5** del worker, inmediatamente después del reconcile de embeddings (que es step 0 bajo ADR 015). Ambos reusan la misma enumeración de `zotero_keys`.
+
+### 2.1 Tablas nuevas en `candidates.db`
+
+```python
+class Reference(SQLModel, table=True):
+    """Una arista del grafo de citas: paper_X cita paper_Y."""
+
+    id: int | None = Field(default=None, primary_key=True)
+    citing_zotero_key: str = Field(index=True)            # 8 chars, FK lógica a Zotero
+    cited_doi: str | None = Field(default=None, index=True)
+    cited_openalex_id: str | None = None
+    cited_text: str | None = None                         # cita libre cuando no hay DOI
+    source_api: str                                       # ver ADR 021 §2
+    fetched_at: datetime = Field(sa_type=UTCDateTime)
+
+
+class ExternalPaper(SQLModel, table=True):
+    """Cache de metadata de DOIs ausentes en Zotero pero citados por papers en él.
+
+    Habilita la bandeja /classics sin re-llamar a OpenAlex en cada render.
+    """
+
+    doi: str = Field(primary_key=True)
+    openalex_id: str | None = None
+    title: str
+    authors_json: str
+    year: int | None = None
+    venue: str | None = None
+    abstract: str | None = None
+    cited_by_count: int = 0
+    last_seen_at: datetime = Field(sa_type=UTCDateTime)
+```
+
+`Reference.cited_doi` y `cited_text` son ambos nullable: pueden coexistir (cita resuelta con texto crudo de respaldo) o sólo uno (cita sin DOI conocido se persiste como `cited_text` libre, ver §2.5). `cited_openalex_id` queda redundante con `cited_doi` para hits de OpenAlex pero permite resolver cited works que aún no tienen DOI registrado en OpenAlex.
+
+### 2.2 Cambios en `Candidate`
+
+`Candidate.source_feed_id` se vuelve **nullable** y se agrega `source_kind` enum:
+
+- `'rss'` — captado por feed RSS (default actual; `source_feed_id` requerido).
+- `'reference_mining'` — sugerido por el sistema desde el grafo de citas (escenario "discovery de classics ausentes"; `source_feed_id` null).
+
+```python
+class Candidate(SQLModel, table=True):
+    # ... campos existentes ...
+    source_feed_id: str | None = Field(default=None, foreign_key="feed.id")
+    source_kind: str = "rss"   # 'rss' | 'reference_mining'
+
+    score_refs: float = 0.0    # nuevo, ver §2.4
+```
+
+### 2.3 Comando explícito y reconcile en worker
+
+- **`zotai s2 backfill-references`**: idempotente, recorre `zotero_keys − refs_keys`, llama la cascade de captura (ADR 021), persiste a `Reference` y `ExternalPaper`. Budget cap: `S2_MAX_COST_USD_BACKFILL_REFS` (default `0` — OpenAlex es gratis; reservado para que futuras fuentes con costo no requieran cambio de schema). Progress bar y mensajes al usuario equivalentes al `backfill-index` de ADR 015.
+- **`zotai s2 reconcile-references`**: lo mismo, sin RSS fetch — para debugging.
+- En el worker (`run_fetch_cycle()`): step 0 reconcile-embeddings (ADR 015), step 0.5 reconcile-references (este ADR), step 1+ resto del ciclo (RSS fetch + scoring + persist).
+
+### 2.4 `score_refs` como cuarta señal del composite
+
+Se agrega `score_refs ∈ [0,1]` a `Candidate`, computado al momento del scoring (post-fetch RSS / post-discovery):
+
+```
+score_refs(c) = |refs(c) ∩ zotero_dois| / |refs(c)|
+```
+
+donde `refs(c)` se obtiene aplicando la cascade ADR 021 al DOI del candidate, y `zotero_dois` es el conjunto de DOIs presentes en Zotero (cacheado al ciclo del worker).
+
+**Si `|refs(c)| = 0`** (cobertura combinada cero), el score se **omite del RRF** (ADR 016) en lugar de penalizar. No podemos puntuar a falta de información; RRF naturalmente integra las tres señales restantes con la convención `rank = ∞ ⇒ contribution = 0`.
+
+**Coupling intra-corpus** (similitud entre dos papers de Zotero por refs compartidas) queda implícito en el grafo y no se materializa en v1. Si se quiere usar para validación de tags o detección de duplicados temáticos, basta con queries SQL sobre `Reference`.
+
+### 2.5 Refs sin DOI
+
+Cuando un parser identifica una cita pero no logra resolverla a DOI (libros viejos, working papers, tesis, fuentes primarias), se persiste con `cited_doi=null` y `cited_text` con el texto crudo de la cita. Estos no contribuyen a `score_refs` (no se intersecta contra `cited_text`), pero son auditables y pueden fuzz-matchearse contra `zotero_dois` por título en una pasada futura. Detalle de captura en ADR 021.
+
+### 2.6 No persistimos `cited_by`
+
+OpenAlex también expone `cited_by_api_url` (paginable). Se decide **no persistir** este lado del grafo en v1: los datos cambian rápido (un paper recién publicado puede ser citado en semanas), persistirlo invita a que se desactualice, y los casos de uso identificados (overlap, scoring, discovery de classics) no lo requieren — todos se resuelven con el lado saliente.
+
+`cited_by` queda como consulta on-demand cuando aparezca una feature que lo justifique (por ejemplo: bandeja "papers que citan a tus papers").
+
+## 3. Consecuencias
+
+### 3.1 Positivas
+
+- **Nueva señal ortogonal de scoring**. `score_refs` es estructural (un paper cita o no cita), no falseable por palabras. Particularmente fuerte donde el resto degrada: humanidades, LATAM, paywalled.
+- **Bandeja /classics habilitada**. Discovery de papers altamente citados ausentes en Zotero queda como bandeja del dashboard (ver plan_02 §8.3 post este ADR). Misma máquina de triage que candidates RSS, distinta fuente.
+- **Coherencia con ADR 015**. Mismo subsistema, mismo patrón de reconciliación, mismo modelo de auto-curación. S2 ahora maneja dos derivados del corpus (embeddings + refs).
+- **Auto-curación uniforme**. Si `Reference` se borra, el siguiente ciclo la repuebla. Sin estado externo a Zotero.
+- **Items metadata-only ganan utilidad**. La decisión de ADR 022 (aceptar items no-OA como ciudadanos de primera clase) sólo es útil si esos items aportan algo. Refs son lo que aportan.
+
+### 3.2 Negativas / costos asumidos
+
+- **Duplicación de calls a OpenAlex**. S1 Etapa 04 ya llama a OpenAlex por DOI para metadata. S2 backfill-references re-llama por los mismos DOIs para refs. Costo: ~5-10 min de calls extra para 1000 papers, $0 USD (OpenAlex es gratis, polite pool 10 req/s). El contrato S1/S2 disjuntas justifica la duplicación: no introducir DB compartida ni dependencia inter-subsistema. Mitigación cosmética (no operacional): cliente compartido `fetch_work_with_refs(doi)` en `api/openalex.py` reusable por ambos.
+- **`candidates.db` crece**. Para 1000 papers × ~30 refs promedio = ~30k filas en `Reference`, ~5-10k DOIs únicos en `ExternalPaper`. Trivial para SQLite.
+- **Captura no es uniforme**. OpenAlex cubre ~85-95% de journals modernos pero cae para LATAM/SciELO. ADR 021 cubre el gap con HTML scraping. Mitigación: experimento I1 (§5 de este ADR) antes de mergear el sprint que implementa.
+- **`Candidate` ahora tiene un campo más** y `source_feed_id` se vuelve nullable. Migración de schema en `candidates.db` cuando aterrice Sprint 5.
+
+### 3.3 Neutras
+
+- No cambia el modelo de embeddings (ADR 004) ni el ownership de ChromaDB (ADR 015). Sólo agrega una cuarta dimensión al scoring.
+- S3 (MCP) no se afecta. El servidor `zotero-mcp serve` no consulta refs; opera sobre Zotero + ChromaDB sólo.
+- ADR 016 (RRF) no se modifica: la cuarta señal se integra naturalmente vía la convención de "rank infinito ⇒ contribución 0".
+
+## 4. Alternativas consideradas y descartadas
+
+**A. S1 captura refs en Etapa 04, las escribe a `state.db`, S2 lee desde ahí.**
+Más eficiente (una sola call a OpenAlex). Descartada: viola el contrato plan_00 §3 sin una ganancia operacional clara. La duplicación de calls es ~5 min que se pagan una sola vez (backfill); los reconciles incrementales son <30 segundos.
+
+**B. Cliente HTTP compartido `fetch_work_with_refs(doi)` que ambos subsistemas usan; cada uno persiste a su DB.**
+Refactor cosmético: las HTTP calls siguen duplicadas porque OpenAlex no tiene cache compartida. Adoptado en términos de buena práctica de código (un único cliente OpenAlex en `api/openalex.py`) pero no resuelve el "costo" — sólo limpia ergonomía.
+
+**C. Refs como blob JSON en `metadata_json` de `Item` o `Candidate`.**
+Imposible queries de overlap eficientes (overlap en SQL requiere relación normalizada). Descartada.
+
+**D. Reference graph como tercera DB (`references.db`).**
+Ortogonal al diseño plan_02 §5. Descartada por complejidad: una tabla en `candidates.db` alcanza, owner es S2, no hace falta un tercer SQLite con su propio engine y migrations.
+
+**E. Captura on-demand cuando aparece un candidate (sin backfill).**
+Imposible computar overlap sin tener refs del corpus completo (`zotero_dois` es el lado lento del intersect). Descartada.
+
+**F. Persistir también `cited_by` (citas hacia atrás).**
+Descartada para v1 por motivos de §2.6.
+
+## 5. Validación empírica antes de cerrar implementación
+
+Antes de mergear el Sprint 5 que implementa este ADR, ejecutar el experimento **I1** (cobertura combinada de fuentes):
+
+1. Tomar 50-100 DOIs random de la biblioteca Zotero del usuario (post-S1 corrida real).
+2. Para cada DOI: llamar OpenAlex; si `|referenced_works| = 0`, intentar HTML scraping (cascade ADR 021).
+3. Reportar:
+   - % de papers con refs ≥1 (cobertura combinada).
+   - Distribución de `len(refs)`.
+   - % de refs intra-corpus (papers cuyas refs caen en otros DOIs de la misma biblioteca — proxy de `score_refs` no degenerado).
+   - Breakdown por venue / publisher (para identificar cuál fuente hace el peso).
+
+**Gate**:
+- Si cobertura combinada **≥ 80%** y % intra-corpus **≥ 5%**, este ADR queda firme.
+- Si cobertura combinada **< 60%**, reabrir decisión sobre PDF parsing en ADR 021.
+- Si **60% ≤ cobertura < 80%**, este ADR sigue en pie pero `score_refs` se considera señal complementaria, no central; el composite RRF lo absorbe naturalmente.
+
+Mientras el experimento no se haya corrido, este ADR procede con el **supuesto** explícito de cobertura aceptable basado en la prevalencia de OpenAlex en journals modernos. El supuesto se verifica antes del primer merge de código, no del merge de docs.
+
+## 6. Cambios requeridos en documentos existentes
+
+- `docs/plan_02_subsystem2.md`:
+  - §5 (modelo de datos): agregar tablas `Reference`, `ExternalPaper`. Agregar campos `source_kind`, `score_refs` en `Candidate`.
+  - §7 (scoring): nueva subsección §7.4 "Score por refs (4ta señal del RRF)".
+  - §8 (dashboard): nueva subsección §8.3 "Bandeja /classics".
+  - §9 (worker): agregar reconcile-references como step 0.5.
+  - §11 (sprints): agregar Sprint 5 "Citation graph + bandeja classics + metadata-only push".
+- `docs/plan_00_overview.md`:
+  - §3 (diagrama): S2 ahora maneja dos stores derivados (ChromaDB + Reference graph).
+  - §5 (tabla ADRs): agregar filas 020, 021, 022.
+- `docs/plan_01_subsystem1.md`:
+  - §10 (fuera de alcance): explicitar "captura de refs no es responsabilidad de S1; S2 lo maneja (ver ADR 020)".
+- `docs/plan_03_subsystem3.md`:
+  - §X (donde corresponda): confirmación explícita de que items metadata-only se indexan via la cascade existente de ADR 015 (`s2_abstract` / `s2_title_only`); no requiere cambios al schema ChromaDB.
+- `docs/plan_glossary.md`: entradas para "citation graph", "anchor papers", "reference mining", "bandeja /classics".
+- `CLAUDE.md` §"Contratos entre subsistemas": agregar segundo store derivado owned por S2.
+- `README.md`:
+  - §"Cómo queda tu biblioteca Zotero": mencionar tags `metadata-only`, `discovered-via-refs` (definidos en ADR 022).
+  - §"Estado del proyecto": agregar Sprint 5 a la tabla de S2.
+- `.env.example`: agregar `S2_MAX_COST_USD_BACKFILL_REFS`, `S2_MAX_REFS_FETCH_PER_CYCLE`, `S2_SAFE_DELETE_RATIO_REFS`, `S2_REFS_FETCH_TIMEOUT_SECONDS`. (Las variables específicas de la cascade van en ADR 021.)
+
+Estos cambios se aplican en un PR derivado, separado de este (regla CLAUDE.md "Si Claude Code propone un cambio al plan, hacerlo en PR separado de la implementación").
+
+## 7. Presupuesto y métricas
+
+### 7.1 Impacto en budgets
+
+- **Backfill inicial** (`zotai s2 backfill-references`): ~1000 calls OpenAlex (gratis, polite pool) ≈ 5-10 min wall-clock. Si HTML scraping se activa para los misses: ~50-150 calls HTTP adicionales, mismo orden de magnitud, igual gratis.
+- **Reconcile incremental** (paso 0.5 del worker): ~10-30 calls por ciclo (papers nuevos en Zotero desde el ciclo anterior), <30 segundos.
+- **PDF parsing**: opt-in detrás de flag (ADR 021 §2). Default off; cuando se active, costo en CPU/tiempo no en USD.
+
+`S2_MAX_COST_USD_BACKFILL_REFS` se introduce con default `0.00`. Existe como slot por si una fuente futura agrega costo (ej. Crossref+ con tier pago, scrapers con rotating proxy).
+
+### 7.2 Métricas a exponer en `/metrics`
+
+- `refs_total_edges`: tamaño de `Reference`.
+- `refs_papers_indexed`: `COUNT(DISTINCT citing_zotero_key)`.
+- `refs_external_papers_cached`: tamaño de `ExternalPaper`.
+- `refs_coverage_ratio`: `refs_papers_indexed / |zotero_keys|`.
+- `refs_pending`: `|zotero_keys − refs_keys|`.
+- `refs_orphans`: `|refs_keys − zotero_keys|`.
+- `refs_last_reconcile_at`.
+- Breakdown de `source_api` (cuántas refs vienen de openalex / ojs_html / scielo_html / generic_html / pdf).
+
+## 8. Follow-ups
+
+- Si I1 muestra cobertura <60%, reabrir decisión PDF parsing (ADR 021 §3 / §8).
+- Si después de 3 meses se observa que `score_refs` domina injustamente sobre las otras señales (RRF se vuelve casi-determinístico por refs), recalibrar pesos en `config/scoring.yaml` o agregar normalización por `cited_by_count_globally` para descontar la importancia bruta del paper citado.
+- Coupling intra-corpus (sim A↔B por refs compartidas) queda implícito. Si más adelante se quiere herramienta de "audit de taxonomía" o "detección de duplicados temáticos", materializar tabla `BibliographicCoupling` en una versión sucesora.
+- Considerar persistir `cited_by` cuando una bandeja "papers que citan a tus papers" se vuelva una feature deseada (forward reference network, complementaria a la backward que este ADR habilita).
+- Si la bandeja /classics produce demasiado ruido en uso real (k=2 default genera N>1000 entries), subir k o agregar normalización por subárea (clusters por embeddings o por venue).
+
+## 9. Relación con ADRs previos
+
+- **ADR 015** (S2 owna ChromaDB): este ADR es el análogo para refs. Mismo subsistema, mismo patrón, mismo modelo de reconciliación. Conceptualmente, "S2 owna los derivados estructurales del corpus" cubre ambos.
+- **ADR 016** (RRF default para `score_composite`): `score_refs` se integra naturalmente como cuarta dimensión. Ningún cambio al ADR 016.
+- **ADR 017** (hybrid BM25+dense para `score_queries`): independiente. Persistent queries no se afectan.
+- **ADR 018/019** (SciELO + DOAJ substages en S1 Stage 04): SciELO queda como **fuente potencial de refs vía HTML scraping** en ADR 021, no como cliente de metadata bibliográfica adicional. Sin conflicto: el cliente Crossref Member 530 de ADR 019 sigue siendo el path para metadata; el parser HTML de ADR 021 es path para refs.
+- **ADR 014** (skip attach if existing PDF): independiente. Refs vienen de OpenAlex/HTML, no del PDF en Zotero.
+- **ADR 022** (metadata-only push): este ADR provee la motivación operacional para 022 (items metadata-only sólo son útiles si aportan refs).

--- a/docs/decisions/021-refs-collection-cascade.md
+++ b/docs/decisions/021-refs-collection-cascade.md
@@ -1,0 +1,178 @@
+# ADR 021 — Cascade de captura de refs: OpenAlex → HTML scraping → PDF (opcional)
+
+**Status**: Accepted
+**Date**: 2026-04-28
+**Deciders**: project owner
+**Related**: ADR 020 (S2 owna citation graph), ADR 018/019 (SciELO + DOAJ substages en Stage 04 S1).
+
+---
+
+## 1. Contexto
+
+ADR 020 establece que S2 captura el grafo de citas. La pregunta de implementación es: **¿de dónde se obtienen las refs de cada paper?**
+
+Tres fuentes con perfiles distintos:
+
+- **OpenAlex** (`referenced_works` en el endpoint `/works/{doi}`). Cobertura ~85-95% para journals modernos anglo. Cae para humanidades, papers <2000, y journals LATAM/SciELO que no depositan refs en Crossref. Gratis, polite pool 10 req/s con header `User-Agent` que incluye email (ya integrado en `api/openalex.py`).
+- **HTML scraping** del landing page del artículo. La mayoría de revistas LATAM corren OJS (Public Knowledge Project) y exponen refs directo en HTML — por ejemplo, https://sociedadeconomiacritica.org/ojs/index.php/cec/article/view/377 muestra refs como `<ol>` legible con un parser sencillo. Mismo caso para SciELO HTML view. Esfuerzo modesto (un parser por plataforma + fallback genérico). Gratis.
+- **PDF parsing** (anystyle, GROBID, refextract). Fiable pero costoso: GROBID requiere service Java aparte; anystyle es Ruby-only; refextract es Python pero lento (~5-10s por PDF). Sólo justificable si las dos fuentes anteriores fallan sistemáticamente.
+
+La decisión de fondo es priorizar el costo cero (OpenAlex + HTML) y dejar PDF parsing como backup contingente en una decisión sucesora si los datos lo piden.
+
+## 2. Decisión
+
+**Cascade de fuentes en orden, primer hit gana**:
+
+1. **OpenAlex** `referenced_works` vía `api/openalex.py` (ya integrado).
+2. **HTML scraping** del landing page del artículo:
+   - **OJS** (PKP-based, dominante en LATAM): parser dedicado para la estructura `<ol class="references">` o `<div class="references">` típica de OJS.
+   - **SciELO** (HTML view distinto de OJS): parser dedicado.
+   - **Genérico** (fallback): heurística sobre JSON-LD `@type=ScholarlyArticle.citation` + listas `<ol>` / `<ul>` con tag `references` / `bibliography`.
+3. **PDF parsing**: opt-in detrás de `S2_REFS_PDF_PARSING_ENABLED=true`, default `false`. **No se implementa en v1**; el flag existe para que un sprint sucesor agregue la integración (con su propio ADR para elegir motor) sin romper este contrato.
+
+Cada nivel reporta `source_api` para auditabilidad: `'openalex'` | `'ojs_html'` | `'scielo_html'` | `'generic_html'` | `'pdf'`. El campo se persiste en `Reference.source_api` (ADR 020 §2.1).
+
+### 2.1 Mecánica del cascade
+
+```python
+def fetch_refs(doi: str, landing_url: str | None) -> list[ParsedRef]:
+    """Cascade de captura. Primer nivel con resultado no vacío gana."""
+
+    if refs := openalex.fetch_refs(doi):
+        return refs   # source_api='openalex'
+
+    if not landing_url:
+        landing_url = openalex.get_landing_url(doi)   # best-effort
+
+    if landing_url and settings.s2_refs_scraping_enabled:
+        if refs := scrape_html(landing_url):
+            return refs   # source_api inferido por parser que matcheó
+
+    if settings.s2_refs_pdf_parsing_enabled:
+        if pdf := zotero.get_attachment_path(doi):
+            return parse_pdf_refs(pdf)   # source_api='pdf'
+
+    return []   # no hay refs disponibles; ADR 020 §2.4 maneja el caso
+```
+
+**Idempotencia**: cada nivel devuelve `[]` si no aplica, nunca raise. Errores de red en un nivel se loguean con `structlog` y no bloquean el siguiente. El logger registra el path tomado y el tiempo por nivel para análisis posterior y para que el `/metrics` (ADR 020 §7.2) pueda exponer la distribución.
+
+**Timeouts**: cada llamada HTTP respeta `S2_REFS_FETCH_TIMEOUT_SECONDS` (default 15). Un nivel que timeoutea cuenta como falla y pasa al siguiente.
+
+### 2.2 HTML scraping: alcance v1
+
+Tres parsers, aislados en `src/zotai/api/refs_scrapers/`:
+
+- **`ojs.py`**. Estructura PKP estándar. Detecta vía URL pattern (`/ojs/`, `/article/view/`) o vía meta tag `generator=Open Journal Systems`. Cobertura estimada: 80%+ de revistas LATAM en OJS.
+- **`scielo.py`**. Detecta vía URL host (`.scielo.org`, `.scielo.br`, mirrors). HTML view de SciELO tiene su propio layout distinto al PDF view.
+- **`generic.py`**. Best-effort sobre JSON-LD + heurística DOM. Si nada matchea, devuelve `[]`.
+
+Cada parser está aislado para que agregar uno nuevo (ej. `redalyc.py` si I1 lo justifica) no afecte los existentes. Tests con **fixtures HTML capturadas (snapshot)** — no live network en tests, no flakiness.
+
+### 2.3 Refs sin DOI
+
+Cuando un parser identifica una cita pero no logra resolverla a DOI (libros viejos, working papers, tesis, fuentes primarias):
+
+- Se persiste con `cited_doi=null` y `cited_text` con el texto crudo de la cita (typically la string completa del item en la `<ol>`).
+- Estos no contribuyen a `score_refs` (no podés intersectar contra `cited_text`), pero quedan auditables.
+- Pasada futura puede fuzz-matchear `cited_text` contra títulos en Zotero o `ExternalPaper` para resolver retroactivamente.
+
+OpenAlex resuelve refs a OpenAlex IDs (mapeables a DOI cuando existe). HTML scrapers extraen DOI cuando lo encuentran explícito en el item de la lista; cuando no, dejan `cited_text`.
+
+### 2.4 Variables de configuración
+
+Nuevas en `.env.example`:
+
+```bash
+# ── S2 refs collection (ADR 021) ────────────────────────────
+S2_REFS_SCRAPING_ENABLED=true        # apaga HTML scraping si querés sólo OpenAlex
+S2_REFS_PDF_PARSING_ENABLED=false    # opt-in (no implementado en v1, slot reservado)
+S2_REFS_FETCH_TIMEOUT_SECONDS=15     # timeout por fuente
+```
+
+## 3. Consecuencias
+
+### 3.1 Positivas
+
+- **Cobertura LATAM ampliada**. OpenAlex + HTML cubre >90% en corpora mixtos (expectativa pre-I1). Resuelve el gap principal del scoring por refs en corpora CONICET / humanidades / ciencias sociales LATAM.
+- **Costo cero adicional**. Las tres fuentes no-PDF son gratis. PDF queda detrás de flag y de un ADR sucesor.
+- **Modular**. Agregar plataforma N+1 es un archivo nuevo en `refs_scrapers/`, sin tocar lógica existente. No requiere ADR salvo que cambie el orden de la cascade.
+- **Auditable**. `source_api` en `Reference` permite al usuario / al desarrollador ver de dónde vino cada arista. Fundamental para el follow-up "qué fuentes son las que más rinden en mi corpus".
+- **Fail-soft uniforme**. Cada nivel falla sin romper el siguiente, ni el ciclo del worker.
+
+### 3.2 Negativas
+
+- **Fragility de scrapers**. Cambios de DOM en OJS/SciELO rompen el parser. Mitigación: tests con snapshots de HTML real; falla del parser devuelve `[]` y la cascade sigue. La fragility se monitorea vía la métrica `refs_source_api_breakdown` — caída brusca de `ojs_html` cuenta es señal.
+- **Cobertura no garantizada en v1**. El experimento I1 (en ADR 020 §5) valida empíricamente. Si el experimento contradice la asunción de cobertura ≥80%, se reabre la decisión sobre PDF parsing.
+- **Sin PDF parsing en v1**. Es deliberado, pero significa que cierto residual queda sin captura (papers viejos digitalizados sin OpenAlex ni HTML accesible). El residual se mide en I1; si es <20%, se acepta.
+- **Per-platform parsers son trabajo continuo**. Cada agregado nuevo (REDIB, RedALyC, La Referencia si aplica — ver issue #46) es un archivo más. Aceptable: cada parser <100 líneas con tests.
+
+### 3.3 Neutras
+
+- No cambia ADR 020. Sólo formaliza cómo se captan las refs que ADR 020 promete.
+- No conflictúa con ADR 018/019: el cliente SciELO de ADR 019 (Crossref Member 530) sigue siendo el path para metadata bibliográfica del candidato; el parser SciELO HTML de este ADR es path para refs salientes. Son módulos distintos con responsabilidades distintas.
+
+## 4. Alternativas consideradas y descartadas
+
+**A. PDF parsing como fuente primaria.**
+Costoso (GROBID dep, ~5-10s/PDF, service Java aparte). Innecesario si OpenAlex+HTML cubren ≥80%. Descartado para v1.
+
+**B. Sólo OpenAlex.**
+Asumir que OpenAlex alcanza. Descartado: corpora LATAM dejarían refs no capturadas sistemáticamente y el escenario 2 de la discusión inicial (papers no-OA con bibliografía como señal estructural) quedaría sin sustento.
+
+**C. Crossref directo como segundo nivel** (antes que HTML).
+A veces tiene refs cuando OpenAlex aún no las indexó (delay típico de 2-4 semanas). Descartado para v1: el delay es chico relativo al ciclo del worker (días/semanas), y agregar un cliente más es overhead. Reconsiderable si I1 muestra que es un gap real.
+
+**D. Per-publisher API clients en lugar de HTML scraping.**
+Algunos publishers exponen API de refs (Elsevier, Springer). Descartado por: (1) requieren credenciales/keys que el usuario no tiene; (2) cobertura LATAM nula; (3) no agregan sobre lo que OpenAlex ya tiene para esos casos.
+
+**E. Una sola fuente con merge** (consultar todas, deduplicar, persistir todas las refs).
+Más completo pero re-llama a OpenAlex/HTML cuando ya tenemos resultado. Descartado para v1 por costo. La cascade "primer hit gana" es estrictamente más barata; si una fuente da incompleto (parser HTML pierde 2 refs de 30), el incremento marginal no justifica el costo. Reconsiderable si I1 muestra gaps específicos.
+
+## 5. Validación empírica
+
+Misma I1 que ADR 020 §5. La cascade se valida en bloque: si la combinación OpenAlex+HTML da cobertura combinada **≥80%** y % intra-corpus **≥5%**, este ADR queda firme.
+
+Si cobertura **<60%**, reabrir decisión sobre PDF parsing (potencialmente con ADR sucesor que elija motor: anystyle vs GROBID vs refextract, con pros/contras de instalación y precisión).
+
+Si **60% ≤ cobertura < 80%**, este ADR sigue en pie; el deficit residual se documenta como limitación conocida hasta que el corpus crezca o aparezca demanda de agregar PDF parsing.
+
+## 6. Cambios requeridos en documentos existentes
+
+- `docs/plan_02_subsystem2.md` §5 (modelo de datos): mencionar `Reference.source_api` y los valores legales (referenciar este ADR §2).
+- `docs/plan_02_subsystem2.md` §11 (Sprint 5): la captura de refs se implementa según la cascade de este ADR.
+- `.env.example`: agregar las tres variables del §2.4.
+- `docs/plan_glossary.md`: entradas para "refs cascade", "OJS scraper", "SciELO HTML scraper".
+
+Estos cambios se aplican en el PR derivado que sigue al merge de los tres ADRs.
+
+## 7. Presupuesto y métricas
+
+### 7.1 Costo
+
+Cero adicional en USD. Costo en wall-clock:
+
+- OpenAlex: ~100ms/call con polite pool.
+- HTML scraping: ~500ms-2s/call (varía por sitio).
+- Fallback completo (OpenAlex miss → HTML miss): ~3s antes de devolver `[]`.
+
+Para 1000 papers en backfill, peor caso (toda la biblioteca cae en HTML por SciELO-heavy): ~30 min wall-clock. Caso típico (OpenAlex-dominant): ~5-10 min.
+
+### 7.2 Métricas
+
+`/metrics` expone (vía ADR 020 §7.2):
+
+- `refs_source_api_breakdown`: distribución por valor de `source_api` (qué fracción del grafo viene de cada fuente).
+- `refs_html_scrape_failures_last_24h`: contador de errores DOM (ej. parser OJS no encontró `<ol>`). Caída brusca detecta DOM changes.
+
+## 8. Follow-ups
+
+- Plataformas adicionales según corpus real: si I1 muestra que un publisher específico aparece mucho y no es ni OJS ni SciELO, agregar parser dedicado en `refs_scrapers/` con un PR puntual (sin ADR salvo que cambie el orden de la cascade).
+- Si la cobertura es <60%, reabrir PDF parsing y elegir entre anystyle (Ruby), GROBID (Java service), refextract (Python). Cada motor con su ADR sucesor; comparativa de precisión, latencia y deps.
+- Si OpenAlex empieza a indexar refs LATAM (no es imposible — es proyecto activo), la cascade naturalmente migra hacia "OpenAlex domina y HTML es tail" sin cambios de código. Sólo cambia el `refs_source_api_breakdown`.
+
+## 9. Relación con ADRs previos
+
+- **ADR 020** (S2 owna citation graph): este ADR es la implementación de "cómo se captan refs" referenciada en ADR 020 §2.4 y §5.
+- **ADR 018/019** (SciELO + DOAJ en Stage 04 S1): SciELO queda en ambos contextos pero con responsabilidades distintas — Crossref Member 530 para metadata bibliográfica del candidato (ADR 019), parser HTML para refs salientes (este ADR). Sin conflicto.
+- **ADR 015** (S2 owna ChromaDB): independiente. La captura de refs y el embedding son operaciones paralelas en el step 0/0.5 del worker.

--- a/docs/decisions/022-metadata-only-push-first-class.md
+++ b/docs/decisions/022-metadata-only-push-first-class.md
@@ -1,0 +1,160 @@
+# ADR 022 — Push de items metadata-only como flujo de primera clase
+
+**Status**: Accepted
+**Date**: 2026-04-28
+**Deciders**: project owner
+**Related**: ADR 020 (citation graph + bandeja /classics), ADR 015 (S2 owna ChromaDB), plan_02 §10 (push), issue #14 (PDF cascade Sprint 3).
+
+---
+
+## 1. Contexto
+
+El diseño original de S2 (plan_02 §10 + issue #14) asume que cada candidate aceptado tiene PDF: el push intenta una cascade de fuentes (OA → DOI resolver → Anna's → LibGen → Sci-Hub → RSS) y, si falla, deja el item en Zotero con tag `needs-pdf` para reintentar después.
+
+Pero hay dos casos donde no conseguir el PDF **no es accidente**, es la realidad estructural:
+
+- **Papers paywalled estables**: el publisher no expone OA, el paper no aparece en piratería. La señal del paper (abstract + refs + venue + autores) puede ser suficiente para citarlo en un trabajo propio.
+- **Classics ausentes** (escenario 3 de la discusión inicial; bandeja `/classics` introducida por ADR 020 §2.4): papers altamente citados por mi corpus que no tengo en Zotero. El usuario quiere incorporarlos por su valor citacional aunque no necesariamente leerlos como PDF.
+
+En ambos casos:
+
+- El item es legítimamente parte del corpus.
+- Sus refs alimentan el grafo de citas (ADR 020) y el perfil de interés del usuario.
+- S3 (MCP / `zotero-mcp serve`) puede recuperarlo por título / abstract aunque no haya fulltext indexable — ADR 015 §6 ya prevé `source ∈ {s2_fulltext, s2_abstract, s2_title_only}`.
+- Para citar en un paper propio basta con metadata.
+
+El tag `needs-pdf` actual asume que el PDF falta **transitoriamente** — implica retry. No comunica "este item es metadata-only por diseño". Aplicar `needs-pdf` a un classic ausente es semánticamente incorrecto: el sistema iba a quedar reintentando indefinidamente algo que estructuralmente no va a aparecer.
+
+## 2. Decisión
+
+**Items metadata-only son ciudadanos de primera clase del corpus**. El push de S2 soporta dos modos:
+
+1. **Push estándar** (default para candidates con `source_kind='rss'` que pasan triage `accepted`):
+   - Cascade completa de PDF (issue #14, sprint 3).
+   - Si exitoso: item en Zotero sin tags adicionales.
+   - Si falla: tag `needs-pdf` (transitorio, retry-able).
+
+2. **Push metadata-only**:
+   - Cascade de PDF se intenta **una sola vez** en silencio.
+   - Si exitoso: item en Zotero sin tags adicionales (el sistema ganó un PDF gratis).
+   - Si falla: tag `metadata-only` permanente. **No retry**.
+   - Default para candidates con `source_kind='reference_mining'` (bandeja /classics).
+   - Disponible como opción explícita del usuario para candidates RSS via botón "Aceptar como metadata-only" en el dashboard.
+
+### 2.1 Tags reservados por el sistema
+
+Los tres tags relacionados a PDF / origen son **ortogonales**:
+
+| Tag | Significado | Permanencia | Aplicado por |
+|---|---|---|---|
+| `needs-pdf` | Cascade falló transitoriamente, espera retry | Transitorio (lo remueve sprint 3 si retry exitoso) | Push estándar al fallar la cascade |
+| `metadata-only` | Aceptado deliberadamente sin expectativa de PDF | Permanente (el usuario puede removerlo a mano) | Push metadata-only al fallar la cascade silenciosa |
+| `discovered-via-refs` | Origen: bandeja /classics (reference mining) | Permanente | Push metadata-only de candidates con `source_kind='reference_mining'` |
+
+Combinaciones legales:
+- Item RSS aceptado con PDF: ningún tag.
+- Item RSS aceptado sin PDF (cascade falló accidentalmente): `needs-pdf`.
+- Item RSS aceptado deliberadamente como metadata-only por el usuario, cascade silenciosa falló: `metadata-only`.
+- Item RSS aceptado deliberadamente como metadata-only, cascade silenciosa exitosa: ningún tag (el sistema ganó un PDF gratis).
+- Item de /classics aceptado con PDF gratis (cascade silenciosa exitosa): `discovered-via-refs`.
+- Item de /classics aceptado sin PDF (cascade silenciosa falló): `discovered-via-refs` + `metadata-only`.
+
+`needs-pdf` y `metadata-only` son **mutuamente excluyentes** — el primero declara intención de retry, el segundo declara aceptación del estado.
+
+### 2.2 Collection
+
+Misma `Inbox S2` que candidates RSS estándar. El tag `metadata-only` distingue; no hace falta una collection separada.
+
+Esta decisión es revisable: si en uso real la mezcla resulta confusa (muchos metadata-only en `Inbox S2` enmascarando los items con PDF), se puede:
+- (a) Mover `metadata-only` a una collection aparte (`Inbox S2 — Metadata only`).
+- (b) Filtrar por tag en la vista de Zotero del usuario (decisión personal, no del sistema).
+
+V1 va con la opción simple. Cambio futuro requiere ADR sucesor o nota en plan_02.
+
+### 2.3 Comportamiento de la cascade en modo metadata-only
+
+**Una sola vuelta**. Si falla, no hay retry automático.
+
+Esto es deliberado:
+
+- El modo metadata-only es **declarativo** — el usuario está diciendo "aceptá este item incluso sin PDF". Reintentar contradice esa declaración.
+- Reintentos silenciosos contra Sci-Hub/LibGen/Anna's son hostiles a esos servicios (terms-of-service grises, rate limits compartidos con otros usuarios). Una vuelta es polite; un loop background no.
+- El usuario puede forzar retry manualmente removiendo el tag `metadata-only` y disparando el cascade del sprint 3 con `--re-pdf` o equivalente.
+
+Excepción: si el usuario re-corre `zotai s2 push --retry-metadata-only` explícitamente, la cascade se vuelve a intentar para todos los items con tag `metadata-only`. Comando opt-in, no scheduled.
+
+### 2.4 Selección del modo
+
+- **Default por `source_kind`**:
+  - `'rss'` → push estándar.
+  - `'reference_mining'` → push metadata-only.
+- **Override en triage UI** (sprint 5, issue futuro):
+  - Para candidates RSS: botón secundario "Aceptar como metadata-only" además del "Aceptar" estándar. Útil cuando el usuario sabe que el paper es paywalled estable.
+  - Para candidates de /classics: el botón "Aceptar" hace metadata-only por default. No hay opción de "aceptar con cascade exhaustiva" en v1 (el modo metadata-only ya intenta cascade silenciosa una vez, que es lo razonable).
+
+## 3. Consecuencias
+
+### 3.1 Positivas
+
+- **Items legítimos no-OA en el corpus**. El usuario no tiene que decidir entre "no incorporo el paper" y "lo incorporo con tag transitorio que se va a quedar mal taggeado para siempre".
+- **Bandeja /classics tiene un push coherente**. ADR 020 introduce la bandeja; este ADR provee el flujo de aceptación que esa bandeja necesita. Sin este ADR, /classics no tendría un patrón de push semánticamente correcto.
+- **Auditable**. Los tres tags permiten filtros claros en Zotero:
+  - "Items que esperan PDF" → `needs-pdf`.
+  - "Items metadata-only deliberados" → `metadata-only`.
+  - "Items que entraron por discovery, no por journals" → `discovered-via-refs`.
+- **Refs como compensación**. Item metadata-only sin refs sería mortifero (un agujero en el corpus); con refs (ADR 020) aporta señal estructural que beneficia al scoring de futuros candidates.
+- **Sin loops contra Sci-Hub/LibGen**. La política de "una vuelta y declaración" es respetuosa con esos servicios y predecible para el usuario.
+
+### 3.2 Negativas
+
+- **Más tags reservados en la biblioteca**. Tres tags nuevos: `needs-pdf` (que ya existía en plan), `metadata-only`, `discovered-via-refs`. Mitigación: documentar bien en plan_02 + README + glossary; los tres tienen prefijos / nombres descriptivos no ambiguos.
+- **Tags ortogonales son fáciles de confundir**. Mitigación: tabla en este ADR §2.1 + entrada en `plan_glossary.md` que cubra las combinaciones legales.
+- **Push tiene dos modos con UX distinto**. El dashboard sprint 5 va a ofrecer dos botones donde antes había uno. Aceptable; el segundo botón aplica sólo a candidates RSS (los de /classics tienen un solo "Aceptar" que es metadata-only por default).
+
+### 3.3 Neutras
+
+- **No cambia ADR 015**. S3 indexa todo lo que está en Zotero, no se hace caso especial para metadata-only. El schema ChromaDB ya tiene `source ∈ {s2_fulltext, s2_abstract, s2_title_only}` — items metadata-only caen en `s2_abstract` o `s2_title_only` según haya abstract disponible o no. El reconcile de ADR 015 los procesa naturalmente.
+- **No afecta plan_01 / S1**. S1 sigue importando con cascade propia (Ruta A / C); este ADR vive enteramente en S2 push.
+
+## 4. Alternativas consideradas y descartadas
+
+**A. Sólo `needs-pdf`, retry agresivo permanente.**
+Suficiente operacionalmente para casos transitorios. Falla en el caso classics ausentes (un paper de 1985 de un journal cerrado: nunca va a aparecer un PDF; el tag `needs-pdf` persiste con semántica incorrecta y el sistema reintenta indefinidamente). Descartada.
+
+**B. Collection separada `Metadata-only` (sin tag).**
+Más visible. Descartada: rompe el modelo "el usuario ve su biblioteca como un corpus único, las collections son organizativas, no semánticas". Tag basta y es ortogonal a la organización por proyecto / tema que el usuario quiera hacer.
+
+**C. Sin marker explícito** (los items sin PDF se ven igual a los con PDF).
+Confunde con items de S1 que pueden tener metadata sin PDF transitoriamente (ej. Etapa 03 abortó para ese item). No discrimina origen RSS vs /classics. Descartada por auditabilidad.
+
+**D. Tag único `closed-access` o similar** que reemplaza tanto `metadata-only` como `discovered-via-refs`.
+Más simple. Descartada: el origen del item (`/classics` vs RSS) es información valiosa para que el usuario filtre lo descubierto vs lo monitoreado por journals seguidos.
+
+**E. Reintentos silenciosos en background para items `metadata-only`.**
+Más completo. Descartada por hostilidad hacia Sci-Hub / LibGen / Anna's (rate limits compartidos), por contradecir la declaración del usuario, y porque el comando manual `zotai s2 push --retry-metadata-only` cubre el caso "ahora sí buscame los PDFs que faltan" sin loops automáticos.
+
+## 5. Cambios requeridos en documentos existentes
+
+- `docs/plan_02_subsystem2.md` §10 (push):
+  - Documentar los dos modos (estándar / metadata-only).
+  - Documentar los tres tags y su tabla de combinaciones.
+  - Ajustar acceptance criteria de issue #14 (sprint 3) para que sea forward-compatible con el modo metadata-only que aterriza en sprint 5.
+- `README.md` §"Cómo queda tu biblioteca Zotero":
+  - Agregar los tres tags (`needs-pdf`, `metadata-only`, `discovered-via-refs`) a la lista de "tags reservados por el sistema".
+  - Una línea sobre cómo el usuario los puede usar como filtros en Zotero.
+- `docs/plan_glossary.md`: entradas para los tres tags + "push metadata-only" + "push estándar".
+
+Estos cambios se aplican en el PR derivado que sigue al merge de los tres ADRs.
+
+## 6. Follow-ups
+
+- Si en uso real `metadata-only` se aplica a >50% del corpus que pasa por S2, revisar el modelo: puede ser señal de que la cascade sprint 3 es muy laxa (rinde poco), o de que el corpus estructuralmente tiene pocos OA y conviene revisar fuentes adicionales (institutional repos, preprint servers).
+- Si zotero-mcp no maneja bien items con `source=s2_abstract` o `s2_title_only` (recall pobre en queries semánticas desde Claude Desktop), considerar embedding de "título inflado" — incluir autores + venue + year + abstract truncado. Follow-up de ADR 015 §9 ya prevé esto y se aplica acá.
+- Si la mezcla en `Inbox S2` resulta confusa (muchos metadata-only enmascarando items con PDF), agregar collection separada `Inbox S2 — Metadata only` con ADR sucesor o decisión documentada en plan_02 §10.
+
+## 7. Relación con ADRs previos
+
+- **ADR 014** (skip attach if existing PDF en S1 dedup): independiente. Aplica al push estándar de S1; no afecta el push de S2 ni el modo metadata-only.
+- **ADR 015** (S2 owna ChromaDB): items metadata-only se indexan vía la cascade existente (`s2_abstract` / `s2_title_only`), sin cambios al schema ChromaDB ni al reconcile.
+- **ADR 020** (S2 owna citation graph + bandeja /classics): la bandeja /classics introducida por ADR 020 §2.4 usa exclusivamente push metadata-only para candidates con `source_kind='reference_mining'`. Este ADR provee el flujo que esa bandeja consume.
+- **ADR 021** (cascade de captura de refs): independiente. La captura de refs alimenta el grafo (ADR 020) y el grafo alimenta /classics (ADR 020); este ADR sólo formaliza el push de los items aceptados desde esa bandeja.


### PR DESCRIPTION
## Summary

Tres ADRs nuevos que formalizan el diseño discutido en sesión para incorporar el grafo de citas como información estructural de primera clase del proyecto. Sólo documentación; código aterriza después en un Sprint 5 separado.

- **ADR 020 — S2 owna el grafo de citas de la biblioteca**. Análogo a ADR 015 para embeddings: tablas \`Reference\` + \`ExternalPaper\` en \`candidates.db\`, reconciliación por diff en step 0.5 del worker, comando explícito \`zotai s2 backfill-references\`. \`score_refs\` se incorpora como cuarta señal del RRF (ADR 016), con omisión natural cuando \`|refs|=0\` para no penalizar falta de información. Habilita la bandeja \`/classics\` (discovery de papers altamente citados ausentes en Zotero).
- **ADR 021 — Cascade de captura de refs**: OpenAlex → HTML scraping (OJS / SciELO / genérico) → PDF (opt-in, no implementado v1). Cubre el gap LATAM sin costo adicional. Tres parsers aislados en \`src/zotai/api/refs_scrapers/\`, fail-soft en cada nivel.
- **ADR 022 — Items metadata-only como flujo de primera clase**. Tres tags reservados ortogonales: \`needs-pdf\` (transitorio, retry-able), \`metadata-only\` (deliberado, permanente), \`discovered-via-refs\` (origen \`/classics\`). Default por \`source_kind\`: RSS → push estándar; reference_mining → push metadata-only. Una vuelta de cascade silenciosa, sin loops contra Sci-Hub/LibGen/Anna's.

## Decisiones explícitas

- **Owner**: S2 (no S1). Mantiene contrato plan_00 §3 a costa de duplicar ~1000 calls a OpenAlex (gratis, ~5-10 min).
- **No persistimos \`cited_by\`**: on-demand cuando aparezca caso de uso.
- **Refs sin DOI**: se persisten como \`cited_text\` libre, no contribuyen al overlap del scoring pero quedan auditables.
- **PDF parsing**: flag \`S2_REFS_PDF_PARSING_ENABLED\`, default \`false\`, sin implementación v1.

## Validación empírica antes del Sprint 5

Los tres ADRs proceden con asunción explícita de **cobertura combinada (OpenAlex + HTML) ≥ 80%**. El gate I1 (ADR 020 §5) verifica empíricamente con 50-100 DOIs random del Zotero del usuario antes del primer merge de código:

- Si cobertura ≥ 80% e intra-corpus ≥ 5%: ADRs firmes.
- Si 60% ≤ cobertura < 80%: ADRs siguen, \`score_refs\` como señal complementaria.
- Si cobertura < 60%: reabrir decisión PDF parsing en ADR 021.

I1 corre cuando el usuario termine la corrida real de S1.

## Próximo PR

PR derivado actualiza:
- \`docs/plan_02_subsystem2.md\` (§5 modelo de datos, §7 scoring, §8 dashboard, §9 worker, §11 sprints — nuevo Sprint 5).
- \`docs/plan_00_overview.md\` (§3 diagrama, §5 tabla ADRs).
- \`docs/plan_01_subsystem1.md\` (§10 fuera de alcance, nota sobre refs en S2).
- \`docs/plan_03_subsystem3.md\` (confirmación de que metadata-only se indexa via cascade existente).
- \`docs/plan_glossary.md\` (entradas nuevas).
- \`CLAUDE.md\` (segundo store derivado owned por S2).
- \`README.md\` (tags reservados, estado del proyecto).
- \`.env.example\` (variables nuevas de los tres ADRs).

Issue de Sprint 5 en S2 se crea después del merge de los derivados.

## Test plan

- [ ] Revisar que los tres ADRs son internamente coherentes y no se contradicen entre sí.
- [ ] Verificar que las referencias cruzadas a ADRs previos (014, 015, 016, 017, 018, 019) son correctas.
- [ ] Verificar que el supuesto de cobertura ≥ 80% queda visiblemente marcado como hipótesis a validar empíricamente, no como hecho.
- [ ] Confirmar que el orden propuesto (este PR → PR derivado → issue Sprint 5 → I1 → código) calza con el flujo de trabajo del proyecto.