### PR TITLE
docs: align plans/glossary/CLAUDE/README/.env with ADRs 020/021/022

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -119,6 +119,34 @@ S2_MAX_COST_USD_BACKFILL=3.00
 # env var takes priority for per-run experimentation.
 S2_QUERY_BM25_WEIGHT=0.4
 
+# ────────────── S2 Citation graph (ADR 020) ──────────────
+# Max refs fetched per worker cycle (paso 0.5). Limits wall-clock impact
+# of refs reconciliation; residual converges across cycles. Tune up if a
+# big import landed in Zotero and you want fewer cycles to converge.
+S2_MAX_REFS_FETCH_PER_CYCLE=50
+# Safety threshold for refs reconciliation: if orphans/total > this ratio,
+# do NOT auto-delete from Reference and require manual intervention.
+# Mirrors the embeddings safety net (S2_SAFE_DELETE_RATIO).
+S2_SAFE_DELETE_RATIO_REFS=0.10
+# Budget cap for the one-shot `zotai s2 backfill-references` command.
+# Default 0.00 because OpenAlex is free; slot reserved so future paid
+# sources (e.g. Crossref Plus, scrapers with rotating proxies) don't
+# require schema changes. See ADR 020 §7.1.
+S2_MAX_COST_USD_BACKFILL_REFS=0.00
+
+# ────────────── S2 Refs collection cascade (ADR 021) ──────────────
+# Master toggle for HTML scraping fallback (OJS / SciELO / generic).
+# Set false to use OpenAlex only — useful for anglo-only corpora where
+# coverage is already high and you want to skip the scrape latency.
+S2_REFS_SCRAPING_ENABLED=true
+# Opt-in for PDF parsing as last-resort source. Not implemented in v1;
+# the flag exists so a future sprint can wire it in (anystyle / GROBID /
+# refextract) without revisiting this ADR. See ADR 021 §2.
+S2_REFS_PDF_PARSING_ENABLED=false
+# Per-source timeout for the refs cascade (seconds). A slow source does
+# not block subsequent sources nor the worker cycle.
+S2_REFS_FETCH_TIMEOUT_SECONDS=15
+
 # ────────────── S2 PDF fetch cascade ──────────────
 # Ordered, comma-separated list of sources to try when pushing an accepted
 # candidate with a missing PDF. Stops at first success. Remove an entry to

--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -203,9 +203,9 @@ S2 (write accepted items)  │
 **Reglas:**
 - No hay DB compartida entre S1 y S2 — `state.db` y `candidates.db` son disjuntas.
 - No hay API interna entre subsistemas. Si S2 necesita "saber algo" de S1, ese algo tiene que estar en Zotero (como tag, colección, o campo).
-- ChromaDB es la única excepción al "solo via Zotero": es estado derivado que S2 mantiene como índice secundario sobre Zotero. ADR 015 explica por qué S2 (no S3) es el owner. S3 lee ChromaDB para responder queries MCP; nunca escribe (`zotero-mcp update-db` no se usa en ningún flujo del proyecto).
+- ChromaDB y el citation graph (tablas `Reference` + `ExternalPaper` en `candidates.db`) son las dos excepciones al "solo via Zotero": son estado derivado que S2 mantiene como índices secundarios sobre Zotero. ADR 015 explica por qué S2 (no S3) es el owner de ChromaDB; ADR 020 aplica el mismo patrón al citation graph (`Reference` aristas, `ExternalPaper` cache de DOIs externos). En ambos, el invariante se preserva por reconciliación por diff en cada ciclo del worker. S3 lee ChromaDB para responder queries MCP; nunca escribe (`zotero-mcp update-db` no se usa en ningún flujo del proyecto). El citation graph no lo lee S3, sólo S2 (lo consume desde `score_refs` y la bandeja `/classics`).
 
-**Consecuencia**: S2 y S3 deben poder correr aunque S1 no haya corrido nunca. Degradan gracefully (S2: `score_semantic=neutral_fallback`; S3: queries devuelven vacío hasta que `zotai s2 backfill-index` corra).
+**Consecuencia**: S2 y S3 deben poder correr aunque S1 no haya corrido nunca. Degradan gracefully (S2: `score_semantic=neutral_fallback`, `score_refs` omitido del RRF cuando `|refs(c)|=0`; S3: queries devuelven vacío hasta que `zotai s2 backfill-index` corra).
 
 ---
 

--- a/README.md
+++ b/README.md
@@ -50,6 +50,18 @@ Si querés colecciones por proyecto de investigación (p.ej. "Tesis doctoral", "
 
 Definidas en `config/taxonomy.yaml`; taxonomía completa y reglas en `docs/plan_taxonomy.md`. El archivo hoy viene con plantilla de economía / LATAM que el investigador debe customizar antes de correr Etapa 05 (tagging).
 
+### Tags reservados por el sistema (S2, ADR 022)
+
+Adicionalmente, S2 aplica hasta tres tags reservados ortogonales a TEMA/METODO. Son útiles como filtros en Zotero:
+
+| Tag | Significado | Permanencia |
+|---|---|---|
+| `needs-pdf` | Push intentó cascade de PDF y falló transitoriamente; espera retry. | Transitorio (lo remueve el sprint 3 cuando un retry exitoso aterrice). |
+| `metadata-only` | Item aceptado deliberadamente sin expectativa de PDF (paywalled estable o classic ausente). | Permanente (el usuario lo puede remover manualmente). |
+| `discovered-via-refs` | Origen: bandeja `/classics` (reference mining), no journal RSS. | Permanente. |
+
+`needs-pdf` y `metadata-only` son mutuamente excluyentes. `discovered-via-refs` es ortogonal: un classic ausente sin PDF queda con `discovered-via-refs` + `metadata-only`. Detalle completo en `docs/decisions/022-metadata-only-push-first-class.md`.
+
 ### Campos nativos de Zotero (no duplicar como tags)
 - `Place` → país / región del estudio.
 - `Item Type` → `journalArticle`, `book`, `thesis`, `report`, `preprint`, `conferencePaper`, etc.
@@ -68,13 +80,15 @@ Ver `docs/plan_01_subsystem1.md` §3.1 para el detalle del clasificador.
 | Subsistema | Estado | Plan |
 |---|---|---|
 | S1 – Retroactive | 🟢 Funcional end-to-end (Stages 01-06 + `run-all` + `status` + Docker + setup docs). Taxonomía pendiente de customizar por cada investigador antes de aplicar tags reales. | `docs/plan_01_subsystem1.md` |
-| S2 – Prospective | 🟡 Spec, pendiente implementación ([#12](https://github.com/igalkej/auto_zotero/issues/12)–[#15](https://github.com/igalkej/auto_zotero/issues/15)) | `docs/plan_02_subsystem2.md` |
+| S2 – Prospective | 🟡 Spec cerrada (Sprints 1-4: [#12](https://github.com/igalkej/auto_zotero/issues/12)–[#15](https://github.com/igalkej/auto_zotero/issues/15)) + Sprint 5 nuevo (citation graph + bandeja `/classics` + push metadata-only; ADRs 020/021/022). Implementación pendiente. | `docs/plan_02_subsystem2.md` |
 | S3 – MCP access | 🟡 Spec, pendiente implementación ([#11](https://github.com/igalkej/auto_zotero/issues/11)) | `docs/plan_03_subsystem3.md` |
 
-Orden de implementación (plan_00 §4): **S1 → S2 → S3**. S2 es owner del
-índice de embeddings (ADR 015); S3 es lector puro y arranca a darle
-valor al modo descubrimiento una vez que el primer `zotai s2
-backfill-index` haya corrido.
+Orden de implementación (plan_00 §4): **S1 → S2 → S3**. S2 es owner de
+**dos índices secundarios** sobre la biblioteca: el índice de
+embeddings de ChromaDB (ADR 015) y el citation graph en
+`candidates.db` (ADR 020 + 021). S3 es lector puro de ChromaDB y
+arranca a darle valor al modo descubrimiento una vez que el primer
+`zotai s2 backfill-index` haya corrido.
 
 ---
 

--- a/docs/plan_00_overview.md
+++ b/docs/plan_00_overview.md
@@ -53,6 +53,8 @@ Objetivo de más alto nivel: **multiplicar por 3-5x la cantidad de consultas bib
 
 **Comunicación entre subsistemas**: solo a través de Zotero. No hay DB compartida ni API interna. Esto es deliberado: loose coupling, Zotero ya resuelve persistencia, permisos, y sync.
 
+**Estado derivado owned por S2**: aunque la fuente de verdad es Zotero, S2 mantiene **dos índices secundarios** sobre el corpus para responder eficientemente sus tareas de scoring y discovery — (a) **ChromaDB** con embeddings de cada item (ADR 015), y (b) **citation graph** en `candidates.db` con tablas `Reference` + `ExternalPaper` (ADR 020). Ambos se mantienen por reconciliación por diff en cada ciclo del worker; ambos son auto-curativos (si se borran, el siguiente ciclo los repuebla); ninguno es DB compartida con S1 — son strict downstream de Zotero. S3 lee ChromaDB; el citation graph no se expone a S3.
+
 ---
 
 ## 4. Orden de implementación
@@ -96,6 +98,9 @@ Cada una con ADR correspondiente en `docs/decisions/`.
 | 017 | Hybrid retrieval (BM25 + dense) para `score_queries` de S2 | Queries persistentes son cortas (3-7 tokens); dense puro underperforma por 5-15 recall points. SQLite FTS5 built-in provee BM25 sin nueva dep. α=0.4 literatura default; calibrar con ADR sucesor post-datos. |
 | 018 | Stage 04 cascade: agregar substages 04bs (SciELO) + 04bd (DOAJ) entre 04b y 04c | Cierra el gap LATAM/open-access del cascade gratis para corpus CONICET. Default ON con opt-out via `S1_ENABLE_SCIELO`/`S1_ENABLE_DOAJ`. REDIB / RedALyC / La Referencia / ERIH PLUS / Scopus quedan fuera con justificación documentada. **Amended por ADR 019** — 04bs implementa via Crossref Member 530 porque `search.scielo.org` está cerrado a clientes anónimos. |
 | 019 | Substage 04bs implementa via Crossref Member 530 (no `search.scielo.org`) | El endpoint Solr público de SciELO devuelve 403 a httpx anónimo en toda variante; ArticleMeta sólo soporta lookup por SciELO PID. Member 530 es el ID Crossref de SciELO; el filter narrows el search space y mejora ranking top-5 LATAM-Spanish vs OpenAlex sin filtro. Amends ADR 018 §"Sources evaluated" SciELO row + §Decision §1 + §"Implementation artefacts" §1. |
+| 020 | **S2 owna el grafo de citas de la biblioteca** (tablas `Reference` + `ExternalPaper` en `candidates.db`) | Análogo a ADR 015 para embeddings. Habilita `score_refs` (4ta señal RRF) + bandeja `/classics` (discovery de papers altamente citados ausentes). Reconciliación por diff en step 0.5 del worker; comando explícito `zotai s2 backfill-references`. Owner S2 (no S1) preserva el contrato plan_00 §3 a costa de duplicar calls a OpenAlex (gratis). |
+| 021 | Cascade de captura de refs: OpenAlex → HTML scraping (OJS / SciELO / genérico) → PDF (opt-in) | Cubre el gap LATAM sin costo USD adicional. Tres parsers aislados en `src/zotai/api/refs_scrapers/`, fail-soft por nivel. PDF parsing detrás de flag `S2_REFS_PDF_PARSING_ENABLED`, default `false`, no implementado v1. Variables `S2_REFS_*` agregadas a `.env.example`. |
+| 022 | Items metadata-only como flujo de primera clase del push | Tres tags reservados ortogonales: `needs-pdf` transitorio (retry-able), `metadata-only` permanente (deliberado), `discovered-via-refs` por origen (bandeja /classics). Default por `source_kind`: RSS → push estándar; `reference_mining` → push metadata-only. Una sola vuelta de cascade silenciosa, sin loops contra Sci-Hub/LibGen. Habilita el flujo de aceptación de la bandeja /classics que introduce ADR 020. |
 
 ---
 

--- a/docs/plan_01_subsystem1.md
+++ b/docs/plan_01_subsystem1.md
@@ -556,6 +556,7 @@ Modo `--yes` skippea confirmaciones (para CI o usuarios experimentados).
 
 Explícitamente pospuesto:
 - Indexación semántica con ChromaDB → responsabilidad de S2 (ver ADR 015). S1 no escribe a ChromaDB bajo ninguna circunstancia.
+- **Captura del grafo de citas** (refs salientes de cada paper) → responsabilidad de S2 (ver ADR 020). S1 no escribe a `Reference` ni a `ExternalPaper`. Etapa 04 sigue llamando a OpenAlex sólo para metadata bibliográfica del item; las refs las re-pide S2 en su backfill propio. La duplicación de calls (~5 min, gratis) se acepta para no romper el contrato S1/S2 disjuntas (plan_00 §3, ADR 020 §3.2).
 - Dashboard web → parte del S2.
 - Integración con Better BibTeX export → post-v1.0.
 - Detección de duplicados entre preprint/published → v1.1 si hace falta.

--- a/docs/plan_02_subsystem2.md
+++ b/docs/plan_02_subsystem2.md
@@ -44,10 +44,12 @@ Mantener la biblioteca Zotero sincronizada con el estado del arte de los temas d
 ┌───────────────────────────────────────────────────────────────┐
 │ Worker (scheduled, corre c/ N horas)                          │
 │  ┌──────────────────────────────────────────────────────┐     │
-│  │ 0. Reconcile ChromaDB (add missing, remove orphans)  │     │
-│  │    Mantiene el invariante: todo item no-cuarentenado │     │
-│  │    en Zotero tiene entrada en ChromaDB. Ver ADR 015. │     │
-│  │ 1. Fetch RSS de journals configurados                │     │
+│  │ 0.   Reconcile ChromaDB (ADR 015 — embeddings)       │     │
+│  │ 0.5  Reconcile citation graph (ADR 020 — refs)       │     │
+│  │      Invariantes: todo item no-cuarentenado en       │     │
+│  │      Zotero tiene entrada en ChromaDB Y refs         │     │
+│  │      persistidas en Reference. Auto-curativos.       │     │
+│  │ 1.   Fetch RSS de journals configurados              │     │
 │  │ 2. Parsear, deduplicar vs candidatos ya vistos       │     │
 │  │ 3. Para cada nuevo candidato:                        │     │
 │  │    a. Enriquecer metadata (DOI → OpenAlex)           │     │
@@ -96,7 +98,8 @@ Mantener la biblioteca Zotero sincronizada con el estado del arte de los temas d
 ```python
 class Candidate(SQLModel, table=True):
     id: str = Field(primary_key=True)  # hash del DOI o URL
-    source_feed_id: str = Field(foreign_key="feed.id")
+    source_feed_id: Optional[str] = Field(foreign_key="feed.id", default=None)
+    source_kind: str = "rss"  # 'rss' | 'reference_mining' (ADR 020 §2.2)
     doi: Optional[str] = None
     title: str
     authors_json: str  # JSON list
@@ -106,10 +109,11 @@ class Candidate(SQLModel, table=True):
     url: Optional[str] = None
 
     # Scoring
-    score_tags: float = 0.0           # 0-1
+    score_tags: float = 0.0            # 0-1
     score_semantic: float = 0.0        # 0-1
     score_queries: float = 0.0         # 0-1
-    score_composite: float = 0.0       # 0-1
+    score_refs: float = 0.0            # 0-1 — overlap bibliográfico (ADR 020 §2.4)
+    score_composite: float = 0.0       # 0-1 — RRF sobre los cuatro (ADR 016)
     scoring_explanation: str  # JSON blob explicando por qué cada score
 
     # Triage
@@ -153,6 +157,35 @@ class TriageMetric(SQLModel, table=True):
     candidates_rejected: int
     candidates_deferred: int
     precision_observed: float  # accepted / (accepted + rejected)
+
+
+# ───── Citation graph (ADR 020) ─────
+
+class Reference(SQLModel, table=True):
+    """Una arista del grafo de citas: paper_X cita paper_Y."""
+    id: int = Field(primary_key=True)
+    citing_zotero_key: str  # 8 chars, FK lógica a Zotero, indexed
+    cited_doi: Optional[str] = None              # indexed
+    cited_openalex_id: Optional[str] = None
+    cited_text: Optional[str] = None             # cita libre cuando no hay DOI
+    source_api: str  # 'openalex' | 'ojs_html' | 'scielo_html' | 'generic_html' | 'pdf'
+    fetched_at: datetime
+
+
+class ExternalPaper(SQLModel, table=True):
+    """Cache de DOIs ausentes en Zotero pero citados por papers en él.
+
+    Habilita la bandeja /classics sin re-llamar a OpenAlex en cada render.
+    """
+    doi: str = Field(primary_key=True)
+    openalex_id: Optional[str] = None
+    title: str
+    authors_json: str
+    year: Optional[int] = None
+    venue: Optional[str] = None
+    abstract: Optional[str] = None
+    cited_by_count: int = 0   # global, no en mi corpus
+    last_seen_at: datetime
 ```
 
 **Nota — ChromaDB no está en `candidates.db`**. Bajo ADR 015, S2 también
@@ -173,6 +206,19 @@ sync vía triggers INSERT/UPDATE/DELETE sobre `Candidate`. Es la que
 responde la mitad BM25 del score híbrido en §7.3. Zero mantenimiento
 del usuario; los triggers se crean junto con el schema al
 `init_s2()`.
+
+**Nota — citation graph en `candidates.db`** (ADR 020). Las tablas
+`Reference` (aristas del grafo) y `ExternalPaper` (cache de DOIs
+ausentes en Zotero pero citados por papers en él) son el segundo
+índice secundario que S2 mantiene sobre el corpus, después de
+ChromaDB. S2 es owner; S1 no escribe; S3 no consume. Mantenido por
+reconciliación por diff en step 0.5 del worker (§9). Consumido por
+`score_refs` (§7.4) y por la bandeja `/classics` (§8.3). Captura de
+refs vía cascade ADR 021 (OpenAlex → HTML scraping → PDF opcional).
+Indexes:
+- `Reference(citing_zotero_key)` — overlap intra-corpus O(log n).
+- `Reference(cited_doi)` — frecuencia de cita global (ranking de
+  `/classics`) y "qué papers de mi corpus citan a X" O(log n).
 
 ---
 
@@ -287,17 +333,45 @@ END;
 
 `remove_diacritics 2` hace que "política" matchee "politica" — útil para corpus mixto es/en donde los acentos son inconsistentes.
 
-### 7.4 Score compuesto
+### 7.4 Score por refs (ADR 020)
 
-**Método default: Reciprocal Rank Fusion (RRF)** sobre los tres scores por criterio. Ver ADR 016 para el rationale completo — resumen: un promedio ponderado destruye señales ortogonales (un paper con `queries=0.9` pero `tags=0.1, semantic=0.1` se entierra bajo pesos arbitrarios); RRF es robusto a distribuciones distintas de cada criterio y favorece a quienes aparecen arriba en *cualquiera* de los tres.
+**Input**: candidate con `doi` (o `landing_url` si vino de RSS sin DOI confirmado).
+**Output**: `score_refs ∈ [0, 1]`.
+
+**Lógica**:
+1. Obtener `refs(c)` aplicando la cascade ADR 021 (OpenAlex → HTML scraping → PDF opcional). Para candidates RSS la cascade corre en el momento del scoring; para candidates de `/classics` (`source_kind='reference_mining'`) las refs ya están en `Reference` con `citing_zotero_key='cand:<id>'` o equivalente — reusar.
+2. Cargar `zotero_dois` del corpus (cacheado al ciclo del worker, ver §9).
+3. `score_refs(c) = |refs(c) ∩ zotero_dois| / |refs(c)|`, clippeado a `[0, 1]`.
+
+**Si `|refs(c)| = 0`** (cobertura combinada cero — OpenAlex devolvió vacío y la cascade HTML también): el score se **omite del RRF** (§7.5 / ADR 016) en lugar de penalizar. No podemos puntuar a falta de información; RRF integra naturalmente las tres señales restantes con la convención `rank = ∞ ⇒ contribution = 0`.
+
+**Por qué es ortogonal a tags / semantic / queries**:
+- Estructural, no falseable por palabras: un paper cita o no cita.
+- Captura "nueva aplicación de ideas viejas" (taxonomía distinta, bibliografía compartida) que `score_tags` se pierde.
+- Robusto en corpora donde abstract es genérico (humanidades, paywalled, LATAM): donde `score_semantic` degrada, `score_refs` mantiene señal estructural.
+- Ortogonal incluso a queries persistentes: una query de 3 tokens puede no matchear nada del title/abstract de un paper que sin embargo cita 6 anchors centrales del campo.
+
+**Coupling intra-corpus** (similitud entre dos papers de Zotero por refs compartidas) queda implícito en `Reference` y no se materializa como métrica separada en v1. Si más adelante se quiere usar para validación de tags o detección de duplicados temáticos, basta con queries SQL sobre la tabla.
+
+### 7.5 Score compuesto
+
+**Método default: Reciprocal Rank Fusion (RRF)** sobre los **cuatro** scores por criterio (`tags`, `semantic`, `queries`, `refs`). Ver ADR 016 para el rationale completo — resumen: un promedio ponderado destruye señales ortogonales (un paper con `queries=0.9` pero `tags=0.1, semantic=0.1, refs=0.1` se entierra bajo pesos arbitrarios); RRF es robusto a distribuciones distintas de cada criterio y favorece a quienes aparecen arriba en *cualquiera* de los cuatro. La cuarta señal (`score_refs`) entró en ADR 020 sin requerir cambios al ADR 016: un candidate sin refs disponibles se omite naturalmente del ranking de ese criterio (rank infinito ⇒ contribución cero).
 
 ```python
 # Reciprocal Rank Fusion (Cormack, Clarke, Büttcher 2009).
 # Lower rank = better; k absorbs the noise at the tail.
 def composite_score(candidates: list[Candidate], k: int = 60) -> None:
-    for criterion in ("tags", "semantic", "queries"):
+    for criterion in ("tags", "semantic", "queries", "refs"):
+        # Para `refs`: candidates con score_refs == 0 (porque |refs(c)| = 0)
+        # se excluyen del ranking de ese criterio para no pisar a los que sí
+        # tienen señal. ADR 020 §2.4.
+        eligible = (
+            candidates
+            if criterion != "refs"
+            else [c for c in candidates if c.score_refs > 0]
+        )
         ranked = sorted(
-            candidates,
+            eligible,
             key=lambda c: getattr(c, f"score_{criterion}"),
             reverse=True,
         )
@@ -312,11 +386,11 @@ def composite_score(candidates: list[Candidate], k: int = 60) -> None:
 **Configuración** (`config/scoring.yaml`, bloque `composite_score`):
 - `method: rrf` (default) | `weighted_mean` (legacy, documented for opt-in).
 - `rrf_k: 60` — constante estándar del paper original. Aumentarla suaviza, bajarla pesa más a los tops. Raramente hay que tocarla.
-- `weighted_mean` sigue disponible con `weights.{tags, semantic, queries}` por si el usuario quiere forzar calibración manual; no recomendado como default.
+- `weighted_mean` sigue disponible con `weights.{tags, semantic, queries, refs}` por si el usuario quiere forzar calibración manual; no recomendado como default.
 
-**UI complement**: el dashboard `/inbox` ordena por `score_composite DESC` pero **expone también ordenamiento por criterio individual** (tabs o filtros). Un paper con `queries=0.9` (match perfecto a una query persistente) debe poder mostrarse primero aunque RRF lo ranke medio por tener `tags` y `semantic` bajos.
+**UI complement**: el dashboard `/inbox` ordena por `score_composite DESC` pero **expone también ordenamiento por criterio individual** (tabs o filtros). Un paper con `queries=0.9` (match perfecto a una query persistente) o `refs=0.8` (overlap bibliográfico fuerte) debe poder mostrarse primero aunque RRF lo ranke medio por tener bajos los otros tres.
 
-**Calibración diferida**. RRF no necesita pesos — elimina la pregunta "¿cuánto vale tags vs semantic?". **Cuando haya ≥100 decisiones históricas** en `candidates.db` (una vez que el usuario lleve 2-3 meses de triage), un futuro ADR puede reintroducir pesos vía regresión logística sobre `score_tags, score_semantic, score_queries → {accepted, rejected}`, y comparar la precisión observada de RRF vs weighted-mean calibrado. **Calibrar escalas no es echo chamber** (el antipatrón que plan_02 §3 evita); sesgar el ranker con las aceptaciones del usuario sí lo sería — no es lo mismo. El dashboard `/metrics` ya expone `candidates_accepted / (accepted + rejected)` como precision observada por semana; esos datos son el input de la calibración futura.
+**Calibración diferida**. RRF no necesita pesos — elimina la pregunta "¿cuánto vale tags vs semantic vs refs?". **Cuando haya ≥100 decisiones históricas** en `candidates.db` (una vez que el usuario lleve 2-3 meses de triage), un futuro ADR puede reintroducir pesos vía regresión logística sobre `score_tags, score_semantic, score_queries, score_refs → {accepted, rejected}`, y comparar la precisión observada de RRF vs weighted-mean calibrado. **Calibrar escalas no es echo chamber** (el antipatrón que plan_02 §3 evita); sesgar el ranker con las aceptaciones del usuario sí lo sería — no es lo mismo. El dashboard `/metrics` ya expone `candidates_accepted / (accepted + rejected)` como precision observada por semana; esos datos son el input de la calibración futura.
 
 ---
 
@@ -367,7 +441,46 @@ def composite_score(candidates: list[Candidate], k: int = 60) -> None:
 - Por feed de origen.
 - Por semana (`published_at`).
 
-### 8.3 Autenticación
+### 8.3 Bandeja `/classics` — discovery por reference mining (ADR 020)
+
+**Propósito**: surfacear los DOIs ausentes en Zotero pero altamente citados por el corpus del usuario. Misma máquina de triage que `/inbox` (accept/reject/defer + push), distinta fuente: los candidates aparecen vía SQL sobre `Reference + ExternalPaper`, no vía RSS.
+
+**Ruta**: `/classics`. Independiente de `/inbox` (no es un filtro de la misma vista). Razón: el ranking, la ausencia de "feed source", y el modo de push (default metadata-only por ADR 022 §2.4) hacen que la UX sea distinta lo suficiente como para justificar ruta propia.
+
+**Query base** (simplificada):
+
+```sql
+SELECT
+    r.cited_doi,
+    COUNT(DISTINCT r.citing_zotero_key) AS cites_in_corpus,
+    ep.title, ep.authors_json, ep.year, ep.venue, ep.cited_by_count
+FROM reference r
+JOIN externalpaper ep ON ep.doi = r.cited_doi
+WHERE r.cited_doi IS NOT NULL
+  AND r.cited_doi NOT IN (SELECT doi FROM zotero_dois_view)
+GROUP BY r.cited_doi
+HAVING cites_in_corpus >= :k                         -- threshold k=2 default
+ORDER BY cites_in_corpus DESC, ep.cited_by_count DESC
+LIMIT :page_size OFFSET :offset;
+```
+
+**Ranking inicial v1**:
+- **Naive con filtro**: `cites_in_corpus DESC` con filtro `cited_by_count_globally ≥ 50`. Suficiente para la primera vuelta. El filtro evita ruido de papers que casualmente son citados varias veces por mi corpus pero son irrelevantes globalmente.
+- Threshold `k=2` configurable via `S2_CLASSICS_MIN_CITES_IN_CORPUS` (default 2). Si la bandeja queda con miles de entries y eso resulta abrumador, subir a `k=3` o `k=5`.
+- Filtro `cited_by_count ≥ 50` configurable via `S2_CLASSICS_MIN_GLOBAL_CITES` (default 50).
+
+**Triage**: los mismos botones accept/reject/defer de `/inbox`. Aceptar dispara push metadata-only (ADR 022): cascade silenciosa de PDF una vez, si falla queda con tags `metadata-only` + `discovered-via-refs`.
+
+**Materialization**: la query corre on-demand al render; `ExternalPaper.last_seen_at` permite refrescar metadata stale lazy (>30 días). Para corpora >5k papers donde la query empiece a tardar, materializar como vista en `candidates.db` con refresh post step-0.5.
+
+**Filtros UX**:
+- Por threshold k (slider).
+- Por venue / publisher (dropdown derivado de `ExternalPaper.venue` distinct).
+- Por año (range slider).
+
+**Métricas en `/metrics`**: cuántos classics totales hay, cuántos descubiertos por semana, ratio aceptado/descartado en `/classics` separado del `/inbox` (para detectar si la calidad del ranking está mejor o peor que el de RSS).
+
+### 8.4 Autenticación
 
 **Para v1**: ninguna. Localhost-only, el dashboard bind a `127.0.0.1:8000`.
 
@@ -395,9 +508,23 @@ async def run_fetch_cycle():
     # for deletes (S2_SAFE_DELETE_RATIO). Errors are logged but do not
     # abort the cycle — score_semantic degrades to neutral_fallback if
     # the corpus_size threshold isn't met after reconcile. See ADR 015.
+    zotero_keys = enumerate_zotero_keys(zot_client)  # shared with step 0.5
     reconcile_embeddings(zot_client, chroma_collection, openai_client,
+                         zotero_keys=zotero_keys,
                          max_per_cycle=settings.s2.max_embed_per_cycle,
                          safe_delete_ratio=settings.s2.safe_delete_ratio)
+
+    # Step 0.5 — reconcile citation graph so score_refs and /classics see
+    # fresh edges. Reuses zotero_keys from step 0; bounded by
+    # S2_MAX_REFS_FETCH_PER_CYCLE; safe-guarded by S2_SAFE_DELETE_RATIO_REFS.
+    # Captura via ADR 021 cascade (OpenAlex → HTML scraping → optional PDF).
+    # Errors per source are logged but do not abort the cycle —
+    # score_refs degrades by omission from RRF for candidates with
+    # |refs|=0 (ADR 020 §2.4).
+    reconcile_references(zot_client, refs_db_session,
+                         zotero_keys=zotero_keys,
+                         max_per_cycle=settings.s2.max_refs_fetch_per_cycle,
+                         safe_delete_ratio=settings.s2.safe_delete_ratio_refs)
 
     for feed in get_active_feeds():
         try:
@@ -418,7 +545,9 @@ async def run_fetch_cycle():
 
 **Budget**: cada candidato cuesta ~$0.0005 en embeddings + scoring. Para 30 candidates/ciclo × 4 ciclos/día × 30 días = 3600/mes → ~$2/mes. Sumar ~$0.01-0.05/ciclo de reconciliación incremental sobre la biblioteca (típicamente 0-3 items nuevos por ciclo en régimen). El backfill inicial (`zotai s2 backfill-index`) tiene su propio cap `S2_MAX_COST_USD_BACKFILL=3.00`. Ver ADR 015 §8.
 
-**Comando manual `zotai s2 reconcile`**: dispara un solo ciclo de reconciliación sin fetch de RSS — útil para debug, para forzar la propagación de un push reciente, o para usuarios que prefieren disparar el reconcile desde un cron externo independiente del worker. Usa los mismos defaults de `.env` que el ciclo del worker.
+**Comando manual `zotai s2 reconcile`**: dispara un solo ciclo de reconciliación sin fetch de RSS — útil para debug, para forzar la propagación de un push reciente, o para usuarios que prefieren disparar el reconcile desde un cron externo independiente del worker. Usa los mismos defaults de `.env` que el ciclo del worker. Por default reconcilia ambos índices (ChromaDB + citation graph); flags `--only-embeddings` y `--only-refs` permiten disparar uno solo.
+
+**Comando manual `zotai s2 backfill-references`** (ADR 020 §2.3): análogo a `backfill-index` pero para `Reference` + `ExternalPaper`. Recorre toda la biblioteca Zotero, llama la cascade de captura (ADR 021), persiste edges + cache de externos. Budget cap propio (`S2_MAX_COST_USD_BACKFILL_REFS`, default 0.00 — OpenAlex es gratis). Idempotente; re-correrlo es seguro y barato. El primer comando que el usuario corre tras el `backfill-index` para tener el citation graph poblado al arrancar el dashboard.
 
 ---
 
@@ -428,7 +557,31 @@ async def run_fetch_cycle():
 
 Se dispara cuando un candidate se marca `accepted`.
 
-**Lógica**:
+### 10.1 Dos modos de push (ADR 022)
+
+Bajo **ADR 022**, el push tiene dos modos. El default depende del `source_kind` del candidate:
+
+| Modo | Default para | Comportamiento si cascade falla |
+|---|---|---|
+| **Estándar** | `source_kind='rss'` | Tag `needs-pdf` (transitorio, retry-able sprint 3 / issue #14) |
+| **Metadata-only** | `source_kind='reference_mining'` | Tag `metadata-only` (permanente, sin retry automático) |
+
+El usuario puede forzar push metadata-only sobre un candidate RSS desde el dashboard (botón secundario "Aceptar como metadata-only") cuando sabe a priori que el paper es paywalled estable y no quiere reintentos. La opción inversa (forzar cascade exhaustiva sobre un candidate de `/classics`) no existe en v1; el modo metadata-only ya intenta la cascade silenciosa una vez, y si falla queda con la declaración de "no esperamos PDF".
+
+**Tags reservados**:
+
+| Tag | Cuándo se aplica | Permanencia |
+|---|---|---|
+| `needs-pdf` | Push estándar, cascade falló | Transitorio |
+| `metadata-only` | Push metadata-only, cascade silenciosa falló | Permanente |
+| `discovered-via-refs` | Push de un candidate con `source_kind='reference_mining'` | Permanente |
+
+`needs-pdf` y `metadata-only` son **mutuamente excluyentes** (uno declara intención de retry, el otro declara aceptación). `discovered-via-refs` es ortogonal: un classic ausente sin PDF queda con `discovered-via-refs` + `metadata-only`. Detalle de combinaciones legales en ADR 022 §2.1.
+
+**Comando manual `zotai s2 push --retry-metadata-only`**: re-intenta cascade para todos los items con tag `metadata-only`. Opt-in, no scheduled — porque el modo metadata-only es declarativo y reintentos automáticos contradicen esa declaración (y son hostiles a Sci-Hub/LibGen/Anna's). Útil para "ahora sí buscame los PDFs que faltan" después de un periodo (ej. el preprint apareció en arXiv).
+
+### 10.2 Lógica del push (ambos modos)
+
 1. Crear item en Zotero via API con metadata del candidate.
 2. Si el candidate tiene DOI o URL con PDF descargable, intentar fetch del PDF.
    Priorizar en orden (detener en primer éxito):
@@ -445,6 +598,8 @@ Se dispara cuando un candidate se marca `accepted`.
    - `S2_PDF_FETCH_MAX_MINUTES_WEEKLY` (default 20) — budget global wall-clock por semana para fetch de PDFs. Al excederlo, el worker salta el fetch y etiqueta `needs-pdf`; evita que un outage prolongado de Sci-Hub/LibGen queme tiempo del usuario. Se resetea el lunes 00:00 local.
 
    Si ninguna fuente entrega PDF dentro del budget, el item mantiene el tag `needs-pdf` y queda visible en el dashboard para retry manual.
+
+   **En modo metadata-only (ADR 022 §2.3)**: la cascade se intenta **una sola vez en silencio** — sin contar contra `S2_PDF_FETCH_MAX_MINUTES_WEEKLY`, sin loguear como falla, sin retry. Si falla, el item queda con tag `metadata-only` permanente; si tiene éxito, sin tag (el sistema ganó un PDF gratis sobre algo que se aceptó como declaradamente sin PDF).
 3. Aplicar tags derivados del scoring (los que mejor matchearon).
 4. Mover a colección "Inbox S2" en Zotero. **El push la crea on-demand e idempotentemente** — si no existe, S2 la crea; si ya existe, la usa. El nombre viene de `S2_ZOTERO_INBOX_COLLECTION` (default `Inbox S2`). No se le pide al usuario que la cree a mano.
 5. Update del candidate: `zotero_item_key`, `pushed_at`.
@@ -531,6 +686,34 @@ Mirrors fuera de servicio o saturados pueden tragarse todo el budget wall-clock 
 
 **Deliverable**: S2 listo para uso productivo del usuario.
 
+### Sprint 5 (5-7 días): Citation graph + bandeja /classics + push metadata-only
+
+**Objetivo**: aterrizan los tres ADRs 020, 021, 022. Habilita scoring por refs y el discovery de classics ausentes; el push gana modo metadata-only con tags reservados.
+
+**Pre-requisito de cierre**: el experimento **I1** de cobertura empírica (ADR 020 §5) debe correr **antes** de mergear el primer PR de código de este sprint. Toma 50-100 DOIs random de la biblioteca Zotero del usuario, mide cobertura combinada OpenAlex + HTML scraping, y reporta la distribución de `len(refs)` y el % intra-corpus. Gates:
+
+- Cobertura ≥ 80% e intra-corpus ≥ 5% → ADRs firmes, sprint procede como diseñado.
+- 60% ≤ cobertura < 80% → sprint procede; `score_refs` se trata como señal complementaria (no central) en docs y métricas.
+- Cobertura < 60% → reabrir ADR 021 y decidir sobre PDF parsing antes de continuar.
+
+**Tabla de cambios**:
+
+- [ ] Schema migration: agregar `source_kind`, `score_refs` a `Candidate`; `source_feed_id` nullable. Crear tablas `Reference` y `ExternalPaper` (alembic migration o `init_s2()` extendido).
+- [ ] `src/zotai/api/refs_scrapers/{ojs,scielo,generic}.py` — tres parsers HTML (ADR 021). Tests con fixtures HTML capturadas.
+- [ ] `src/zotai/api/openalex.py` — agregar `fetch_refs(doi)` reusando el cliente existente.
+- [ ] `src/zotai/s2/refs.py` — orchestrador de la cascade (ADR 021 §2.1).
+- [ ] `src/zotai/s2/citation_graph.py` — `reconcile_references()` análogo a `reconcile_embeddings()`. Tests con `Reference` temporal.
+- [ ] `src/zotai/s2/worker.py` — agregar step 0.5 al `run_fetch_cycle()`.
+- [ ] CLI: `zotai s2 backfill-references`, `zotai s2 reconcile-references` (y flags `--only-embeddings` / `--only-refs` en el `reconcile` existente).
+- [ ] `src/zotai/s2/scoring.py` — agregar `compute_score_refs()` y `score_refs` al composite RRF (§7.5 de este plan).
+- [ ] `src/zotai/s2/push.py` — agregar modo metadata-only (ADR 022) y los tres tags reservados. Comando `zotai s2 push --retry-metadata-only`.
+- [ ] Dashboard: ruta nueva `/classics` con triage (ADR 020 §2 + §8.3 de este plan). Filtros básicos.
+- [ ] `/metrics`: agregar `refs_*` (ADR 020 §7.2) y breakdown ranking de la bandeja.
+- [ ] Variables nuevas en `.env.example` (las seis ya están: `S2_MAX_REFS_FETCH_PER_CYCLE`, `S2_SAFE_DELETE_RATIO_REFS`, `S2_MAX_COST_USD_BACKFILL_REFS`, `S2_REFS_SCRAPING_ENABLED`, `S2_REFS_PDF_PARSING_ENABLED`, `S2_REFS_FETCH_TIMEOUT_SECONDS`).
+- [ ] Tests E2E: backfill-references → ver `Reference` poblada → bandeja /classics muestra entries → accept un classic → ve metadata-only + discovered-via-refs en Zotero.
+
+**Deliverable**: el usuario corre `zotai s2 backfill-references` después del `backfill-index`, abre el dashboard, ve la bandeja `/classics` con sus anchors ausentes, y empieza a aceptar con el tiempo. Los candidates RSS también ganan la cuarta dimensión de scoring sin esfuerzo del usuario.
+
 ---
 
 ## 12. Configuración via .env (adicional al S1)
@@ -570,6 +753,26 @@ S2_MAX_COST_USD_BACKFILL=3.00
 # en config/scoring.yaml como `query_scoring.bm25_weight`; esta env var tiene
 # prioridad para experimentación per-run. Rango útil: [0.2, 0.6].
 S2_QUERY_BM25_WEIGHT=0.4
+
+# ──────────── S2 Citation graph (ADR 020) ────────────
+# Max refs fetched per worker cycle (paso 0.5). Análogo a S2_MAX_EMBED_PER_CYCLE.
+S2_MAX_REFS_FETCH_PER_CYCLE=50
+# Safety threshold para reconciliación de refs. Mirrors S2_SAFE_DELETE_RATIO.
+S2_SAFE_DELETE_RATIO_REFS=0.10
+# Budget cap del comando one-shot `zotai s2 backfill-references`. Default 0.00
+# porque OpenAlex es gratis; slot reservado para fuentes futuras con costo.
+S2_MAX_COST_USD_BACKFILL_REFS=0.00
+
+# ──────────── S2 Refs collection cascade (ADR 021) ────────────
+# Toggle master del HTML scraping (OJS / SciELO / genérico). Setear false
+# para usar sólo OpenAlex (corpus anglo-only donde la cobertura ya es alta).
+S2_REFS_SCRAPING_ENABLED=true
+# Opt-in de PDF parsing como último recurso. No implementado v1; el flag
+# existe para que sprints futuros lo wireen (anystyle / GROBID / refextract)
+# sin nuevo ADR. Default false. Ver ADR 021 §2.
+S2_REFS_PDF_PARSING_ENABLED=false
+# Timeout por fuente del cascade (segundos).
+S2_REFS_FETCH_TIMEOUT_SECONDS=15
 
 # ──────────── S2 PDF fetch cascade ────────────
 S2_PDF_SOURCES=openaccess,doi,annas,libgen,scihub,rss
@@ -624,6 +827,7 @@ Cada una es un ticket para v1.1+.
 
 - **S1** debe haber corrido: necesitamos biblioteca poblada para que el scoring funcione y para que el primer `backfill-index` tenga material que embebera.
 - **S2 es owner de ChromaDB** (ADR 015). El primer backfill se dispara con `zotai s2 backfill-index`. Los ciclos siguientes del worker mantienen el invariante "todo item no-cuarentenado en Zotero está indexado" via reconciliación por diff. El bind mount es `:rw` (`/workspace/chroma_db` dentro del container ← `${ZOTERO_MCP_CHROMA_HOST_PATH}` en el host). Ver ADR 011 (mecanismo del mount, amended) + ADR 015 (ownership). Si el corpus indexado tiene <`semantic_scoring.min_corpus_size` documentos, `score_semantic=neutral_fallback` (default 0.5) y el dashboard sigue funcionando.
+- **S2 es también owner del citation graph** (ADR 020). Tablas `Reference` + `ExternalPaper` en `candidates.db`. El primer backfill se dispara con `zotai s2 backfill-references` después del `backfill-index`. Los ciclos siguientes mantienen el invariante "todo item no-cuarentenado en Zotero tiene refs persistidas" via reconciliación por diff (step 0.5 del worker, paralelo al de ChromaDB). Captura por cascade ADR 021 (OpenAlex → HTML scraping → PDF opcional, no v1). Si la cobertura combinada por candidate cae a 0, `score_refs` se omite del RRF (ADR 020 §2.4) sin afectar el resto del scoring. El citation graph **no se expone a S3**; sólo S2 lo consume (`score_refs` + bandeja `/classics`).
 - **S3 NO es prerequisito de S2** bajo ADR 015. S3 (`zotero-mcp serve`) es lector puro del mismo store. Si el usuario nunca configuró S3, S2 funciona igual; lo único que pierde el usuario es la consulta conversacional desde Claude Desktop.
 - **Zotero abierto** con API local (igual que S1). S2 crea la colección `Inbox S2` (o el nombre en `S2_ZOTERO_INBOX_COLLECTION`) on-demand e idempotentemente en el primer push.
 - **Worker y dashboard corriendo**: por default APScheduler in-process en el mismo container del dashboard (ADR 012). Usuarios que no mantienen el dashboard 24/7 pueden setear `S2_WORKER_DISABLED=true` y usar cron / Task Scheduler externos invocando `zotai s2 fetch-once` (receta en `docs/setup-{linux,windows}.md`); el `fetch-once` ejecuta el reconcile como paso 0 igual que el worker, así que el invariante de ChromaDB se mantiene en ambos paths.

--- a/docs/plan_03_subsystem3.md
+++ b/docs/plan_03_subsystem3.md
@@ -241,11 +241,21 @@ Bajo **ADR 015**, la dirección de la integración se invierte respecto a versio
 
 ---
 
+## 9.1 Items metadata-only (ADR 022)
+
+Bajo **ADR 022** los items que S2 pushea sin PDF (papers paywalled estables, classics ausentes descubiertos vía la bandeja `/classics`) son ciudadanos de primera clase del corpus. Llevan tags reservados (`metadata-only`, opcionalmente `discovered-via-refs`) pero por lo demás son items normales de Zotero.
+
+S3 los indexa **sin caso especial**: el reconcile de embeddings de S2 (ADR 015 §6) ya prevé `source ∈ {s2_fulltext, s2_abstract, s2_title_only}`; los metadata-only caen naturalmente en `s2_abstract` (cuando el abstract está disponible) o `s2_title_only` (degradación máxima, recall menor). El schema de ChromaDB no cambia. Las queries MCP desde Claude Desktop los recuperan junto con los items con PDF, distinguibles vía el campo `metadata.source` y los tags Zotero.
+
+**Recall esperado** sobre items metadata-only: aceptable para modo descubrimiento (`zotero_semantic_search` retorna por título / abstract); degradado para modo síntesis puntual (`zotero_fulltext` no tiene fulltext que extraer). El usuario debe asumir que un item con tag `metadata-only` no responde a preguntas tipo "qué dice tal sección de tal paper".
+
+---
+
 ## 10. Fuera de alcance
 
 - Custom MCP server.
 - Integración con editores (Overleaf, Jupyter, Docs).
-- Citation networks.
+- Citation networks como herramienta de exploración del usuario via MCP. **Nota**: bajo ADR 020 S2 sí mantiene un citation graph (tablas `Reference` + `ExternalPaper` en `candidates.db`) para scorear candidates y para alimentar la bandeja `/classics`, pero ese grafo no se expone a S3 — `zotero-mcp serve` no consulta `candidates.db`. Si en el futuro se quiere "preguntale a Claude qué papers de mi corpus se citan entre sí", reabrir como deliverable nuevo.
 - Cross-library queries (multi-usuario).
 - Agentic workflows (Claude decide solo cuándo consultar Zotero vs otra fuente).
 

--- a/docs/plan_glossary.md
+++ b/docs/plan_glossary.md
@@ -70,6 +70,38 @@ Proceso que corre en cada ciclo del worker como paso 0, antes del fetch de RSS y
 **Backfill de índice** (S2)
 Comando `zotai s2 backfill-index`: misma lógica de reconciliación pero con `max_per_cycle` efectivamente sin límite, progress bar, y cap de costo separado (`S2_MAX_COST_USD_BACKFILL`, default 3.00). Es el primer comando que el usuario corre tras completar S1 + setup de S3 — pobla ChromaDB inicialmente para que `score_semantic` arranque con datos. Idempotente; re-correrlo es seguro y barato.
 
+**Citation graph** (S2)
+Grafo dirigido de citas de la biblioteca, persistido en `candidates.db` (tablas `Reference` y `ExternalPaper`). S2 es owner (ADR 020), S1 no escribe. `Reference(citing_zotero_key, cited_doi, cited_openalex_id, cited_text, source_api, fetched_at)` representa aristas; `ExternalPaper(doi, openalex_id, title, authors_json, ...)` cachea metadata de DOIs ausentes en Zotero pero citados por papers en él. Mantenido por reconciliación por diff en step 0.5 del worker (paralelo al de embeddings). Consumido por `score_refs` (4ta señal RRF, §7.4) y por la bandeja `/classics` (§8.3).
+
+**Anchor papers** (S2)
+DOIs externos a Zotero citados por k≥2 papers de la biblioteca del usuario. Equivale a "los clásicos del campo del usuario que aún no están en su biblioteca". Forman el contenido principal de la bandeja `/classics`. Threshold k configurable; default `k=2`.
+
+**Reference mining** (S2)
+Proceso de descubrir candidates a partir del citation graph, no de RSS. Los DOIs en `ExternalPaper` ordenados por frecuencia de cita en el corpus (`COUNT(DISTINCT citing_zotero_key)`) y filtrados por `cited_by_count_globally ≥ 50` constituyen el feed de la bandeja `/classics`. Equivalente operacional al fetch RSS pero con `source_kind='reference_mining'` en `Candidate`.
+
+**Bandeja /classics** (S2)
+Ruta del dashboard de S2 que expone `Candidate`s con `source_kind='reference_mining'`. Triage idéntico a `/inbox` (accept/reject/defer + push) pero ranking por `cites_in_my_corpus DESC` con filtro `global_cited_by_count ≥ 50`. Push de items aceptados es metadata-only por default (ADR 022 §2.4) — el cascade silencioso una vez intenta PDF, si falla queda con tags `metadata-only` + `discovered-via-refs`.
+
+**Refs cascade** (S2)
+Pipeline de captura de refs definido en ADR 021: OpenAlex (`referenced_works`) → HTML scraping (OJS / SciELO / genérico) → PDF parsing (opt-in detrás de flag, no implementado v1). Primer hit gana; cada nivel devuelve `[]` si no aplica, nunca raise. `Reference.source_api` registra qué nivel produjo cada arista para auditabilidad.
+
+**OJS scraper / SciELO HTML scraper / genérico** (S2)
+Tres parsers HTML aislados en `src/zotai/api/refs_scrapers/{ojs,scielo,generic}.py`, parte de la cascade de ADR 021. OJS cubre revistas en plataforma PKP (dominante en LATAM); SciELO cubre la HTML view distinta de OJS; el genérico es best-effort sobre JSON-LD + heurística DOM. Falla de un parser devuelve `[]` y la cascade sigue.
+
+**Score por refs / `score_refs`** (S2)
+Cuarta señal del RRF (ADR 016), incorporada por ADR 020. `score_refs(c) = |refs(c) ∩ zotero_dois| / |refs(c)|` con `refs(c)` obtenido vía la cascade ADR 021. Si `|refs(c)| = 0` el score se omite del RRF (ADR 020 §2.4) — no penaliza, simplemente no contribuye al ranking de ese criterio.
+
+**Push estándar / push metadata-only** (S2, ADR 022)
+Dos modos del push de S2 a Zotero. Estándar: cascade exhaustiva de PDF (issue #14, sprint 3); si falla, tag `needs-pdf` para retry. Metadata-only: cascade silenciosa una sola vez; si falla, tag `metadata-only` permanente, sin retry. Default por `source_kind` del candidate: `'rss'` → estándar; `'reference_mining'` → metadata-only.
+
+**Tags reservados del sistema** (S2, ADR 022)
+Tres tags ortogonales que S2 aplica a items pusheados a Zotero:
+- `needs-pdf`: cascade falló transitoriamente; transitorio, retry-able.
+- `metadata-only`: aceptado deliberadamente sin expectativa de PDF; permanente.
+- `discovered-via-refs`: origen bandeja /classics (no RSS); permanente.
+
+`needs-pdf` y `metadata-only` son mutuamente excluyentes; `discovered-via-refs` es ortogonal a los otros dos. Combinaciones legales documentadas en ADR 022 §2.1.
+
 **Clasificador académico / no-académico** (S1 Etapa 01)
 Filtro upstream del pipeline S1. Decide, para cada PDF encontrado bajo `PDF_SOURCE_FOLDERS`, si es material bibliográfico o material de descarte (facturas, DNIs, tickets, manuales, etc.). Estrategia híbrida en 3 ramas: (1) **accept** automático por heurística positiva — DOI / arXiv / ISBN / keywords académicos en páginas 1-3; (2) **reject** automático por heurística negativa — ≤2 páginas + ausencia de texto o keywords de facturación en primera página; (3) **ambiguos** resueltos por `gpt-4o-mini` con prompt corto. Ver `plan_01_subsystem1.md` §3 Etapa 01 y §3.1.
 


### PR DESCRIPTION
## Summary

Cambios derivados de los tres ADRs mergeados en #70. **Solo documentación; ningún cambio de código.** La implementación aterriza en Sprint 5 (issue separado tras este merge).

8 archivos tocados, 319 líneas añadidas, 25 modificadas. Todos los cambios derivan mecánicamente de los §6/§7 \"Cambios requeridos en documentos existentes\" de los ADRs 020/021/022 — no hay nuevas decisiones acá.

## Cambios principales

### \`docs/plan_02_subsystem2.md\` (mayor parte del PR)

- **§4 worker diagram**: step 0.5 reconcile citation graph junto a step 0 reconcile ChromaDB.
- **§5 modelo de datos**: \`Candidate.source_kind\` + \`Candidate.score_refs\`; tablas \`Reference\` + \`ExternalPaper\`; nota explicando el citation graph como segundo store derivado paralelo a ChromaDB.
- **§7.4 NUEVA — Score por refs**: definición, fallback \"omitir del RRF cuando \`|refs|=0\`\", ortogonalidad con tags/semantic/queries.
- **§7.4 → §7.5 — Score compuesto**: ahora 4 criterios; código RRF actualizado para excluir candidates sin refs del ranking de ese criterio.
- **§8.3 NUEVA — Bandeja /classics**: query SQL base, ranking v1 (\`cites_in_corpus DESC\` + filtro \`global_cited_by_count ≥ 50\`), threshold k configurable, filtros UX.
- **§8.3 → §8.4 — Autenticación**: renumerada (sin cambio de contenido).
- **§9 worker**: pseudo-código actualiza con \`reconcile_references()\`; comando \`reconcile\` gana flags \`--only-embeddings\`/\`--only-refs\`; \`backfill-references\` documentado.
- **§10 push**: dos modos (estándar / metadata-only) + tabla de tags reservados + \`push --retry-metadata-only\`.
- **§11 sprints**: Sprint 5 nuevo (5-7 días) con tabla de cambios y gate I1 explícito antes del primer merge de código.
- **§12 .env**: sección citation graph + sección refs cascade.
- **§15 dependencias**: línea adicional \"S2 también owna el citation graph\".

### Otros archivos

- **\`plan_00_overview.md\`**: §3 menciona dos índices secundarios derivados owned por S2; §5 tabla ADRs gana filas 020/021/022.
- **\`plan_01_subsystem1.md\`** §10: explicita que captura de refs no es responsabilidad de S1.
- **\`plan_03_subsystem3.md\`**: §9.1 nueva (items metadata-only se indexan vía cascade existente ADR 015); §10 aclara que citation graph NO se expone a S3 en v1.
- **\`plan_glossary.md\`**: 11 entradas nuevas (citation graph, anchor papers, reference mining, bandeja /classics, refs cascade, los tres scrapers, score por refs, los dos modos de push, tags reservados).
- **\`CLAUDE.md\`**: §\"Contratos entre subsistemas\" — citation graph como segundo store derivado.
- **\`README.md\`**: tabla de tags reservados + Sprint 5 visible en estado del proyecto.
- **\`.env.example\`**: 6 variables nuevas (\`S2_MAX_REFS_FETCH_PER_CYCLE\`, \`S2_SAFE_DELETE_RATIO_REFS\`, \`S2_MAX_COST_USD_BACKFILL_REFS\`, \`S2_REFS_SCRAPING_ENABLED\`, \`S2_REFS_PDF_PARSING_ENABLED\`, \`S2_REFS_FETCH_TIMEOUT_SECONDS\`).

## Validación

- Todas las referencias internas a §X.Y dentro de plan_02 fueron verificadas tras el renumerado §7.4→§7.5 y §8.3→§8.4 (\`grep\` post-edit).
- ADRs 020/021/022 ya mergeados en main (#70) — todo este PR es ejecución de sus listas \"Cambios requeridos\".
- Próximo paso tras merge: crear issue de Sprint 5 con scope cerrado, referenciando este PR + ADRs.

## Test plan

- [ ] Diff completo limpio (sin emojis incidentales, sin URLs erróneas).
- [ ] Las 11 entradas nuevas del glossary son consistentes con la terminología de los ADRs.
- [ ] El número de variables nuevas en \`.env.example\` matchea las que plan_02 §12 lista (3 + 3 = 6).
- [ ] Sprint 5 (§11) tiene gate I1 visible y el orden de tareas es ejecutable.